### PR TITLE
auth: pass along params to local registration

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/login/auth0-code-callback.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/login/auth0-code-callback.component.ts
@@ -32,14 +32,20 @@ export class Auth0CodeCallbackComponent implements OnInit, OnDestroy {
         if (authCode) {
             this.log.logEvent(this.LOG_SOURCE, 'Will login to ' + this.configuration.localRegistrationUrl + ' using code ' + authCode);
 
-            const tempSession = this.session.isTemporarySession() ? this.session.session : null;
+            const value = sessionStorage.getItem('localAuthParams') || "{}";
+            const params: object = JSON.parse(value);
+            sessionStorage.removeItem('localAuthParams');
+
             const registrationPayload = {
                 auth0ClientId: this.configuration.auth0ClientId,
                 studyGuid: this.configuration.studyGuid,
                 auth0Code: authCode,
                 redirectUri: this.configuration.auth0CodeRedirect,
-                ...(tempSession && {
-                    tempUserGuid: tempSession.userGuid
+                ...(params['temp_user_guid'] && {
+                    tempUserGuid: params['temp_user_guid']
+                }),
+                ...(params['invitation_id'] && {
+                    invitationId: params['invitation_id']
                 })
             };
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/login/auth0-code-callback.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/login/auth0-code-callback.component.ts
@@ -32,10 +32,7 @@ export class Auth0CodeCallbackComponent implements OnInit, OnDestroy {
         if (authCode) {
             this.log.logEvent(this.LOG_SOURCE, 'Will login to ' + this.configuration.localRegistrationUrl + ' using code ' + authCode);
 
-            const value = sessionStorage.getItem('localAuthParams') || "{}";
-            const params: object = JSON.parse(value);
-            sessionStorage.removeItem('localAuthParams');
-
+            const params = this.consumeLocalAuthParams();
             const registrationPayload = {
                 auth0ClientId: this.configuration.auth0ClientId,
                 studyGuid: this.configuration.studyGuid,
@@ -64,6 +61,12 @@ export class Auth0CodeCallbackComponent implements OnInit, OnDestroy {
 
     public ngOnDestroy(): void {
         this.anchor.unsubscribe();
+    }
+
+    private consumeLocalAuthParams(): object {
+        const params = sessionStorage.getItem('localAuthParams') || '{}';
+        sessionStorage.removeItem('localAuthParams');
+        return JSON.parse(params);
     }
 }
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/authentication/auth0Adapter.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/authentication/auth0Adapter.service.ts
@@ -114,6 +114,9 @@ export class Auth0AdapterService implements OnDestroy {
                 ...additionalParams
             })
         };
+        if (this.configuration.doLocalRegistration) {
+            sessionStorage.setItem('localAuthParams', JSON.stringify(params));
+        }
         this.showAuth0Modal(Auth0Mode.SignupOnly, params);
     }
 


### PR DESCRIPTION
While testing osteo age-up locally, I noticed that we're not passing `invitation_id` along via the local registration codepath. This PR attempts to solve that by passing via session storage.

CC @fat23cat 