### PR TITLE
Tightening up GAE service account permissions

### DIFF
--- a/admin/README.md
+++ b/admin/README.md
@@ -1,4 +1,0 @@
-###To create GCP role with permissions to deploy Angular app to GAE:
-`gcloud iam roles create --project GCP_PROJECT_NAME 'DDP_CI_CD' --file DDPCICDRole.yaml` 
-
-where `GCP_PROJECT_NAME` could be `broad-ddp-dev` , `broad-ddp-test` etc. 

--- a/admin/permissions/DDPCICDRole.yaml
+++ b/admin/permissions/DDPCICDRole.yaml
@@ -1,5 +1,4 @@
 description: 'Enable deployments of DDP apps and services on GAE'
-etag: BwWgSLxPGqs=
 includedPermissions:
 - appengine.applications.get
 - appengine.applications.update
@@ -17,10 +16,6 @@ includedPermissions:
 - cloudbuild.builds.get
 - cloudbuild.builds.list
 - cloudbuild.builds.update
-- storage.objects.create
-- storage.objects.delete
-- storage.objects.get
-- storage.objects.list
 - cloudsql.instances.connect
 - cloudsql.instances.get
 stage: GA

--- a/admin/permissions/README.md
+++ b/admin/permissions/README.md
@@ -1,0 +1,39 @@
+## Managing custom roles and permissions
+
+Here's a grab bag of utilities for creating and managing various permissions and roles.
+
+### Set the project and service account
+
+Let's keep our environments consistent by scripting permissions and ACL changes as much as possible.  In general we 
+use service accounts that are unique to each project, so at various points you'll want to change the GCP project
+and the service account when using these scripts.
+
+`GCP_PROJECT` can be either `broad-ddp-dev` , `broad-ddp-test`, `broad-ddp-staging`, or `broad-ddp-prod` 
+
+`SERVICE_ACCOUNT` is the "email" address for the service account
+
+```
+export GCP_PROJECT=...
+export SERVICE_ACCOUNT=...
+
+```
+
+### Create GCP role with permissions to deploy Angular app to GAE.
+```
+gcloud iam roles create --project ${GCP_PROJECT} 'DDP_CI_CD' --file DDPCICDRole.yaml
+```
+
+### Update GCP role with permissions to deploy Angular app to GAE.
+
+```
+gcloud iam roles update --project ${GCP_PROJECT} 'DDP_CI_CD' --file DDPCICDRole.yaml
+```
+
+### Grant the service account full access to various GAE buckets
+```
+gsutil iam ch serviceAccount:${SERVICE_ACCOUNT}:roles/storage.admin gs://staging.${GCP_PROJECT}.appspot.com
+gsutil iam ch serviceAccount:${SERVICE_ACCOUNT}:roles/storage.admin gs://us.artifacts.${GCP_PROJECT}.appspot.com
+gsutil iam ch serviceAccount:${SERVICE_ACCOUNT}:roles/storage.admin gs://${GCP_PROJECT}.appspot.com
+```
+
+

--- a/admin/permissions/README.md
+++ b/admin/permissions/README.md
@@ -10,7 +10,7 @@ and the service account when using these scripts.
 
 `GCP_PROJECT` can be either `broad-ddp-dev` , `broad-ddp-test`, `broad-ddp-staging`, or `broad-ddp-prod` 
 
-`SERVICE_ACCOUNT` is the "email" address for the service account
+`SERVICE_ACCOUNT` is the "email" address for the service account, which can be read via `vaultcli read secret/pepper/[dev | test | staging | prod]/v1/conf | jq .gcp.serviceKey.client_email`
 
 ```
 export GCP_PROJECT=...

--- a/admin/permissions/README.md
+++ b/admin/permissions/README.md
@@ -10,7 +10,7 @@ and the service account when using these scripts.
 
 `GCP_PROJECT` can be either `broad-ddp-dev` , `broad-ddp-test`, `broad-ddp-staging`, or `broad-ddp-prod` 
 
-`SERVICE_ACCOUNT` is the "email" address for the service account, which can be read via `vaultcli read secret/pepper/[dev | test | staging | prod]/v1/conf | jq .gcp.serviceKey.client_email`
+`SERVICE_ACCOUNT` is the "email" address for the service account, which can be read via `vaultcli read secret/pepper/[dev | test | staging | prod]/v1/conf -r .gcp.serviceKey.client_email`
 
 ```
 export GCP_PROJECT=...


### PR DESCRIPTION
* Moved to a permission specific subdir
* Removed project-wide bucket permissions and replaced with GAE-specific buckets
* Expanded the readme to include update/create options