### PR TITLE
DDP-4295: Lazy resources

### DIFF
--- a/ddp-workspace/projects/ddp-angio/src/app/components/about-us/about-us.component.ts
+++ b/ddp-workspace/projects/ddp-angio/src/app/components/about-us/about-us.component.ts
@@ -48,7 +48,7 @@ import { ToolkitConfigurationService } from 'toolkit';
               <a [href]="countMeInUrl" class="Link" target="_blank" translate> Toolkit.AboutUs.ContentLink</a>.
             </p>
           </section>
-          <img lazy-img src="./assets/images/about-page-broad-building.png" class="PageContent-image" alt="Broad Building">
+          <img lazy-resource src="./assets/images/about-page-broad-building.png" class="PageContent-image" alt="Broad Building">
         </div>
         <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12 row--moreTopMargin">
           <section class="Message">
@@ -60,36 +60,36 @@ import { ToolkitConfigurationService } from 'toolkit';
             <div class="row">
               <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 Message-partners">
                 <a href="http://www.sarctrials.org" target="_blank">
-                  <img lazy-img src="./assets/images/SARC-logo.svg" alt="SARC Logo">
+                  <img lazy-resource src="./assets/images/SARC-logo.svg" alt="SARC Logo">
                 </a>
               </div>
               <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 Message-partners">
                 <a href="http://www.sarcomaalliance.org" target="_blank">
-                  <img lazy-img src="./assets/images/SarcomaAlliance-logo.svg" alt="Sarcoma Alliance Logo">
+                  <img lazy-resource src="./assets/images/SarcomaAlliance-logo.svg" alt="Sarcoma Alliance Logo">
                 </a>
               </div>
             </div>
             <div class="row">
               <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 Message-partners">
                 <a href="http://www.curesarcoma.org" target="_blank">
-                  <img lazy-img src="./assets/images/SarcomaFoundationOfAmerica-logo.svg" alt="Sarcoma Foundation of America Logo">
+                  <img lazy-resource src="./assets/images/SarcomaFoundationOfAmerica-logo.svg" alt="Sarcoma Foundation of America Logo">
                 </a>
               </div>
               <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 Message-partners">
                 <a href="http://www.targetcancerfoundation.org" target="_blank">
-                  <img lazy-img src="./assets/images/TargetCancerFoundation-logo.svg" alt="Target Cancer Foundation Logo">
+                  <img lazy-resource src="./assets/images/TargetCancerFoundation-logo.svg" alt="Target Cancer Foundation Logo">
                 </a>
               </div>
             </div>
             <div class="row">
               <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 Message-partners">
                 <a href="https://www.paulatakacsfoundation.org" target="_blank">
-                  <img lazy-img src="./assets/images/PaulaTakacs-logo.svg" alt="The Paula Takacs Foundation Logo">
+                  <img lazy-resource src="./assets/images/PaulaTakacs-logo.svg" alt="The Paula Takacs Foundation Logo">
                 </a>
               </div>
               <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 Message-partners">
                 <a href="http://www.cureasc.org" target="_blank">
-                  <img lazy-img src="./assets/images/AngiosarcomaAwareness-logo.svg" alt="Angiosarcoma Awareness Logo">
+                  <img lazy-resource src="./assets/images/AngiosarcomaAwareness-logo.svg" alt="Angiosarcoma Awareness Logo">
                 </a>
               </div>
             </div>

--- a/ddp-workspace/projects/ddp-angio/src/app/components/data-release/data-release.component.ts
+++ b/ddp-workspace/projects/ddp-angio/src/app/components/data-release/data-release.component.ts
@@ -193,7 +193,8 @@ import { WindowRef } from 'ddp-sdk';
                                     Toolkit.DataRelease.Glossary.Text
                                 </p>
                                 <div id="NCITermDictionaryWidgetEnglish">
-                                    <iframe frameborder="0" 
+                                    <iframe lazy-resource
+                                            frameborder="0" 
                                             src="https://www.cancer.gov/widgets/TermDictionaryWidgetEnglish" 
                                             id="NCITermDictionaryWidgetContainerEnglish"
                                             title="https://www.mbcproject.org/data-release" 

--- a/ddp-workspace/projects/ddp-angio/src/app/components/welcome/welcome.component.ts
+++ b/ddp-workspace/projects/ddp-angio/src/app/components/welcome/welcome.component.ts
@@ -35,7 +35,7 @@ import { GoogleAnalyticsEventsService, BrowserContentService, WindowRef } from '
         <div class="row">
             <a #secondView></a>
             <section class="Message col-lg-6 col-lg-offset-3 col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
-                <img src="./assets/images/turtle.svg" class="Message-turtle" alt="Angiosarcoma pet">
+                <img lazy-resource src="./assets/images/turtle.svg" class="Message-turtle" alt="Angiosarcoma pet">
                 <p class="Message-text" translate>
                     Toolkit.Welcome.SmallTitle
                 </p>
@@ -58,7 +58,7 @@ import { GoogleAnalyticsEventsService, BrowserContentService, WindowRef } from '
         </div>
 
         <div class="row NoPadding NoMargin">
-            <img lazy-img src="./assets/images/dna-strand.svg" class="DNAStrand" alt="DNA Strand" />
+            <img lazy-resource src="./assets/images/dna-strand.svg" class="DNAStrand" alt="DNA Strand" />
         </div>
 
         <div class="row">
@@ -96,7 +96,7 @@ import { GoogleAnalyticsEventsService, BrowserContentService, WindowRef } from '
 
         <div class="row">
             <div class="Message-step col-lg-4 col-md-4 col-sm-12 col-xs-12">
-                <img lazy-img src="./assets/images/step-1.svg" class="Message-stepImage" alt="Step 1">
+                <img lazy-resource src="./assets/images/step-1.svg" class="Message-stepImage" alt="Step 1">
                 <h1 class="Message-stepTitle NoMargin" translate>
                     Toolkit.Welcome.ThirdBlock.FirstStep.Title
                 </h1>
@@ -110,7 +110,7 @@ import { GoogleAnalyticsEventsService, BrowserContentService, WindowRef } from '
                 </p>
             </div>
             <div class="Message-step col-lg-4 col-md-4 col-sm-12 col-xs-12">
-                <img lazy-img src="./assets/images/step-2.svg" class="Message-stepImage" alt="Step 2">
+                <img lazy-resource src="./assets/images/step-2.svg" class="Message-stepImage" alt="Step 2">
                 <h1 class="Message-stepTitle NoMargin" translate>
                     Toolkit.Welcome.ThirdBlock.SecondStep.Title
                 </h1>
@@ -121,7 +121,7 @@ import { GoogleAnalyticsEventsService, BrowserContentService, WindowRef } from '
                 </p>
             </div>
             <div class="Message-step col-lg-4 col-md-4 col-sm-12 col-xs-12">
-                <img lazy-img src="./assets/images/step-3.svg" class="Message-stepImage" alt="Step 3">
+                <img lazy-resource src="./assets/images/step-3.svg" class="Message-stepImage" alt="Step 3">
                 <h1 class="Message-stepTitle NoMargin" translate>
                     Toolkit.Welcome.ThirdBlock.ThirdStep.Title
                 </h1>
@@ -170,26 +170,26 @@ import { GoogleAnalyticsEventsService, BrowserContentService, WindowRef } from '
             <section class="Message col-lg-6 col-lg-offset-3 col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1 NoPadding">
                 <div class="row">
                     <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 Message-partners">
