### PR TITLE
DDP-4396: Google Analytics doesn't cover all osteo website

### DIFF
--- a/ddp-workspace/projects/ddp-angio/src/app/components/welcome/welcome.component.ts
+++ b/ddp-workspace/projects/ddp-angio/src/app/components/welcome/welcome.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { GoogleAnalyticsEventsService, BrowserContentService, WindowRef } from 'ddp-sdk';
+import { GoogleAnalyticsEventsService, BrowserContentService, WindowRef, GoogleAnalytics } from 'ddp-sdk';
 
 @Component({
     selector: 'welcome',
@@ -286,6 +286,6 @@ export class WelcomeComponent implements OnInit {
     }
 
     private doAnalytics(): void {
-        this.analytics.emitCustomEvent('clickedCountMeIn', 'fromMainPage');
+        this.analytics.emitCustomEvent(GoogleAnalytics.ClickedCountMeIn, GoogleAnalytics.FromMainPage);
     }
 }

--- a/ddp-workspace/projects/ddp-angio/src/styles.scss
+++ b/ddp-workspace/projects/ddp-angio/src/styles.scss
@@ -914,6 +914,7 @@ ul {
     transition: all 0.3s ease-out;
     box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.16), 0 2px 10px 0 rgba(0, 0, 0, 0.12) !important;
     background-color: mat-color($app-theme, 600);
+    min-width: unset !important;
 }
 
 .ButtonFilled:focus {
@@ -1347,7 +1348,7 @@ ul {
 }
 
 .ErrorMessage a {
-  text-decoration: underline !important;
+    text-decoration: underline !important;
 }
 
 .ErrorMessage {
@@ -1360,21 +1361,21 @@ ul {
 }
 
 .ErrorMessage a {
-  text-decoration: underline !important;
+    text-decoration: underline !important;
 }
 
 .ddp-activity-validation {
-  .ErrorMessageList {
-    list-style-type: square;
-  }
+    .ErrorMessageList {
+        list-style-type: square;
+    }
 
-  .ErrorMessageItem {
-    font-size: 0.9rem;
-    color: mat-color($app-theme, 1200);
-    font-weight: 300;
-    margin: 10px 0 10px 0;
-    padding: 0 0 0 0;
-  }
+    .ErrorMessageItem {
+        font-size: 0.9rem;
+        color: mat-color($app-theme, 1200);
+        font-weight: 300;
+        margin: 10px 0 10px 0;
+        padding: 0 0 0 0;
+    }
 }
 
 .JoinDialogFiled {

--- a/ddp-workspace/projects/ddp-brain/src/app/components/welcome/welcome.component.ts
+++ b/ddp-workspace/projects/ddp-brain/src/app/components/welcome/welcome.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { GoogleAnalyticsEventsService, BrowserContentService, WindowRef } from 'ddp-sdk';
+import { GoogleAnalyticsEventsService, BrowserContentService, WindowRef, GoogleAnalytics } from 'ddp-sdk';
 
 @Component({
     selector: 'welcome',
@@ -274,6 +274,6 @@ export class WelcomeComponent implements OnInit {
     }
 
     private doAnalytics(): void {
-        this.analytics.emitCustomEvent('clickedCountMeIn', 'fromMainPage');
+        this.analytics.emitCustomEvent(GoogleAnalytics.ClickedCountMeIn, GoogleAnalytics.FromMainPage);
     }
 }

--- a/ddp-workspace/projects/ddp-brain/src/styles.scss
+++ b/ddp-workspace/projects/ddp-brain/src/styles.scss
@@ -1066,6 +1066,7 @@ ul {
     transition: all 0.3s ease-out;
     box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.16), 0 2px 10px 0 rgba(0, 0, 0, 0.12) !important;
     background-color: mat-color($app-theme, 600);
+    min-width: unset !important;
 }
 
 .ButtonFilled:focus {
@@ -1531,18 +1532,19 @@ ul {
 }
 
 .ddp-activity-validation {
-  .ErrorMessageList {
-    list-style-type: square;
-  }
+    .ErrorMessageList {
+        list-style-type: square;
+    }
 
-  .ErrorMessageItem {
-    font-size: 0.9rem;
-    color: mat-color($app-theme, 1200);
-    font-weight: 300;
-    margin: 10px 0 10px 0;
-    padding: 0 0 0 0;
-  }
+    .ErrorMessageItem {
+        font-size: 0.9rem;
+        color: mat-color($app-theme, 1200);
+        font-weight: 300;
+        margin: 10px 0 10px 0;
+        padding: 0 0 0 0;
+    }
 }
+
 .JoinDialogFiled {
     width: 100%;
 }

--- a/ddp-workspace/projects/ddp-mbc/src/app/components/welcome/welcome.component.ts
+++ b/ddp-workspace/projects/ddp-mbc/src/app/components/welcome/welcome.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { GoogleAnalyticsEventsService, BrowserContentService } from 'ddp-sdk';
+import { GoogleAnalyticsEventsService, BrowserContentService, GoogleAnalytics } from 'ddp-sdk';
 
 @Component({
     selector: 'welcome',
@@ -380,6 +380,6 @@ export class WelcomeComponent implements OnInit {
     }
 
     private doAnalytics(): void {
-        this.analytics.emitCustomEvent('clickedCountMeIn', 'fromMainPage');
+        this.analytics.emitCustomEvent(GoogleAnalytics.ClickedCountMeIn, GoogleAnalytics.FromMainPage);
     }
 }

--- a/ddp-workspace/projects/ddp-mbc/src/styles.scss
+++ b/ddp-workspace/projects/ddp-mbc/src/styles.scss
@@ -977,6 +977,7 @@ ul {
     transition: all 0.3s ease-out;
     box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.16), 0 2px 10px 0 rgba(0, 0, 0, 0.12) !important;
     background-color: mat-color($app-theme, 600);
+    min-width: unset !important;
 }
 
 .ButtonFilled:focus {
@@ -1409,21 +1410,23 @@ ul {
 }
 
 .ErrorMessage a {
-  text-decoration: underline !important;
+    text-decoration: underline !important;
 }
-.ddp-activity-validation {
-  .ErrorMessageList {
-    list-style-type: square;
-  }
 
-  .ErrorMessageItem {
-    font-size: 0.9rem;
-    color: mat-color($app-theme, 1200);
-    font-weight: 300;
-    margin: 10px 0 10px 0;
-    padding: 0 0 0 0;
-  }
+.ddp-activity-validation {
+    .ErrorMessageList {
+        list-style-type: square;
+    }
+
+    .ErrorMessageItem {
+        font-size: 0.9rem;
+        color: mat-color($app-theme, 1200);
+        font-weight: 300;
+        margin: 10px 0 10px 0;
+        padding: 0 0 0 0;
+    }
 }
+
 .JoinDialogFiled {
     width: 100%;
 }

--- a/ddp-workspace/projects/ddp-osteo/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-osteo/src/app/app.module.ts
@@ -68,7 +68,6 @@ tkCfg.activityUrl = 'activity';
 tkCfg.errorUrl = 'error';
 tkCfg.stayInformedUrl = 'stay-informed';
 tkCfg.lovedOneThankYouUrl = 'loved-one-thank-you';
-tkCfg.internationalPatientsUrl = 'international-patients';
 tkCfg.phone = '651-602-2020';
 tkCfg.infoEmail = 'info@osproject.org';
 tkCfg.twitterAccountId = 'the_osproject';

--- a/ddp-workspace/projects/ddp-osteo/src/app/components/footer/footer.component.html
+++ b/ddp-workspace/projects/ddp-osteo/src/app/components/footer/footer.component.html
@@ -62,19 +62,22 @@
                 </ul>
                 <ul class="social-media">
                     <li class="social-media__item">
-                        <a class="social-media__link" [href]="twitterUrl" target="_blank">
+                        <a (click)="sendSocialMediaAnalytics('twitter')" class="social-media__link" [href]="twitterUrl"
+                            target="_blank">
                             <img class="social-media__logo" lazy-resource src="assets/images/twitter-small.png"
                                 [alt]="'Common.Alts.Twitter' | translate">
                         </a>
                     </li>
                     <li class="social-media__item">
-                        <a class="social-media__link" [href]="facebookUrl" target="_blank">
+                        <a (click)="sendSocialMediaAnalytics('facebook')" class="social-media__link"
+                            [href]="facebookUrl" target="_blank">
                             <img class="social-media__logo" lazy-resource src="assets/images/facebook-small.png"
                                 [alt]="'Common.Alts.Facebook' | translate">
                         </a>
                     </li>
                     <li>
-                        <a class="social-media__link" [href]="instagramUrl" target="_blank">
+                        <a (click)="sendSocialMediaAnalytics('instagram')" class="social-media__link"
+                            [href]="instagramUrl" target="_blank">
                             <img class="social-media__logo" lazy-resource src="assets/images/instagram-small.png"
                                 [alt]="'Common.Alts.Instagram' | translate">
                         </a>

--- a/ddp-workspace/projects/ddp-osteo/src/app/components/footer/footer.component.ts
+++ b/ddp-workspace/projects/ddp-osteo/src/app/components/footer/footer.component.ts
@@ -1,3 +1,4 @@
+import { GoogleAnalyticsEventsService, GoogleAnalytics } from 'ddp-sdk';
 import { Component, OnInit, Inject } from '@angular/core';
 import { CommunicationService, ToolkitConfigurationService } from 'toolkit';
 
@@ -18,6 +19,7 @@ export class FooterComponent implements OnInit {
 
   constructor(
     private communicationService: CommunicationService,
+    private analytics: GoogleAnalyticsEventsService,
     @Inject('toolkit.toolkitConfig') private toolkitConfiguration: ToolkitConfigurationService) { }
 
   public ngOnInit(): void {
@@ -33,5 +35,9 @@ export class FooterComponent implements OnInit {
 
   public openJoinMailingList(): void {
     this.communicationService.openJoinDialog();
+  }
+
+  public sendSocialMediaAnalytics(event: string): void {
+    this.analytics.emitCustomEvent(GoogleAnalytics.Social, event);
   }
 }

--- a/ddp-workspace/projects/ddp-osteo/src/app/components/footer/footer.component.ts
+++ b/ddp-workspace/projects/ddp-osteo/src/app/components/footer/footer.component.ts
@@ -1,5 +1,5 @@
-import { GoogleAnalyticsEventsService, GoogleAnalytics } from 'ddp-sdk';
 import { Component, OnInit, Inject } from '@angular/core';
+import { GoogleAnalyticsEventsService, GoogleAnalytics } from 'ddp-sdk';
 import { CommunicationService, ToolkitConfigurationService } from 'toolkit';
 
 @Component({

--- a/ddp-workspace/projects/ddp-osteo/src/app/components/header/header.component.html
+++ b/ddp-workspace/projects/ddp-osteo/src/app/components/header/header.component.html
@@ -1,7 +1,8 @@
 <header class="header" [ngClass]="{'panel-opened': isPanelOpened, 'header_shadow': isPageScrolled}">
     <div class="header-content" [ngClass]="{'header-content_sticky': headerConfig.stickySubtitle}">
         <a class="project-logo" routerLink="/">
-            <img class="project-logo__img" src="assets/images/logo-osteo.svg" [alt]="'Header.Logo.ImageAlt' | translate">
+            <img class="project-logo__img" src="assets/images/logo-osteo.svg"
+                [alt]="'Header.Logo.ImageAlt' | translate">
             <p class="project-logo__text" [innerHTML]="'Header.Logo.Title' | translate"></p>
         </a>
         <div *ngIf="headerConfig.stickySubtitle || headerConfig.showBreadcrumbs" class="activity-heading">
@@ -63,7 +64,7 @@
             [ngClass]="{'header-button': !headerConfig.showMainButtons}">
             <ddp-sign-in-out></ddp-sign-in-out>
         </div>
-        <a *ngIf="!isAuthenticated && headerConfig.showCmiButton" routerLink="count-me-in"
+        <a *ngIf="!isAuthenticated && headerConfig.showCmiButton" routerLink="count-me-in" (click)="sendAnalytics()"
             class="button button_small button_primary header-button" [ngClass]="{'button_medium': isPanelOpened}">
             <span translate>Common.Buttons.CountMeIn</span>
         </a>

--- a/ddp-workspace/projects/ddp-osteo/src/app/components/header/header.component.ts
+++ b/ddp-workspace/projects/ddp-osteo/src/app/components/header/header.component.ts
@@ -1,7 +1,7 @@
 import { Component, Inject, HostListener, OnInit } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 import { Router, NavigationEnd } from '@angular/router';
-import { WindowRef, SessionMementoService } from 'ddp-sdk';
+import { WindowRef, SessionMementoService, GoogleAnalyticsEventsService, GoogleAnalytics } from 'ddp-sdk';
 import { HeaderConfigurationService, CommunicationService } from 'toolkit';
 
 @Component({
@@ -19,6 +19,7 @@ export class HeaderComponent implements OnInit {
     private router: Router,
     private communicationService: CommunicationService,
     public headerConfig: HeaderConfigurationService,
+    private analytics: GoogleAnalyticsEventsService,
     @Inject(DOCUMENT) private document: any) { }
 
   public ngOnInit(): void {
@@ -39,6 +40,10 @@ export class HeaderComponent implements OnInit {
 
   public get isAuthenticated(): boolean {
     return this.session.isAuthenticatedSession();
+  }
+
+  public sendAnalytics(): void {
+    this.analytics.emitCustomEvent(GoogleAnalytics.ClickedCountMeIn, GoogleAnalytics.FromHeader);
   }
 
   @HostListener('window: scroll') public onWindowScroll(): void {

--- a/ddp-workspace/projects/ddp-osteo/src/app/components/welcome/welcome.component.html
+++ b/ddp-workspace/projects/ddp-osteo/src/app/components/welcome/welcome.component.html
@@ -9,7 +9,8 @@
                     HomePage.IntroductionSection.Text
                 </p>
                 <div class="intro-media-block__buttons">
-                    <a routerLink="count-me-in" class="button button_medium button_primary" translate>
+                    <a routerLink="count-me-in" (click)="sendCountMeInAnalytics()"
+                        class="button button_medium button_primary" translate>
                         Common.Buttons.CountMeIn
                     </a>
                     <a routerLink="more-details" class="button button_medium button_secondary" translate>
@@ -120,7 +121,8 @@
                     <span translate>HomePage.ParticipatingSection.ClosingText.Part2</span>
                 </p>
                 <div>
-                    <a routerLink="count-me-in" class="button button_medium button_primary" translate>
+                    <a routerLink="count-me-in" (click)="sendCountMeInAnalytics()"
+                        class="button button_medium button_primary" translate>
                         Common.Buttons.CountMeIn
                     </a>
                 </div>
@@ -183,15 +185,18 @@
                     HomePage.SocialMediaSection.Title
                 </h2>
                 <div class="social-media-logos">
-                    <a class="social-media-logo" [href]="twitterUrl" target="_blank">
+                    <a (click)="sendSocialMediaAnalytics('twitter')" class="social-media-logo" [href]="twitterUrl"
+                        target="_blank">
                         <img lazy-resource class="social-media-logos__img" src="assets/images/twitter.png"
                             [alt]="'Common.Alts.Twitter' | translate">
                     </a>
-                    <a class="social-media-logo" [href]="facebookUrl" target="_blank">
+                    <a (click)="sendSocialMediaAnalytics('facebook')" class="social-media-logo" [href]="facebookUrl"
+                        target="_blank">
                         <img lazy-resource class="social-media-logos__img" src="assets/images/facebook.png"
                             [alt]="'Common.Alts.Facebook' | translate">
                     </a>
-                    <a class="social-media-logo" [href]="instagramUrl" target="_blank">
+                    <a (click)="sendSocialMediaAnalytics('instagram')" class="social-media-logo" [href]="instagramUrl"
+                        target="_blank">
                         <img lazy-resource class="social-media-logos__img" src="assets/images/instagram.png"
                             [alt]="'Common.Alts.Instagram' | translate">
                     </a>
@@ -237,7 +242,8 @@
                 <p class="extra-margin" translate>
                     HomePage.ClosingSection.Text
                 </p>
-                <a routerLink="count-me-in" class="button button_big button_primary" translate>
+                <a routerLink="count-me-in" (click)="sendCountMeInAnalytics()" class="button button_big button_primary"
+                    translate>
                     Common.Buttons.CountMeIn
                 </a>
             </div>

--- a/ddp-workspace/projects/ddp-osteo/src/app/components/welcome/welcome.component.ts
+++ b/ddp-workspace/projects/ddp-osteo/src/app/components/welcome/welcome.component.ts
@@ -1,5 +1,5 @@
 import { Component, ViewChild, ElementRef, OnInit, Inject } from '@angular/core';
-import { WindowRef } from 'ddp-sdk';
+import { WindowRef, GoogleAnalyticsEventsService, GoogleAnalytics } from 'ddp-sdk';
 import { HeaderConfigurationService, CommunicationService, ToolkitConfigurationService } from 'toolkit';
 
 @Component({
@@ -19,6 +19,7 @@ export class WelcomeComponent implements OnInit {
     private headerConfig: HeaderConfigurationService,
     private window: WindowRef,
     private communicationService: CommunicationService,
+    private analytics: GoogleAnalyticsEventsService,
     @Inject('toolkit.toolkitConfig') private toolkitConfiguration: ToolkitConfigurationService) { }
 
   public ngOnInit(): void {
@@ -39,6 +40,14 @@ export class WelcomeComponent implements OnInit {
 
   public joinMailingList(): void {
     this.communicationService.openJoinDialog();
+  }
+
+  public sendSocialMediaAnalytics(event: string): void {
+    this.analytics.emitCustomEvent(GoogleAnalytics.Social, event);
+  }
+
+  public sendCountMeInAnalytics(): void {
+    this.analytics.emitCustomEvent(GoogleAnalytics.ClickedCountMeIn, GoogleAnalytics.FromMainPage);
   }
 
   private get getRealHeaderHeight(): number {

--- a/ddp-workspace/projects/ddp-prion/src/app/components/welcome/welcome.component.ts
+++ b/ddp-workspace/projects/ddp-prion/src/app/components/welcome/welcome.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { GoogleAnalyticsEventsService, BrowserContentService, WindowRef } from 'ddp-sdk';
+import { GoogleAnalyticsEventsService, BrowserContentService, WindowRef, GoogleAnalytics } from 'ddp-sdk';
 
 @Component({
     selector: 'welcome',
@@ -158,6 +158,6 @@ export class WelcomeComponent implements OnInit {
     }
 
     private doAnalytics(): void {
-        this.analytics.emitCustomEvent('clickedCountMeIn', 'fromMainPage');
+        this.analytics.emitCustomEvent(GoogleAnalytics.ClickedCountMeIn, GoogleAnalytics.FromMainPage);
     }
 }

--- a/ddp-workspace/projects/ddp-prion/src/styles.scss
+++ b/ddp-workspace/projects/ddp-prion/src/styles.scss
@@ -916,6 +916,7 @@ ul {
     transition: all 0.3s ease-out;
     box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.16), 0 2px 10px 0 rgba(0, 0, 0, 0.12) !important;
     background-color: mat-color($app-theme, 600);
+    min-width: unset !important;
 }
 
 .ButtonFilled:focus {
@@ -1350,22 +1351,22 @@ ul {
 }
 
 .ErrorMessage a {
-  text-decoration: underline !important;
+    text-decoration: underline !important;
 }
 
 
 .ddp-activity-validation {
-  .ErrorMessageList {
-    list-style-type: square;
-  }
+    .ErrorMessageList {
+        list-style-type: square;
+    }
 
-  .ErrorMessageItem {
-    font-size: 0.9rem;
-    color: mat-color($app-theme, 1200);
-    font-weight: 300;
-    margin: 10px 0 10px 0;
-    padding: 0 0 0 0;
-  }
+    .ErrorMessageItem {
+        font-size: 0.9rem;
+        color: mat-color($app-theme, 1200);
+        font-weight: 300;
+        margin: 10px 0 10px 0;
+        padding: 0 0 0 0;
+    }
 }
 
 .JoinDialogFiled {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity.component.ts
@@ -280,11 +280,13 @@ export class ActivityComponent extends BaseActivityComponent implements OnInit, 
     }
 
     public close(): void {
+        this.sendLastSectionAnalytics();
         this.sendActivityAnalytics(GoogleAnalytics.CloseSurvey);
         super.close();
     }
 
     public flush(): void {
+        this.sendLastSectionAnalytics();
         this.sendActivityAnalytics(GoogleAnalytics.SubmitSurvey);
         super.flush();
     }
@@ -310,7 +312,7 @@ export class ActivityComponent extends BaseActivityComponent implements OnInit, 
             this.scrollToTop();
             // enable any validation errors to be visible
             this.validationRequested = true;
-            this.sendActivityStepAnalytics();
+            this.sendSectionAnalytics();
             this.currentSection.validate();
             if (this.currentSection.valid) {
                 this.resetValidationState();
@@ -372,7 +374,7 @@ export class ActivityComponent extends BaseActivityComponent implements OnInit, 
         return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
     }
 
-    private sendActivityStepAnalytics(): void {
+    private sendSectionAnalytics(): void {
         // Some sections don't have name, just send section number
         const sectionName = this.model.sections[this.currentSectionIndex].name ?
             this.model.sections[this.currentSectionIndex].name :
@@ -380,10 +382,13 @@ export class ActivityComponent extends BaseActivityComponent implements OnInit, 
         this.analytics.emitCustomEvent(this.model.activityCode, sectionName);
     }
 
-    private sendActivityAnalytics(event: string): void {
+    private sendLastSectionAnalytics(): void {
         if (this.isStepped && this.isLastStep) {
-            this.sendActivityStepAnalytics();
+            this.sendSectionAnalytics();
         }
+    }
+
+    private sendActivityAnalytics(event: string): void {
         this.analytics.emitCustomEvent(event, this.model.activityCode);
     }
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/user/activities/userActivities.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/user/activities/userActivities.component.ts
@@ -5,7 +5,8 @@ import { ActivityInstanceState } from '../../../models/activity/activityInstance
 import { LoggingService } from '../../../services/logging.service';
 import { UserActivityServiceAgent } from '../../../services/serviceAgents/userActivityServiceAgent.service';
 import { ActivityInstanceStatusServiceAgent } from '../../../services/serviceAgents/activityInstanceStatusServiceAgent.service';
-import { GoogleAnalyticsEventsService } from './../../../services/googleAnalyticsEvents.service';
+import { GoogleAnalyticsEventsService } from '../../../services/googleAnalyticsEvents.service';
+import { GoogleAnalytics } from '../../../models/googleAnalytics';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { tap, mergeMap } from 'rxjs/operators';
 
@@ -235,6 +236,6 @@ export class UserActivitiesComponent implements OnInit, OnDestroy, OnChanges, Af
   }
 
   private doAnalytics(action: string): void {
-    this.analytics.emitCustomEvent('Dashboard', action);
+    this.analytics.emitCustomEvent(GoogleAnalytics.Dashboard, action);
   }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/googleAnalytics.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/googleAnalytics.ts
@@ -1,11 +1,15 @@
 export enum GoogleAnalytics {
     FromHeader = 'fromHeader',
+    FromMainPage = 'fromMainPage',
     FromFAQ = 'fromFAQ',
     ClickedCountMeIn = 'clickedCountMeIn',
     Social = 'social',
     MailingList = 'mailingList',
     Join = 'join',
-    CountMeIn = 'countMeIn',
-    Submit = 'submit',
+    CloseSurvey = 'closeSurvey',
     SubmitSurvey = 'submitSurvey',
+    Dashboard = 'dashboard',
+    Authentication = 'authentication',
+    Login = 'user authenticated',
+    Logout = 'user logged out'
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/authentication/auth0Adapter.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/authentication/auth0Adapter.service.ts
@@ -7,6 +7,7 @@ import { ConfigurationService } from '../configuration.service';
 import { GoogleAnalyticsEventsService } from '../googleAnalyticsEvents.service';
 import { RenewSessionNotifier } from '../renewSessionNotifier.service';
 import { Auth0Mode } from '../../models/auth0-mode';
+import { GoogleAnalytics } from '../../models/googleAnalytics';
 import { JwtHelperService } from '@auth0/angular-jwt';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -138,7 +139,7 @@ export class Auth0AdapterService implements OnDestroy {
                 this.windowRef.nativeWindow.location.hash = '';
                 this.setSession(authResult);
                 this.log.logEvent('auth0Adapter.handleAuthentication', authResult);
-                this.analytics.emitCustomEvent('authentication', 'user authenticated');
+                this.analytics.emitCustomEvent(GoogleAnalytics.Authentication, GoogleAnalytics.Login);
             } else if (err) {
                 this.log.logError('auth0Adapter.handleAuthentication', err);
                 let error = null;
@@ -186,7 +187,7 @@ export class Auth0AdapterService implements OnDestroy {
         // Remove tokens and expiry time from localStorage
         this.session.clear();
         this.log.logEvent('auth0Adapter.logout', null);
-        this.analytics.emitCustomEvent('authentication', 'user logged out');
+        this.analytics.emitCustomEvent(GoogleAnalytics.Authentication, GoogleAnalytics.Logout);
         this.webAuth.logout({
             returnTo: `${baseUrl}${baseUrl.endsWith('/') ? '' : '/'}${returnToUrl}`,
             clientID: this.configuration.auth0ClientId


### PR DESCRIPTION
- GA added for osteo static pages(used the same approach as angio, brain, etc.)
- Updated GA for the activity component(send activity even model doesn't' have a name, send section number if section doesn't have a name, send `closeSurvey` event if an activity is read-only)
- Used enum instead of strings for events
- Noticed that 'PREV' button on the activity a was too compressed, updated CSS