### PR TITLE
DDP-4304: Session Expiration Box_Using Continue button with limited time left can result in wonkiness

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/sessionMemento.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/sessionMemento.service.ts
@@ -8,7 +8,7 @@ import { filter, map, mergeMap, startWith } from 'rxjs/operators';
 export class SessionMementoService implements OnDestroy {
     private readonly SESSION_KEY: string = 'session_key';
     private readonly TOKEN_KEY = 'token';
-    private readonly MSECS_TO_NOTIFICATION = 300000;
+    private readonly MSECS_TO_NOTIFICATION = 360000;
 
     private sessionSubject: BehaviorSubject<Session | null> = new BehaviorSubject<Session | null>(this.session);
     private renewSubject: Subject<number> = new Subject<number>();

--- a/ddp-workspace/projects/toolkit/src/lib/components/dialogs/sessionWillExpire.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/dialogs/sessionWillExpire.component.ts
@@ -42,11 +42,12 @@ export class SessionWillExpireComponent implements OnInit, OnDestroy {
         private dialogRef: MatDialogRef<SessionWillExpireComponent>) { }
 
     public ngOnInit(): void {
+        const EXTRA_TIME = 60000;
         const expiresAt = this.session.expiresAt;
         const timer = interval(1000).subscribe(() => {
             const now = Date.now();
-            const remainingTime = expiresAt - now;
-            if (remainingTime) {
+            const remainingTime = expiresAt - now - EXTRA_TIME;
+            if (remainingTime > 0) {
                 const totalSeconds = Math.floor(remainingTime / 1000);
                 const seconds = (totalSeconds) % 60;
                 const minutes = ((totalSeconds) - seconds) / 60;

--- a/ddp-workspace/projects/toolkit/src/lib/components/dialogs/sessionWillExpire.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/dialogs/sessionWillExpire.component.ts
@@ -49,8 +49,8 @@ export class SessionWillExpireComponent implements OnInit, OnDestroy {
             const remainingTime = expiresAt - now - EXTRA_TIME;
             if (remainingTime > 0) {
                 const totalSeconds = Math.floor(remainingTime / 1000);
-                const seconds = (totalSeconds) % 60;
-                const minutes = ((totalSeconds) - seconds) / 60;
+                const seconds = totalSeconds % 60;
+                const minutes = (totalSeconds - seconds) / 60;
                 const formattedMinutes = this.formatTime(minutes);
                 const formattedSeconds = this.formatTime(seconds);
                 this.timeLeft = `${formattedMinutes}:${formattedSeconds}`;

--- a/ddp-workspace/projects/toolkit/src/lib/components/dialogs/sessionWillExpire.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/dialogs/sessionWillExpire.component.ts
@@ -56,6 +56,7 @@ export class SessionWillExpireComponent implements OnInit, OnDestroy {
                 this.timeLeft = `${formattedMinutes}:${formattedSeconds}`;
             } else {
                 this.timeLeft = '00:00';
+                this.auth0.handleExpiredSession();
             }
         });
         this.anchor.add(timer);


### PR DESCRIPTION
Bug description and steps of reproduction are here: https://broadinstitute.atlassian.net/browse/DDP-4304
Actually, I could reproduce the bug only once, but my impression is that this is occurring by last-second click on the Continue button and slow Internet connection. 
My idea - give extra time in case a user will interact with Sign Out and Continue buttons.
Presently, the session expires at the same time with the counter in the SessionWillExpire dialog, I think it may сause the bug when a user interacts with Sign Out and Continue buttons and makes a last-second click. So I've added "extra time", the dialog will show that a user has only 1 second left, but the session will be alive 1 minute 1 second that allows interacting with the website when a user clicks Continue and renews token even with slow internet.