-                        <a href="http://www.sarctrials.org" target="_blank"><img lazy-img src="./assets/images/SARC-logo.svg" alt="SARC Logo"></a>
+                        <a href="http://www.sarctrials.org" target="_blank"><img lazy-resource src="./assets/images/SARC-logo.svg" alt="SARC Logo"></a>
                     </div>
                     <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 Message-partners">
-                        <a href="http://sarcomaalliance.org" target="_blank"><img lazy-img src="./assets/images/SarcomaAlliance-logo.svg" alt="Sarcoma Alliance Logo"></a>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 Message-partners">
-                        <a href="http://www.curesarcoma.org" target="_blank"><img lazy-img src="./assets/images/SarcomaFoundationOfAmerica-logo.svg" alt="Sarcoma Foundation of America Logo"></a>
-                    </div>
-                    <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 Message-partners">
-                        <a href="http://www.targetcancerfoundation.org" target="_blank"><img lazy-img src="./assets/images/TargetCancerFoundation-logo.svg" alt="Target Cancer Foundation Logo"></a>
+                        <a href="http://sarcomaalliance.org" target="_blank"><img lazy-resource src="./assets/images/SarcomaAlliance-logo.svg" alt="Sarcoma Alliance Logo"></a>
                     </div>
                 </div>
                 <div class="row">
                     <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 Message-partners">
-                        <a href="https://www.paulatakacsfoundation.org" target="_blank"><img lazy-img src="./assets/images/PaulaTakacs-logo.svg" alt="The Paula Takacs Foundation Logo"></a>
+                        <a href="http://www.curesarcoma.org" target="_blank"><img lazy-resource src="./assets/images/SarcomaFoundationOfAmerica-logo.svg" alt="Sarcoma Foundation of America Logo"></a>
                     </div>
                     <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 Message-partners">
-                        <a href="http://www.cureasc.org" target="_blank"><img lazy-img src="./assets/images/AngiosarcomaAwareness-logo.svg" alt="Angiosarcoma Awareness Logo"></a>
+                        <a href="http://www.targetcancerfoundation.org" target="_blank"><img lazy-resource src="./assets/images/TargetCancerFoundation-logo.svg" alt="Target Cancer Foundation Logo"></a>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 Message-partners">
+                        <a href="https://www.paulatakacsfoundation.org" target="_blank"><img lazy-resource src="./assets/images/PaulaTakacs-logo.svg" alt="The Paula Takacs Foundation Logo"></a>
+                    </div>
+                    <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 Message-partners">
+                        <a href="http://www.cureasc.org" target="_blank"><img lazy-resource src="./assets/images/AngiosarcomaAwareness-logo.svg" alt="Angiosarcoma Awareness Logo"></a>
                     </div>
                 </div>
             </section>

--- a/ddp-workspace/projects/ddp-brain/src/app/components/welcome/welcome.component.ts
+++ b/ddp-workspace/projects/ddp-brain/src/app/components/welcome/welcome.component.ts
@@ -17,9 +17,9 @@ import { GoogleAnalyticsEventsService, BrowserContentService, WindowRef } from '
         </div>
 
         <div class="Intro-footer row">
-            <img src="./assets/images/logo-broad-institute.svg" class="Intro-footerLogos" alt="Broad Institute Logo" />
-            <img src="./assets/images/logo-dana-farber-cancer-institute.svg" class="Intro-footerLogos" alt="Dana Farber Logo">
-            <img src="./assets/images/logo-minderoo.png" class="Intro-footerLogo-square" alt="Minderoo Foundation Logo">
+            <img lazy-resource src="./assets/images/logo-broad-institute.svg" class="Intro-footerLogos" alt="Broad Institute Logo" />
+            <img lazy-resource src="./assets/images/logo-dana-farber-cancer-institute.svg" class="Intro-footerLogos" alt="Dana Farber Logo">
+            <img lazy-resource src="./assets/images/logo-minderoo.png" class="Intro-footerLogo-square" alt="Minderoo Foundation Logo">
         </div>
         
         <div class="Intro row">
@@ -54,7 +54,7 @@ import { GoogleAnalyticsEventsService, BrowserContentService, WindowRef } from '
         </div>
 
         <div class="row NoPadding NoMargin">
-            <img lazy-img src="./assets/images/dna-strand.svg" class="DNAStrand" alt="DNA Strand" />
+            <img lazy-resource src="./assets/images/dna-strand.svg" class="DNAStrand" alt="DNA Strand" />
         </div>
 
         <div class="row">
@@ -71,7 +71,7 @@ import { GoogleAnalyticsEventsService, BrowserContentService, WindowRef } from '
 
         <div class="row">
             <div class="Message-step col-lg-4 col-md-4 col-sm-12 col-xs-12">
-                <img lazy-img src="./assets/images/step-1.svg" class="Message-stepImage" alt="Step 1">
+                <img lazy-resource src="./assets/images/step-1.svg" class="Message-stepImage" alt="Step 1">
                 <h1 class="Message-stepTitle NoMargin" translate>
                     Toolkit.Welcome.SecondBlock.FirstStep.Title
                 </h1>
@@ -85,7 +85,7 @@ import { GoogleAnalyticsEventsService, BrowserContentService, WindowRef } from '
                 </p>
             </div>
             <div class="Message-step col-lg-4 col-md-4 col-sm-12 col-xs-12">
-                <img lazy-img src="./assets/images/step-2.svg" class="Message-stepImage" alt="Step 2">
+                <img lazy-resource src="./assets/images/step-2.svg" class="Message-stepImage" alt="Step 2">
                 <h1 class="Message-stepTitle NoMargin" translate>
                     Toolkit.Welcome.SecondBlock.SecondStep.Title
                 </h1>
@@ -99,7 +99,7 @@ import { GoogleAnalyticsEventsService, BrowserContentService, WindowRef } from '
                 </p>
             </div>
             <div class="Message-step col-lg-4 col-md-4 col-sm-12 col-xs-12">
-                <img lazy-img src="./assets/images/step-3.svg" class="Message-stepImage" alt="Step 3">
+                <img lazy-resource src="./assets/images/step-3.svg" class="Message-stepImage" alt="Step 3">
                 <h1 class="Message-stepTitle NoMargin" translate>
                     Toolkit.Welcome.SecondBlock.ThirdStep.Title
                 </h1>
@@ -148,7 +148,7 @@ import { GoogleAnalyticsEventsService, BrowserContentService, WindowRef } from '
             <section class="Message col-lg-6 col-lg-offset-3 col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1 NoPadding">
                 <div class="row">
                     <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12 Message-partners">
-                        <a href="http://www.targetcancerfoundation.org/" target="_blank"><img lazy-img class="partner-logo--single" src="./assets/images/TCF-Logo.png" alt="Target Cancer Foundation"></a>
+                        <a href="http://www.targetcancerfoundation.org/" target="_blank"><img lazy-resource class="partner-logo--single" src="./assets/images/TCF-Logo.png" alt="Target Cancer Foundation"></a>
                     </div>
                 </div>
             </section>
@@ -161,16 +161,16 @@ import { GoogleAnalyticsEventsService, BrowserContentService, WindowRef } from '
             <section class="Message col-lg-6 col-lg-offset-3 col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1 NoPadding">
                 <div class="row">
                     <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 Message-partners">
-                        <a href="https://www.abta.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/ABTA-logo.jpg" alt="ABTA"></a>
+                        <a href="https://www.abta.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/ABTA-logo.jpg" alt="ABTA"></a>
                     </div>
                     <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 Message-partners">
