### PR TITLE
DDP-4337: Osteo footer QA feedback

### DIFF
--- a/ddp-workspace/projects/ddp-osteo/src/app/components/footer/footer.component.scss
+++ b/ddp-workspace/projects/ddp-osteo/src/app/components/footer/footer.component.scss
@@ -46,13 +46,13 @@
 }
 
 .footer-main-text {
-    font-size: 1.25rem;
-    line-height: 1.5625rem;
+    font-size: 20px;
+    line-height: 25px;
 }
 
 .footer-secondary-text {
-    font-size: 0.9375rem;
-    line-height: 1.375rem;
+    font-size: 15px;
+    line-height: 22px;
 }
 
 .footer-link {
@@ -114,7 +114,7 @@
     display: flex;
 }
 
-@media screen and (max-width: 945px) {
+@media screen and (max-width: 975px) {
     .content {
         padding: 3.25rem 4rem 4rem 4rem;
     }
@@ -141,13 +141,13 @@
     }
 }
 
-@media screen and (max-width: 550px) {
+@media screen and (max-width: 650px) {
     .content {
         padding: 3.25rem 1.5625rem 4rem 1.5625rem;
     }
 }
 
-@media screen and (max-width: 500px) {
+@media screen and (max-width: 575px) {
     .navigation {
         flex-direction: column;
     }
@@ -163,5 +163,15 @@
 
     .cmi-info__logo {
         margin-bottom: 1.5rem;
+    }
+
+    .footer-main-text {
+        font-size: 18px;
+        line-height: 23px;
+    }
+
+    .footer-secondary-text {
+        font-size: 14px;
+        line-height: 22px;
     }
 }

--- a/ddp-workspace/projects/ddp-osteo/src/styles.scss
+++ b/ddp-workspace/projects/ddp-osteo/src/styles.scss
@@ -1,17 +1,16 @@
-@import "app-theme.scss";
-@import "./styles/activity.scss";
-@import "./styles/buttons.scss";
-@import "./styles/dashboard.scss";
-@import "./styles/stay-informed.scss";
-@import "./styles/error.scss";
-@import "./styles/password.scss";
-@import "./styles/loved-one-thank-you.scss";
-@import "./styles/age-up-thank-you.scss";
-@import "./styles/session-expired.scss";
-@import "./styles/dialogs.scss";
-@import "./styles//static-page.scss";
+@import 'app-theme.scss';
+@import './styles/activity.scss';
+@import './styles/buttons.scss';
+@import './styles/dashboard.scss';
+@import './styles/stay-informed.scss';
+@import './styles/password.scss';
+@import './styles/loved-one-thank-you.scss';
+@import './styles/age-up-thank-you.scss';
+@import './styles/session-expired.scss';
+@import './styles/dialogs.scss';
+@import './styles//static-page.scss';
 
-$custom-typography: mat-typography-config($font-family: "Source Sans Pro");
+$custom-typography: mat-typography-config($font-family: 'Source Sans Pro');
 
 @include mat-core($custom-typography);
 

--- a/ddp-workspace/projects/ddp-osteo/src/styles/error.scss
+++ b/ddp-workspace/projects/ddp-osteo/src/styles/error.scss
@@ -1,5 +1,0 @@
-@import '../app-theme.scss';
-
-.error-content-section {
-    margin-top: 4rem;
-}

--- a/ddp-workspace/projects/ddp-osteo/src/styles/password.scss
+++ b/ddp-workspace/projects/ddp-osteo/src/styles/password.scss
@@ -1,5 +1,9 @@
 @import '../app-theme.scss';
 
+.static-page-content-section {
+    margin: 4rem 0;
+}
+
 .password-section {
     margin: 4rem 0;
 }

--- a/ddp-workspace/projects/ddp-osteo/src/styles/static-page.scss
+++ b/ddp-workspace/projects/ddp-osteo/src/styles/static-page.scss
@@ -4,3 +4,7 @@
     padding: 2rem 0;
     background-color: mat-color($app-theme, 350);
 }
+
+.static-page-content-section {
+    margin: 4rem 0;
+}

--- a/ddp-workspace/projects/ddp-osteo/src/styles/stay-informed.scss
+++ b/ddp-workspace/projects/ddp-osteo/src/styles/stay-informed.scss
@@ -1,9 +1,5 @@
 @import '../app-theme.scss';
 
-.stay-informed-content-section {
-    margin-top: 2rem;
-}
-
 .stay-informed-button {
     margin: 3rem 0;
     display: flex;

--- a/ddp-workspace/projects/toolkit/src/lib/components/error/error.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/error/error.component.ts
@@ -14,7 +14,7 @@ import { HeaderConfigurationService } from '../../services/headerConfiguration.s
           <h1 translate>Toolkit.ErrorPage.Title</h1>
         </div>
       </section>
-      <section class="section error-content-section">
+      <section class="section static-page-content-section">
         <div class="content content_tight">
           <p translate>Toolkit.ErrorPage.Text</p>
           <p>

--- a/ddp-workspace/projects/toolkit/src/lib/components/password/password.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/password/password.component.ts
@@ -17,7 +17,7 @@ import { HeaderConfigurationService } from '../../services/headerConfiguration.s
                     <h1 translate>Toolkit.Password.Title</h1>
                 </div>
             </section>
-            <section class="section">
+            <section class="section static-page-content-section">
                 <div class="content content_tight">
                     <div class="password-section">
                         <p class="password-section__question" translate>Toolkit.Password.Text</p>

--- a/ddp-workspace/projects/toolkit/src/lib/components/stay-informed/stayInformed.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/stay-informed/stayInformed.component.ts
@@ -14,7 +14,7 @@ import { HeaderConfigurationService } from '../../services/headerConfiguration.s
                     <h1 translate>Toolkit.StayInformed.Title</h1>
                 </div>
             </section>
-            <section class="section stay-informed-content-section">
+            <section class="section static-page-content-section">
                 <div class="content content_tight">
                     <p>
                         <span translate>Toolkit.StayInformed.Text</span>


### PR DESCRIPTION
Kiara: 
>Footer looks good and matches design but for mobile and tablet view the following text seems a bit too small for users (pic for reference to be uploaded):
email
phone number
address
general text describing the study

Changes:
- Used static font size
- Static pages a bit updated because of the new footer, content looked cramped