### PR TITLE
Osteo translate fix

### DIFF
--- a/ddp-workspace/projects/ddp-osteo/src/app/components/header/header.component.html
+++ b/ddp-workspace/projects/ddp-osteo/src/app/components/header/header.component.html
@@ -92,6 +92,6 @@
                 </g>
             </svg>
         </div>
-        <span translate>Header.Navigation.Dashboard</span>
+        <span translate>Common.Navigation.Dashboard</span>
     </a>
 </ng-template>


### PR DESCRIPTION
Noticed that I've forgotten to update translate key for the dashboard button:
![image](https://user-images.githubusercontent.com/30126907/72885393-e1801b00-3d18-11ea-933e-563c8c2e1a5c.png)