-                        <a href="https://braintumor.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/NBTS-logo.png" alt="National Brain Tumor Society"></a>
+                        <a href="https://braintumor.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/NBTS-logo.png" alt="National Brain Tumor Society"></a>
                     </div>
                     <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 Message-partners">
-                        <a href="https://abc2.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/ABC2_LOGO_OrangeBack_wtag.png" alt="Accelerate Brain Cancer Cure"></a>
+                        <a href="https://abc2.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/ABC2_LOGO_OrangeBack_wtag.png" alt="Accelerate Brain Cancer Cure"></a>
                     </div>
                     <div class="col-lg-6 col-md-6 col-sm-6 col-xs-12 Message-partners">
-                        <a href="https://www.oligonation.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/OligoNation_Logo.jpg" alt="Oligo Nation"></a>
+                        <a href="https://www.oligonation.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/OligoNation_Logo.jpg" alt="Oligo Nation"></a>
                     </div>
                 </div>
             </section>

--- a/ddp-workspace/projects/ddp-mbc/src/app/components/about-us/about-us.component.ts
+++ b/ddp-workspace/projects/ddp-mbc/src/app/components/about-us/about-us.component.ts
@@ -56,7 +56,7 @@ import { ToolkitConfigurationService } from 'toolkit';
               <span translate>Toolkit.AboutUs.Content.Paragraph2.Pt4</span>
             </p>
           </section>
-          <img lazy-img src="./assets/images/about-page-broad-building.png" class="PageContent-image" alt="Broad Building">
+          <img lazy-resource src="./assets/images/about-page-broad-building.png" class="PageContent-image" alt="Broad Building">
         </div>
         <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12 row--moreTopMargin">
           <section class="Message">
@@ -68,126 +68,126 @@ import { ToolkitConfigurationService } from 'toolkit';
               <section class="Message">
                 <div class="row">
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="http://www.mbcn.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-mbcn.svg" alt="SARC Logo"></a>
+                        <a href="http://www.mbcn.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-mbcn.svg" alt="SARC Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.avonfoundation.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-avon.svg" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://www.avonfoundation.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-avon.svg" alt="Sarcoma Alliance Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.mbcalliance.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-mbca.svg" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://www.mbcalliance.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-mbca.svg" alt="Sarcoma Alliance Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="http://www.lbbc.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-lbbc.svg" alt="Sarcoma Alliance Logo"></a>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="http://www.ibcresearch.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-ibcrf.svg" alt="SARC Logo"></a>
-                    </div>
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.youngsurvival.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-ysc.svg" alt="Sarcoma Alliance Logo"></a>
-                    </div>
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.sharecancersupport.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-share.png" alt="Sarcoma Alliance Logo"></a>
-                    </div>
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://malebreastcancercoalition.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-mbcc.svg" alt="Sarcoma Alliance Logo"></a>
+                        <a href="http://www.lbbc.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-lbbc.svg" alt="Sarcoma Alliance Logo"></a>
                     </div>
                 </div>
                 <div class="row">
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="http://www.theresasresearch.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-theresas.svg" alt="SARC Logo"></a>
+                        <a href="http://www.ibcresearch.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-ibcrf.svg" alt="SARC Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://tnbcfoundation.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-tnbc.png" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://www.youngsurvival.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-ysc.svg" alt="Sarcoma Alliance Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.theibcnetwork.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-ibc.svg" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://www.sharecancersupport.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-share.png" alt="Sarcoma Alliance Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="http://advocates4breastcancer.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-a4bc.jpg" alt="Sarcoma Alliance Logo"></a>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="http://www.metavivor.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-metavivor.svg" alt="SARC Logo"></a>
-                    </div>
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="http://metup.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-metup.png" alt="Sarcoma Alliance Logo"></a>
-                    </div>
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.tigerlilyfoundation.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-tigerlily.jpg" alt="Sarcoma Alliance Logo"></a>
-                    </div>
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://ww5.komen.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-susangkomen.svg" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://malebreastcancercoalition.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-mbcc.svg" alt="Sarcoma Alliance Logo"></a>
                     </div>
                 </div>
                 <div class="row">
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.bcrf.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-bcrf.svg" alt="SARC Logo"></a>
+                        <a href="http://www.theresasresearch.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-theresas.svg" alt="SARC Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.drsusanloveresearch.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-dslrf.png" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://tnbcfoundation.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-tnbc.png" alt="Sarcoma Alliance Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://bcsm.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-bcsm.png" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://www.theibcnetwork.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-ibc.svg" alt="Sarcoma Alliance Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://hopescarves.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-hopescarves.svg" alt="Sarcoma Alliance Logo"></a>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.thecancercouch.com/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-cancer-couch-foundation.png" alt="SARC Logo"></a>
-                    </div>
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://twistedpink.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-twistedpink.jpg" alt="Sarcoma Alliance Logo"></a>
-                    </div>
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="http://www.cierrasisters.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-cierra-sisters.png" alt="Sarcoma Alliance Logo"></a>
-                    </div>
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.breastcancertrials.org/BCTIncludes/index.html" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-bc-trials.jpg" alt="Sarcoma Alliance Logo"></a>
+                        <a href="http://advocates4breastcancer.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-a4bc.jpg" alt="Sarcoma Alliance Logo"></a>
                     </div>
                 </div>
                 <div class="row">
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="http://breastcanceralliance.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-bca.jpg" alt="SARC Logo"></a>
+                        <a href="http://www.metavivor.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-metavivor.svg" alt="SARC Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://thetutuproject.com/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-tutuproject.jpg" alt="Sarcoma Alliance Logo"></a>
+                        <a href="http://metup.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-metup.png" alt="Sarcoma Alliance Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.mpbcalliance.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-MetaplasticBreastGlobalAlliance.svg" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://www.tigerlilyfoundation.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-tigerlily.jpg" alt="Sarcoma Alliance Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://lobularbreastcancer.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-lbca.png" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://ww5.komen.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-susangkomen.svg" alt="Sarcoma Alliance Logo"></a>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="https://www.bcrf.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-bcrf.svg" alt="SARC Logo"></a>
+                    </div>
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="https://www.drsusanloveresearch.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-dslrf.png" alt="Sarcoma Alliance Logo"></a>
+                    </div>
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="https://bcsm.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-bcsm.png" alt="Sarcoma Alliance Logo"></a>
+                    </div>
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="https://hopescarves.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-hopescarves.svg" alt="Sarcoma Alliance Logo"></a>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="https://www.thecancercouch.com/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-cancer-couch-foundation.png" alt="SARC Logo"></a>
+                    </div>
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="https://twistedpink.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-twistedpink.jpg" alt="Sarcoma Alliance Logo"></a>
+                    </div>
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="http://www.cierrasisters.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-cierra-sisters.png" alt="Sarcoma Alliance Logo"></a>
+                    </div>
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="https://www.breastcancertrials.org/BCTIncludes/index.html" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-bc-trials.jpg" alt="Sarcoma Alliance Logo"></a>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="http://breastcanceralliance.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-bca.jpg" alt="SARC Logo"></a>
+                    </div>
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="https://thetutuproject.com/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-tutuproject.jpg" alt="Sarcoma Alliance Logo"></a>
+                    </div>
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="https://www.mpbcalliance.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-MetaplasticBreastGlobalAlliance.svg" alt="Sarcoma Alliance Logo"></a>
+                    </div>
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="https://lobularbreastcancer.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-lbca.png" alt="Sarcoma Alliance Logo"></a>
                     </div>
 
                 </div>
                 <div class="row">
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.facingourrisk.org/index.php" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-force.svg" alt="SARC Logo"></a>
+                        <a href="https://www.facingourrisk.org/index.php" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-force.svg" alt="SARC Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://shaysharpespinkwishes.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-SSLogo-noBG.PNG" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://shaysharpespinkwishes.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-SSLogo-noBG.PNG" alt="Sarcoma Alliance Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.metastasis-research.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-MRS_LogoColor.jpg" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://www.metastasis-research.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-MRS_LogoColor.jpg" alt="Sarcoma Alliance Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://sistersrus.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-highresolutionpng.png" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://sistersrus.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-highresolutionpng.png" alt="Sarcoma Alliance Logo"></a>
                     </div>
                 </div>
                 <div class="row">
                     <div class="col-lg-4 col-md-4 col-sm-4 col-xs-12 Message-partners">
