### PR TITLE
Change activity submission error message to be broader

### DIFF
--- a/ddp-workspace/projects/ddp-osteo/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-osteo/src/assets/i18n/en.json
@@ -525,7 +525,7 @@
         "SavingButton": "Saving",
         "EditButton": "View/Edit",
         "ReviewButton": "View",
-        "ValidateError": "Please correct any errors in the form",
+        "ValidateError": "Submission cannot proceed. Please review messages in form for details.",
         "CommunicationError": "There was a problem saving your data. Please check the form and your answers before submitting",
         "SaveError": "We're sorry but an error occurred",
         "ExportStudy": {


### PR DESCRIPTION
This is to deal with situation where we have a server-side validation that prevents submitting the form, but it is technically speaking not really an error to be fixed by the user.
Specifically the rules that determine if a minor can signup for a study. We prevent them from continuing with the workflow, but this is not really a data entry error.
Please review the one line error message change.