-                        <img lazy-img class="partner-logo" src="./assets/images/logo-hmn.png" alt="SARC Logo">
+                        <img lazy-resource class="partner-logo" src="./assets/images/logo-hmn.png" alt="SARC Logo">
                     </div>
                     <div class="col-lg-4 col-md-4 col-sm-4 col-xs-12 Message-partners">
-                        <img lazy-img class="partner-logo" src="./assets/images/logo-min_coalition.png" alt="Sarcoma Alliance Logo">
+                        <img lazy-resource class="partner-logo" src="./assets/images/logo-min_coalition.png" alt="Sarcoma Alliance Logo">
                     </div>
                     <div class="col-lg-4 col-md-4 col-sm-4 col-xs-12 Message-partners">
-                        <a href="https://mbccanada.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo_mbccanada.png" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://mbccanada.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo_mbccanada.png" alt="Sarcoma Alliance Logo"></a>
                     </div>
                 </div>
             </section>

--- a/ddp-workspace/projects/ddp-mbc/src/app/components/data-release/data-release.component.ts
+++ b/ddp-workspace/projects/ddp-mbc/src/app/components/data-release/data-release.component.ts
@@ -175,7 +175,8 @@ import { DisclaimerComponent, ToolkitConfigurationService } from 'toolkit';
                                     Toolkit.DataRelease.Glossary.Text
                                 </p>
                                 <div id="NCITermDictionaryWidgetEnglish">
-                                    <iframe frameborder="0" 
+                                    <iframe lazy-resource
+                                            frameborder="0" 
                                             src="https://www.cancer.gov/widgets/TermDictionaryWidgetEnglish" 
                                             id="NCITermDictionaryWidgetContainerEnglish"
                                             title="https://www.mbcproject.org/data-release" 

--- a/ddp-workspace/projects/ddp-mbc/src/app/components/more-details/more-details.component.ts
+++ b/ddp-workspace/projects/ddp-mbc/src/app/components/more-details/more-details.component.ts
@@ -47,7 +47,7 @@ import { ToolkitConfigurationService } from 'toolkit';
                         <h2 class="PageContent-subtitle" translate>Toolkit.MoreDetails.HowProjectWorks.SendUs.Title</h2>
                         <p class="PageContent-text" translate>Toolkit.MoreDetails.HowProjectWorks.SendUs.Text</p>
                         <div class="PageContent-video">
-                            <iframe class="PageContent-video--iframe" src="https://www.youtube.com/embed/_dKSNMarRuA" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                            <iframe lazy-resource class="PageContent-video--iframe" src="https://www.youtube.com/embed/_dKSNMarRuA" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
                         </div>
                                             
                         <h2 class="PageContent-subtitle" translate>Toolkit.MoreDetails.HowProjectWorks.Analyze.Title</h2>

--- a/ddp-workspace/projects/ddp-mbc/src/app/components/welcome/welcome.component.ts
+++ b/ddp-workspace/projects/ddp-mbc/src/app/components/welcome/welcome.component.ts
@@ -17,8 +17,8 @@ import { GoogleAnalyticsEventsService, BrowserContentService } from 'ddp-sdk';
         </div>
 
         <div class="Intro-footer row">
-            <img src="./assets/images/logo-broad-institute.svg" class="Intro-footerLogos" alt="Broad Institute Logo" />
-            <img src="./assets/images/logo-dana-farber-cancer-institute.svg" class="Intro-footerLogos" alt="Dana Farber Logo">
+            <img lazy-resource src="./assets/images/logo-broad-institute.svg" class="Intro-footerLogos" alt="Broad Institute Logo" />
+            <img lazy-resource src="./assets/images/logo-dana-farber-cancer-institute.svg" class="Intro-footerLogos" alt="Dana Farber Logo">
         </div>
         
         <div class="Intro row">
@@ -35,7 +35,7 @@ import { GoogleAnalyticsEventsService, BrowserContentService } from 'ddp-sdk';
         <div class="row">
             <a #secondView></a>
             <section class="Message col-lg-6 col-lg-offset-3 col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1">
-                <img lazy-img src="./assets/images/patient.png" class="Message-turtle" alt="Angiosarcoma pet">
+                <img lazy-resource src="./assets/images/patient.png" class="Message-turtle" alt="Angiosarcoma pet">
                 <p class="Message-text" translate>
                     Toolkit.Welcome.SmallTitle
                 </p>
@@ -58,7 +58,7 @@ import { GoogleAnalyticsEventsService, BrowserContentService } from 'ddp-sdk';
         </div>
 
         <div class="row NoPadding NoMargin">
-            <img lazy-img src="./assets/images/dna-strand.png" class="DNAStrand" alt="DNA Strand" />
+            <img lazy-resource src="./assets/images/dna-strand.png" class="DNAStrand" alt="DNA Strand" />
         </div>
 
         <div class="row">
@@ -96,7 +96,7 @@ import { GoogleAnalyticsEventsService, BrowserContentService } from 'ddp-sdk';
 
         <div class="row">
             <div class="Message-step col-lg-4 col-md-4 col-sm-12 col-xs-12">
-                <img lazy-img src="./assets/images/step-1.svg" class="Message-stepImage" alt="Step 1">
+                <img lazy-resource src="./assets/images/step-1.svg" class="Message-stepImage" alt="Step 1">
                 <h1 class="Message-stepTitle NoMargin" translate>
                     Toolkit.Welcome.ThirdBlock.FirstStep.Title
                 </h1>
@@ -110,7 +110,7 @@ import { GoogleAnalyticsEventsService, BrowserContentService } from 'ddp-sdk';
                 </p>
             </div>
             <div class="Message-step col-lg-4 col-md-4 col-sm-12 col-xs-12">
-                <img lazy-img src="./assets/images/step-2.svg" class="Message-stepImage" alt="Step 2">
+                <img lazy-resource src="./assets/images/step-2.svg" class="Message-stepImage" alt="Step 2">
                 <h1 class="Message-stepTitle NoMargin" translate>
                     Toolkit.Welcome.ThirdBlock.SecondStep.Title
                 </h1>
@@ -121,7 +121,7 @@ import { GoogleAnalyticsEventsService, BrowserContentService } from 'ddp-sdk';
                 </p>
             </div>
             <div class="Message-step col-lg-4 col-md-4 col-sm-12 col-xs-12">
-                <img lazy-img src="./assets/images/step-3.svg" class="Message-stepImage" alt="Step 3">
+                <img lazy-resource src="./assets/images/step-3.svg" class="Message-stepImage" alt="Step 3">
                 <h1 class="Message-stepTitle NoMargin" translate>
                     Toolkit.Welcome.ThirdBlock.ThirdStep.Title
                 </h1>
@@ -170,126 +170,126 @@ import { GoogleAnalyticsEventsService, BrowserContentService } from 'ddp-sdk';
             <section class="Message col-lg-6 col-lg-offset-3 col-md-8 col-md-offset-2 col-sm-8 col-sm-offset-2 col-xs-10 col-xs-offset-1 NoPadding">
                 <div class="row">
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="http://www.mbcn.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-mbcn.svg" alt="SARC Logo"></a>
+                        <a href="http://www.mbcn.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-mbcn.svg" alt="SARC Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.avonfoundation.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-avon.svg" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://www.avonfoundation.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-avon.svg" alt="Sarcoma Alliance Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.mbcalliance.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-mbca.svg" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://www.mbcalliance.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-mbca.svg" alt="Sarcoma Alliance Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="http://www.lbbc.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-lbbc.svg" alt="Sarcoma Alliance Logo"></a>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="http://www.ibcresearch.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-ibcrf.svg" alt="SARC Logo"></a>
-                    </div>
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.youngsurvival.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-ysc.svg" alt="Sarcoma Alliance Logo"></a>
-                    </div>
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.sharecancersupport.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-share.png" alt="Sarcoma Alliance Logo"></a>
-                    </div>
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://malebreastcancercoalition.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-mbcc.svg" alt="Sarcoma Alliance Logo"></a>
+                        <a href="http://www.lbbc.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-lbbc.svg" alt="Sarcoma Alliance Logo"></a>
                     </div>
                 </div>
                 <div class="row">
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="http://www.theresasresearch.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-theresas.svg" alt="SARC Logo"></a>
+                        <a href="http://www.ibcresearch.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-ibcrf.svg" alt="SARC Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://tnbcfoundation.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-tnbc.png" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://www.youngsurvival.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-ysc.svg" alt="Sarcoma Alliance Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.theibcnetwork.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-ibc.svg" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://www.sharecancersupport.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-share.png" alt="Sarcoma Alliance Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="http://advocates4breastcancer.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-a4bc.jpg" alt="Sarcoma Alliance Logo"></a>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="http://www.metavivor.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-metavivor.svg" alt="SARC Logo"></a>
-                    </div>
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="http://metup.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-metup.png" alt="Sarcoma Alliance Logo"></a>
-                    </div>
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.tigerlilyfoundation.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-tigerlily.jpg" alt="Sarcoma Alliance Logo"></a>
-                    </div>
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://ww5.komen.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-susangkomen.svg" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://malebreastcancercoalition.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-mbcc.svg" alt="Sarcoma Alliance Logo"></a>
                     </div>
                 </div>
                 <div class="row">
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.bcrf.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-bcrf.svg" alt="SARC Logo"></a>
+                        <a href="http://www.theresasresearch.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-theresas.svg" alt="SARC Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.drsusanloveresearch.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-dslrf.png" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://tnbcfoundation.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-tnbc.png" alt="Sarcoma Alliance Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://bcsm.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-bcsm.png" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://www.theibcnetwork.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-ibc.svg" alt="Sarcoma Alliance Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://hopescarves.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-hopescarves.svg" alt="Sarcoma Alliance Logo"></a>
-                    </div>
-                </div>
-                <div class="row">
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.thecancercouch.com/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-cancer-couch-foundation.png" alt="SARC Logo"></a>
-                    </div>
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://twistedpink.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-twistedpink.jpg" alt="Sarcoma Alliance Logo"></a>
-                    </div>
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="http://www.cierrasisters.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-cierra-sisters.png" alt="Sarcoma Alliance Logo"></a>
-                    </div>
-                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.breastcancertrials.org/BCTIncludes/index.html" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-bc-trials.jpg" alt="Sarcoma Alliance Logo"></a>
+                        <a href="http://advocates4breastcancer.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-a4bc.jpg" alt="Sarcoma Alliance Logo"></a>
                     </div>
                 </div>
                 <div class="row">
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="http://breastcanceralliance.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-bca.jpg" alt="SARC Logo"></a>
+                        <a href="http://www.metavivor.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-metavivor.svg" alt="SARC Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://thetutuproject.com/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-tutuproject.jpg" alt="Sarcoma Alliance Logo"></a>
+                        <a href="http://metup.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-metup.png" alt="Sarcoma Alliance Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.mpbcalliance.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-MetaplasticBreastGlobalAlliance.svg" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://www.tigerlilyfoundation.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-tigerlily.jpg" alt="Sarcoma Alliance Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://lobularbreastcancer.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-lbca.png" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://ww5.komen.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-susangkomen.svg" alt="Sarcoma Alliance Logo"></a>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="https://www.bcrf.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-bcrf.svg" alt="SARC Logo"></a>
+                    </div>
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="https://www.drsusanloveresearch.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-dslrf.png" alt="Sarcoma Alliance Logo"></a>
+                    </div>
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="https://bcsm.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-bcsm.png" alt="Sarcoma Alliance Logo"></a>
+                    </div>
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="https://hopescarves.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-hopescarves.svg" alt="Sarcoma Alliance Logo"></a>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="https://www.thecancercouch.com/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-cancer-couch-foundation.png" alt="SARC Logo"></a>
+                    </div>
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="https://twistedpink.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-twistedpink.jpg" alt="Sarcoma Alliance Logo"></a>
+                    </div>
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="http://www.cierrasisters.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-cierra-sisters.png" alt="Sarcoma Alliance Logo"></a>
+                    </div>
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="https://www.breastcancertrials.org/BCTIncludes/index.html" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-bc-trials.jpg" alt="Sarcoma Alliance Logo"></a>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="http://breastcanceralliance.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-bca.jpg" alt="SARC Logo"></a>
+                    </div>
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="https://thetutuproject.com/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-tutuproject.jpg" alt="Sarcoma Alliance Logo"></a>
+                    </div>
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="https://www.mpbcalliance.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-MetaplasticBreastGlobalAlliance.svg" alt="Sarcoma Alliance Logo"></a>
+                    </div>
+                    <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
+                        <a href="https://lobularbreastcancer.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-lbca.png" alt="Sarcoma Alliance Logo"></a>
                     </div>
         
                 </div>
                 <div class="row">
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.facingourrisk.org/index.php" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-force.svg" alt="SARC Logo"></a>
+                        <a href="https://www.facingourrisk.org/index.php" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-force.svg" alt="SARC Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://shaysharpespinkwishes.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-SSLogo-noBG.PNG" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://shaysharpespinkwishes.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-SSLogo-noBG.PNG" alt="Sarcoma Alliance Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://www.metastasis-research.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-MRS_LogoColor.jpg" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://www.metastasis-research.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-MRS_LogoColor.jpg" alt="Sarcoma Alliance Logo"></a>
                     </div>
                     <div class="col-lg-3 col-md-3 col-sm-3 col-xs-12 Message-partners">
-                        <a href="https://sistersrus.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo-highresolutionpng.png" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://sistersrus.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo-highresolutionpng.png" alt="Sarcoma Alliance Logo"></a>
                     </div>
                 </div>
                 <div class="row">
                     <div class="col-lg-4 col-md-4 col-sm-4 col-xs-12 Message-partners">
-                        <img lazy-img class="partner-logo" src="./assets/images/logo-hmn.png" alt="SARC Logo">
+                        <img lazy-resource class="partner-logo" src="./assets/images/logo-hmn.png" alt="SARC Logo">
                     </div>
                     <div class="col-lg-4 col-md-4 col-sm-4 col-xs-12 Message-partners">
-                        <img lazy-img class="partner-logo" src="./assets/images/logo-min_coalition.png" alt="Sarcoma Alliance Logo">
+                        <img lazy-resource class="partner-logo" src="./assets/images/logo-min_coalition.png" alt="Sarcoma Alliance Logo">
                     </div>
                     <div class="col-lg-4 col-md-4 col-sm-4 col-xs-12 Message-partners">
-                        <a href="https://mbccanada.org/" target="_blank"><img lazy-img class="partner-logo" src="./assets/images/logo_mbccanada.png" alt="Sarcoma Alliance Logo"></a>
+                        <a href="https://mbccanada.org/" target="_blank"><img lazy-resource class="partner-logo" src="./assets/images/logo_mbccanada.png" alt="Sarcoma Alliance Logo"></a>
                     </div>
                 </div>
             </section>

--- a/ddp-workspace/projects/ddp-osteo/src/app/components/about-us/about-us.component.html
+++ b/ddp-workspace/projects/ddp-osteo/src/app/components/about-us/about-us.component.html
@@ -24,7 +24,7 @@
         <div class="content content_tight cmi-block">
             <div class="cmi-block__logo">
                 <a [href]="countMeInUrl" target="_blank">
-                    <img src="../../../assets/images/logo-count-me-in.svg"
+                    <img lazy-resource src="../../../assets/images/logo-count-me-in.svg"
                         [alt]="'AboutUsPage.CMISection.CMIImgAlt' | translate">
                 </a>
             </div>
@@ -43,7 +43,7 @@
             <p [innerHTML]="'AboutUsPage.PACSection.Text' | translate"></p>
             <ng-container *ngFor="let member of 'AboutUsPage.PACSection.Members' | translate">
                 <div class="pac-member">
-                    <img class="pac-member__image" [src]="member.Image" [alt]="member.Alt">
+                    <img lazy-resource class="pac-member__image" [src]="member.Image" [alt]="member.Alt">
                     <h4 class="no-margin">{{member.Name}}</h4>
                     <p>{{member.Bio}}</p>
                 </div>
@@ -58,7 +58,7 @@
             <div class="sac-members">
                 <ng-container *ngFor="let member of 'AboutUsPage.SACSection.Members' | translate">
                     <div class="sac-member">
-                        <img class="sac-member__image" [src]="member.Image" [alt]="member.Alt">
+                        <img lazy-resource class="sac-member__image" [src]="member.Image" [alt]="member.Alt">
                         <div>
                             <a class="sac-member__link" [href]="member.Url" target="_blank">{{member.Name}}</a>
                             <div class="affiliations">

--- a/ddp-workspace/projects/ddp-osteo/src/app/components/welcome/welcome.component.html
+++ b/ddp-workspace/projects/ddp-osteo/src/app/components/welcome/welcome.component.html
@@ -30,9 +30,9 @@
             [alt]="'HomePage.NavigationSection.Button.Alt' | translate">
     </section>
     <section class="organizations-section">
-        <img src="assets/images/logo-broad-institute.svg" class="organizations-section__img"
+        <img lazy-resource src="assets/images/logo-broad-institute.svg" class="organizations-section__img"
             [alt]="'HomePage.OrganizationsSection.BroadLogo.Alt' | translate">
-        <img src="assets/images/logo-dana-farber-cancer-institute.svg" class="organizations-section__img"
+        <img lazy-resource src="assets/images/logo-dana-farber-cancer-institute.svg" class="organizations-section__img"
             [alt]="'HomePage.OrganizationsSection.DanaFarberLogo.Alt' | translate">
     </section>
     <section #scrollAnchor class="background-decorator"></section>
@@ -41,26 +41,32 @@
             <h2 class="section-title" translate>HomePage.StepsSection.Title</h2>
             <div class="steps">
                 <div class="step">
-                    <div class="step__img"><img src="assets/images/clipboard.svg"
-                            [alt]="'HomePage.StepsSection.Step1.ImageAlt' | translate"></div>
+                    <div class="step__img">
+                        <img lazy-resource src="assets/images/clipboard.svg"
+                            [alt]="'HomePage.StepsSection.Step1.ImageAlt' | translate">
+                    </div>
                     <p translate>HomePage.StepsSection.Step1.Text</p>
                 </div>
                 <div class="arrow">
-                    <img src="assets/images/step-arrow.svg"
+                    <img lazy-resource src="assets/images/step-arrow.svg"
                         [alt]="'HomePage.StepsSection.NextStepArrowAlt' | translate">
                 </div>
                 <div class="step">
-                    <div class="step__img"><img src="assets/images/microscope.svg"
-                            [alt]="'HomePage.StepsSection.Step2.ImageAlt' | translate"></div>
+                    <div class="step__img">
+                        <img lazy-resource src="assets/images/microscope.svg"
+                            [alt]="'HomePage.StepsSection.Step2.ImageAlt' | translate">
+                    </div>
                     <p translate>HomePage.StepsSection.Step2.Text</p>
                 </div>
                 <div class="arrow">
-                    <img src="assets/images/step-arrow.svg"
+                    <img lazy-resource src="assets/images/step-arrow.svg"
                         [alt]="'HomePage.StepsSection.NextStepArrowAlt' | translate">
                 </div>
                 <div class="step">
-                    <div class="step__img"><img src="assets/images/heart.svg"
-                            [alt]="'HomePage.StepsSection.Step3.ImageAlt' | translate"></div>
+                    <div class="step__img">
+                        <img lazy-resource src="assets/images/heart.svg"
+                            [alt]="'HomePage.StepsSection.Step3.ImageAlt' | translate">
+                    </div>
                     <div>
                         <p translate>HomePage.StepsSection.Step3.Text</p>
                         <a routerLink="/more-details" class="button button_medium button_secondary" translate>
@@ -120,8 +126,8 @@
                 </div>
             </div>
             <div class="youtube-video">
-                <iframe [title]="'HomePage.ParticipatingSection.IframeTitle' | translate" class="youtube-video__iframe"
-                    src="https://www.youtube.com/embed/VAvMSzBJaqQ" frameborder="0"
+                <iframe lazy-resource [title]="'HomePage.ParticipatingSection.IframeTitle' | translate"
+                    class="youtube-video__iframe" src="https://www.youtube.com/embed/VAvMSzBJaqQ" frameborder="0"
                     allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
                     allowfullscreen></iframe>
             </div>
@@ -131,7 +137,7 @@
         <div class="content content_medium gallery-block">
             <div class="gallery-header">
                 <h2 class="gallery-header__title" translate>HomePage.GallerySection.Title</h2>
-                <img class="gallery-header__image" src="assets/images/molecule.svg"
+                <img lazy-resource class="gallery-header__image" src="assets/images/molecule.svg"
                     [alt]="'HomePage.GallerySection.TitleImageAlt' | translate">
             </div>
             <app-gallery></app-gallery>
@@ -143,12 +149,12 @@
                 HomePage.PartnersSection.Title
             </h2>
             <div class="partners-group">
-                <img class="image" src="assets/images/partner_mib.png" alt="Make It Better">
-                <img class="image" src="https://via.placeholder.com/350x150" alt="Placeholder">
-                <img class="image" src="https://via.placeholder.com/350x150" alt="Placeholder">
-                <img class="image" src="https://via.placeholder.com/350x150" alt="Placeholder">
-                <img class="image" src="https://via.placeholder.com/350x150" alt="Placeholder">
-                <img class="image" src="https://via.placeholder.com/350x150" alt="Placeholder">
+                <img lazy-resource class="image" src="assets/images/partner_mib.png" alt="Make It Better">
+                <img lazy-resource class="image" src="https://via.placeholder.com/350x150" alt="Placeholder">
+                <img lazy-resource class="image" src="https://via.placeholder.com/350x150" alt="Placeholder">
+                <img lazy-resource class="image" src="https://via.placeholder.com/350x150" alt="Placeholder">
+                <img lazy-resource class="image" src="https://via.placeholder.com/350x150" alt="Placeholder">
+                <img lazy-resource class="image" src="https://via.placeholder.com/350x150" alt="Placeholder">
             </div>
         </div>
     </section>
@@ -160,15 +166,15 @@
                 </h2>
                 <div class="social-media-logos">
                     <a [href]="twitterUrl" target="_blank">
-                        <img class="social-media-logos__img" src="assets/images/twitter.png"
+                        <img lazy-resource class="social-media-logos__img" src="assets/images/twitter.png"
                             [alt]="'HomePage.SocialMediaSection.ImagesAlts.Twitter' | translate">
                     </a>
                     <a [href]="facebookUrl" target="_blank">
-                        <img class="social-media-logos__img" src="assets/images/facebook.png"
+                        <img lazy-resource class="social-media-logos__img" src="assets/images/facebook.png"
                             [alt]="'HomePage.SocialMediaSection.ImagesAlts.Facebook' | translate">
                     </a>
                     <a [href]="instagramUrl" target="_blank">
-                        <img class="social-media-logos__img" src="assets/images/instagram.png"
+                        <img lazy-resource class="social-media-logos__img" src="assets/images/instagram.png"
                             [alt]="'HomePage.SocialMediaSection.ImagesAlts.Instagram' | translate">
                     </a>
                 </div>
@@ -179,15 +185,15 @@
                     <app-twitter-timeline-widget></app-twitter-timeline-widget>
                 </div>
                 <div class="instagram-feed">
-                    <img class="image" src="https://via.placeholder.com/200x200" alt="Placeholder">
-                    <img class="image" src="https://via.placeholder.com/200x200" alt="Placeholder">
-                    <img class="image" src="https://via.placeholder.com/200x200" alt="Placeholder">
-                    <img class="image" src="https://via.placeholder.com/200x200" alt="Placeholder">
-                    <img class="image" src="https://via.placeholder.com/200x200" alt="Placeholder">
-                    <img class="image" src="https://via.placeholder.com/200x200" alt="Placeholder">
-                    <img class="image" src="https://via.placeholder.com/200x200" alt="Placeholder">
-                    <img class="image" src="https://via.placeholder.com/200x200" alt="Placeholder">
-                    <img class="image" src="https://via.placeholder.com/200x200" alt="Placeholder">
+                    <img lazy-resource class="image" src="https://via.placeholder.com/200x200" alt="Placeholder">
+                    <img lazy-resource class="image" src="https://via.placeholder.com/200x200" alt="Placeholder">
+                    <img lazy-resource class="image" src="https://via.placeholder.com/200x200" alt="Placeholder">
+                    <img lazy-resource class="image" src="https://via.placeholder.com/200x200" alt="Placeholder">
+                    <img lazy-resource class="image" src="https://via.placeholder.com/200x200" alt="Placeholder">
+                    <img lazy-resource class="image" src="https://via.placeholder.com/200x200" alt="Placeholder">
+                    <img lazy-resource class="image" src="https://via.placeholder.com/200x200" alt="Placeholder">
+                    <img lazy-resource class="image" src="https://via.placeholder.com/200x200" alt="Placeholder">
+                    <img lazy-resource class="image" src="https://via.placeholder.com/200x200" alt="Placeholder">
                 </div>
             </div>
         </div>

--- a/ddp-workspace/projects/ddp-prion/src/app/components/about-us/about-us.component.ts
+++ b/ddp-workspace/projects/ddp-prion/src/app/components/about-us/about-us.component.ts
@@ -48,7 +48,7 @@ import { ToolkitConfigurationService } from 'toolkit';
               <a [href]="countMeInUrl" class="Link" target="_blank" translate> Toolkit.AboutUs.ContentLink</a>.
             </p>
           </section>
-          <img lazy-img src="./assets/images/about-page-broad-building.png" class="PageContent-image" alt="Broad Building">
+          <img lazy-resource src="./assets/images/about-page-broad-building.png" class="PageContent-image" alt="Broad Building">
         </div>
       </div>
     </article>

--- a/ddp-workspace/projects/ddp-prion/src/app/components/welcome/welcome.component.ts
+++ b/ddp-workspace/projects/ddp-prion/src/app/components/welcome/welcome.component.ts
@@ -58,7 +58,7 @@ import { GoogleAnalyticsEventsService, BrowserContentService, WindowRef } from '
 
         <div class="row">
             <div class="Message-step col-lg-4 col-md-4 col-sm-12 col-xs-12">
-                <img lazy-img src="./assets/images/step-1.svg" class="Message-stepImage" alt="Step 1">
+                <img lazy-resource src="./assets/images/step-1.svg" class="Message-stepImage" alt="Step 1">
                 <h1 class="Message-stepTitle NoMargin" translate>
                     Toolkit.Welcome.Steps.FirstStep.Title
                 </h1>
@@ -72,7 +72,7 @@ import { GoogleAnalyticsEventsService, BrowserContentService, WindowRef } from '
                 </p>
             </div>
             <div class="Message-step col-lg-4 col-md-4 col-sm-12 col-xs-12">
-                <img lazy-img src="./assets/images/step-2.svg" class="Message-stepImage" alt="Step 2">
+                <img lazy-resource src="./assets/images/step-2.svg" class="Message-stepImage" alt="Step 2">
                 <h1 class="Message-stepTitle NoMargin" translate>
                     Toolkit.Welcome.Steps.SecondStep.Title
                 </h1>
@@ -83,7 +83,7 @@ import { GoogleAnalyticsEventsService, BrowserContentService, WindowRef } from '
                 </p>
             </div>
             <div class="Message-step col-lg-4 col-md-4 col-sm-12 col-xs-12">
-                <img lazy-img src="./assets/images/step-3.svg" class="Message-stepImage" alt="Step 3">
+                <img lazy-resource src="./assets/images/step-3.svg" class="Message-stepImage" alt="Step 3">
                 <h1 class="Message-stepTitle NoMargin" translate>
                     Toolkit.Welcome.Steps.ThirdStep.Title
                 </h1>

--- a/ddp-workspace/projects/ddp-sdk/src/lib/ddp.module.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/ddp.module.ts
@@ -145,7 +145,7 @@ import { AddressService } from './services/address.service';
 import { AddressEntryDataService } from './services/addressEntryData.service';
 
 import { InputRestrictionDirective } from './directives/inputRestrictionDirective.directive';
-import { LazyLoadImagesDirective } from './directives/lazyLoadImages.directive';
+import { LazyLoadResourcesDirective } from './directives/lazyLoadResources.directive';
 import { DateService } from './services/dateService.service';
 import { CountryService } from './services/addressCountry.service';
 import { MedicalProvidersServiceAgent } from './services/serviceAgents/medicalProvidersServiceAgent.service';
@@ -318,7 +318,7 @@ export function createTranslateLoader(http: HttpClient): TranslateHttpLoader {
     AddressConfirmComponent,
     AcceptAgeUpComponent,
     InputRestrictionDirective,
-    LazyLoadImagesDirective,
+    LazyLoadResourcesDirective,
     UpperCaseInputDirective,
     AddressGoogleAutocompleteDirective,
     RouteTransformerDirective
@@ -376,7 +376,7 @@ export function createTranslateLoader(http: HttpClient): TranslateHttpLoader {
     AcceptAgeUpComponent,
     ValidationMessage,
     TranslateModule,
-    LazyLoadImagesDirective,
+    LazyLoadResourcesDirective,
     RouteTransformerDirective
   ],
   entryComponents: [

--- a/ddp-workspace/projects/ddp-sdk/src/lib/directives/lazyLoadImages.directive.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/directives/lazyLoadImages.directive.ts
@@ -1,15 +1,15 @@
-import { Directive, AfterViewInit, HostBinding, Input, ElementRef } from '@angular/core';
+import { Directive, AfterViewInit, Input, ElementRef, Renderer2 } from '@angular/core';
 import { WindowRef } from '../services/windowRef';
 
 @Directive({
     selector: 'img[lazy-img]'
 })
 export class LazyLoadImagesDirective implements AfterViewInit {
-    @HostBinding('attr.src') srcAttr = '';
     @Input() src: string;
 
     constructor(
         private el: ElementRef,
+        private renderer: Renderer2,
         private windowRef: WindowRef) { }
 
     public ngAfterViewInit(): void {
@@ -17,6 +17,9 @@ export class LazyLoadImagesDirective implements AfterViewInit {
     }
 
     private lazyLoadImage(): void {
+        const options = {
+            rootMargin: '0px 0px 300px 0px'
+        };
         const observer = new IntersectionObserver((entries: any[]) => {
             entries.forEach((entry: any) => {
                 if (entry.isIntersecting) {
@@ -24,12 +27,12 @@ export class LazyLoadImagesDirective implements AfterViewInit {
                     observer.unobserve(this.el.nativeElement);
                 }
             });
-        });
+        }, options);
         observer.observe(this.el.nativeElement);
     }
 
     private loadImage(): void {
-        this.srcAttr = this.src;
+        this.renderer.setAttribute(this.el.nativeElement, 'src', this.src)
     }
 
     private get canUseLazyLoad(): boolean {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/directives/lazyLoadResources.directive.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/directives/lazyLoadResources.directive.ts
@@ -2,7 +2,7 @@ import { Directive, AfterViewInit, Input, ElementRef, Renderer2 } from '@angular
 import { WindowRef } from '../services/windowRef';
 
 @Directive({
-    selector: 'lazy-resource'
+    selector: '[lazy-resource]'
 })
 export class LazyLoadResourcesDirective implements AfterViewInit {
     @Input() src: string;

--- a/ddp-workspace/projects/ddp-sdk/src/lib/directives/lazyLoadResources.directive.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/directives/lazyLoadResources.directive.ts
@@ -13,7 +13,10 @@ export class LazyLoadResourcesDirective implements AfterViewInit {
         private windowRef: WindowRef) { }
 
     public ngAfterViewInit(): void {
-        this.canUseLazyLoad ? this.lazyLoadResource() : this.loadResource();
+        if (this.canUseLazyLoad()) {
+            this.renderer.setAttribute(this.el.nativeElement, 'src', '');
+            this.lazyLoadResource();
+        }
     }
 
     private lazyLoadResource(): void {
@@ -32,10 +35,10 @@ export class LazyLoadResourcesDirective implements AfterViewInit {
     }
 
     private loadResource(): void {
-        this.renderer.setAttribute(this.el.nativeElement, 'src', this.src)
+        this.renderer.setAttribute(this.el.nativeElement, 'src', this.src);
     }
 
-    private get canUseLazyLoad(): boolean {
+    private canUseLazyLoad(): boolean {
         return this.windowRef.nativeWindow && 'IntersectionObserver' in this.windowRef.nativeWindow;
     }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/directives/lazyLoadResources.directive.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/directives/lazyLoadResources.directive.ts
@@ -2,9 +2,9 @@ import { Directive, AfterViewInit, Input, ElementRef, Renderer2 } from '@angular
 import { WindowRef } from '../services/windowRef';
 
 @Directive({
-    selector: 'img[lazy-img]'
+    selector: 'lazy-resource'
 })
-export class LazyLoadImagesDirective implements AfterViewInit {
+export class LazyLoadResourcesDirective implements AfterViewInit {
     @Input() src: string;
 
     constructor(
@@ -13,17 +13,17 @@ export class LazyLoadImagesDirective implements AfterViewInit {
         private windowRef: WindowRef) { }
 
     public ngAfterViewInit(): void {
-        this.canUseLazyLoad ? this.lazyLoadImage() : this.loadImage();
+        this.canUseLazyLoad ? this.lazyLoadResource() : this.loadResource();
     }
 
-    private lazyLoadImage(): void {
+    private lazyLoadResource(): void {
         const options = {
             rootMargin: '0px 0px 300px 0px'
         };
         const observer = new IntersectionObserver((entries: any[]) => {
             entries.forEach((entry: any) => {
                 if (entry.isIntersecting) {
-                    this.loadImage();
+                    this.loadResource();
                     observer.unobserve(this.el.nativeElement);
                 }
             });
@@ -31,7 +31,7 @@ export class LazyLoadImagesDirective implements AfterViewInit {
         observer.observe(this.el.nativeElement);
     }
 
-    private loadImage(): void {
+    private loadResource(): void {
         this.renderer.setAttribute(this.el.nativeElement, 'src', this.src)
     }
 

--- a/ddp-workspace/projects/toolkit/src/lib/components/footer/footer.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/footer/footer.component.ts
@@ -10,7 +10,7 @@ import { GoogleAnalyticsEventsService, GoogleAnalytics, WindowRef } from 'ddp-sd
     template: `<footer class="Footer">
   <div class="Footer-navigation">
       <a class="Footer-logo" [routerLink]="['/']">
-          <img src="assets/images/project-logo.svg" class="Footer-logoImg" alt="Project isotype">
+          <img lazy-resource src="assets/images/project-logo.svg" class="Footer-logoImg" alt="Project isotype">
           <div class="Footer-logoText" [innerHTML]="'Toolkit.Footer.FooterLogo' | translate">
           </div>
       </a>
@@ -53,10 +53,10 @@ import { GoogleAnalyticsEventsService, GoogleAnalytics, WindowRef } from 'ddp-sd
                   </li>
                   <li>
                       <a target="_blank" [href]="facebookUrl" (click)="doAnalytics('facebook')">
-                          <img class="Footer-contactLogos" src="assets/images/facebook.svg" alt="Facebook">
+                          <img lazy-resource class="Footer-contactLogos" src="assets/images/facebook.svg" alt="Facebook">
                       </a>
                       <a target="_blank" [href]="twitterUrl" (click)="doAnalytics('twitter')">
-                          <img class="Footer-contactLogos" src="assets/images/twitter.svg" alt="Twitter">
+                          <img lazy-resource class="Footer-contactLogos" src="assets/images/twitter.svg" alt="Twitter">
                       </a>
                   </li>
               </ul>
@@ -74,7 +74,7 @@ import { GoogleAnalyticsEventsService, GoogleAnalytics, WindowRef } from 'ddp-sd
       </div>
       </nav>
       <a class="Footer-logoCMI" target="_blank" [href]="countMeInUrl">
-            <img class="Footer-logoCMI-img" src="assets/images/logo-count-me-in.svg" alt="Count Me In logo">
+            <img lazy-resource class="Footer-logoCMI-img" src="assets/images/logo-count-me-in.svg" alt="Count Me In logo">
       </a>
   </div>
 </footer>`


### PR DESCRIPTION
- We can use lazy loading not only for images, but we can also load lazily all resources which have `src` attribute(img, iframe, video). For this reason, the directive was re-implemented and re-named.
- We can configure `rootMargin` property in `IntersectionObserver` object. It allows preload resources while they stay invisible for a user, but a user will see them soon. It improves UX, a user does not need to wait until resources load.