### PR TITLE
Script to trigger build/deploy to dev and other refactors and improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,17 +3,11 @@ version: 2.1
 references:
   npm_cache_key: &npm_cache_key
                    v1-dependency-npm-{{ checksum "package-lock.json" }}
+  # Note: important that values of guids and keys have matching order!"
   study_keys: &study_keys
                 "osteo brain angio mbc"
   study_guids: &study_guids
                 "CMI-OSTEO cmi-brain ANGIO cmi-mbc"
-#  deploy_branch_filters: &deploy_branch_filters
-#    filters:
-#      branches:
-#        only:
-#          - test
-#          - staging
-#          - production
 
 # Container for all the builds
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -477,6 +477,7 @@ workflows:
             branches:
               only:
                 - develop
+                - trigger-build-deploy
 
   build-and-deploy-workflow:
     when: << pipeline.parameters.do-builds >>
@@ -525,7 +526,6 @@ workflows:
             branches:
               only:
                 - develop
-                - trigger-build-deploy
     jobs:
       - osteo-build-and-deploy:
           name: osteo-nightly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,6 +401,16 @@ jobs:
       - app-build-and-store:
           study_key: << pipeline.parameters.study_key >>
 
+  deploy-stored-build-job:
+    parameters:
+      study_key:
+        type: string
+    executor:
+      name: commit-executor
+    steps:
+      - deploy-stored-build:
+          study_key: <<parameter.study_key>>
+
   osteo-deploy-only:
     executor:
       name: commit-executor
@@ -506,7 +516,7 @@ workflows:
 
   deploy-all-apps-workflow:
     jobs:
-      - deploy-stored-build: &deploy_branch_filters
+      - deploy-stored-build-job: &deploy_branch_filters
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -525,6 +525,7 @@ workflows:
             branches:
               only:
                 - develop
+                - trigger-build-deploy
     jobs:
       - osteo-build-and-deploy:
           name: osteo-nightly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,9 @@ commands:
     parameters:
       study_key:
         type: string
+      study_guid:
+        type: string
+        default: NOTNEEDED
       skip_build:
         type: boolean
         default: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,7 +226,9 @@ commands:
       - checkout:
           path: ~/repo
       - restore_cache:
-          key: *npm_cache_key
+          keys:
+            - *npm_cache_key
+            - v1-dependency-npm-
       - run:
           name: npm install
           command: npm install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -402,11 +402,14 @@ jobs:
           study_key: << pipeline.parameters.study_key >>
 
   deploy-stored-build-job:
+    parameters:
+      study_key:
+        type: string
     executor:
       name: commit-executor
     steps:
       - deploy-stored-build:
-          study_key: << pipeline.parameters.study_key >>
+          study_key: << parameters.study_key >>
 
   osteo-deploy-only:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -414,7 +414,7 @@ workflows:
   build-and-deploy-all-apps-workflow:
     unless: << pipeline.parameters.do-builds >>
     jobs:
-      - conditionally-launch-build-and-deploy-all-job: &build-and-deploy-filters
+      - conditionally-launch-build-and-deploy-all-job:
           filters:
             branches:
               only:
@@ -424,7 +424,6 @@ workflows:
     when: << pipeline.parameters.do-builds >>
     jobs:
       - build-and-deploy-job:
-          <<: *build-and-deploy-filters
           study_key: << pipeline.parameters.study_key >>
 
   launch-all-app-builds-workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,13 @@ references:
                 "osteo brain angio mbc"
   study_guids: &study_guids
                 "CMI-OSTEO cmi-brain ANGIO cmi-mbc"
+#  deploy_branch_filters: &deploy_branch_filters
+#    filters:
+#      branches:
+#        only:
+#          - test
+#          - staging
+#          - production
 
 # Container for all the builds
 executors:
@@ -63,7 +70,12 @@ commands:
               test)
                 DEPLOY_ENV=test
               ;;
+              # @todo cleanup whendone
               trigger-build-deploy)
+                DEPLOY_ENV=dev
+              ;;
+              ;;
+              deleteme*)
                 DEPLOY_ENV=dev
               ;;
               staging)
@@ -85,8 +97,6 @@ commands:
     description: Deploy archived build to GAE
     parameters:
       study_key:
-        type: string
-      study_guid:
         type: string
     steps:
       - checkout:
@@ -116,16 +126,12 @@ commands:
             ls -l $OUTPUT_DIR
       - deploy-exploded-build:
           study_key: << parameters.study_key >>
-          study_guid: << parameters.study_guid >>
 
   deploy-exploded-build:
     description: Deploy files to GAE
     parameters:
       study_key:
         type: string
-      study_guid:
-        type: string
-        default: UNKNOWN
     steps:
       - set-deployment-environment
       - run:
@@ -399,61 +405,57 @@ jobs:
     executor:
       name: commit-executor
     steps:
-      - deploy-stored-build: &osteo-params
+      - deploy-stored-build:
           study_key: osteo
-          study_guid: CMI-OSTEO
 
   brain-deploy-only:
     executor:
       name: commit-executor
     steps:
-      - deploy-stored-build: &brain-params
+      - deploy-stored-build:
           study_key: brain
-          study_guid: cmi-brain
 
   angio-deploy-only:
     executor:
       name: commit-executor
     steps:
-      - deploy-stored-build: &angio-params
+      - deploy-stored-build:
           study_key: angio
-          study_guid: ANGIO
 
   mbc-deploy-only:
     executor:
       name: commit-executor
     steps:
-      - deploy-stored-build: &mbc-params
+      - deploy-stored-build:
           study_key: mbc
-          study_guid: cmi-mbc
 
   osteo-build-and-deploy:
     executor:
       name: commit-executor
     steps:
       - app-build-and-deploy:
-          <<: *osteo-params
+          study_key: osteo
 
   angio-build-and-deploy:
     executor:
       name: commit-executor
     steps:
       - app-build-and-deploy:
-          <<: *angio-params
+          study_key: angio
 
   brain-build-and-deploy:
     executor:
       name: commit-executor
     steps:
       - app-build-and-deploy:
-          <<: *brain-params
+          study_key: brain
 
   mbc-build-and-deploy:
     executor:
       name: commit-executor
     steps:
       - app-build-and-deploy:
-          <<: *mbc-params
+          study_key: mbc
 
 parameters:
   study_key:
@@ -504,19 +506,24 @@ workflows:
 
   deploy-all-apps-workflow:
     jobs:
-      - osteo-deploy-only: &deploy-filters
+      - deploy-stored-build: &deploy_branch_filters
           filters:
             branches:
               only:
                 - test
                 - staging
                 - production
-      - brain-deploy-only:
-          <<: *deploy-filters
-      - mbc-deploy-only:
-          <<: *deploy-filters
-      - angio-deploy-only:
-          <<: *deploy-filters
+          study_key: osteo
+
+      - deploy-stored-build:
+          <<: *deploy_branch_filters
+          study_key: brain
+      - deploy-stored-build:
+          <<: *deploy_branch_filters
+          study_key: mbc
+      - deploy-stored-build:
+          <<: *deploy_branch_filters
+          study_key: angio
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -402,14 +402,11 @@ jobs:
           study_key: << pipeline.parameters.study_key >>
 
   deploy-stored-build-job:
-    parameters:
-      study_key:
-        type: string
     executor:
       name: commit-executor
     steps:
       - deploy-stored-build:
-          study_key: <<parameter.study_key>>
+          study_key: << pipeline.parameters.study_key >>
 
   osteo-deploy-only:
     executor:
@@ -525,13 +522,13 @@ workflows:
                 - production
           study_key: osteo
 
-      - deploy-stored-build:
+      - deploy-stored-build-job:
           <<: *deploy_branch_filters
           study_key: brain
-      - deploy-stored-build:
+      - deploy-stored-build-job:
           <<: *deploy_branch_filters
           study_key: mbc
-      - deploy-stored-build:
+      - deploy-stored-build-job:
           <<: *deploy_branch_filters
           study_key: angio
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,13 +61,6 @@ commands:
               test)
                 DEPLOY_ENV=test
               ;;
-              # @todo cleanup whendone
-              trigger-build-deploy)
-                DEPLOY_ENV=dev
-              ;;
-              deleteme*)
-                DEPLOY_ENV=dev
-              ;;
               staging)
                 DEPLOY_ENV=staging
               ;;
@@ -462,7 +455,6 @@ workflows:
                 - test
                 - staging
                 - production
-                - /^deleteme.*/
           study_key: osteo
 
       - deploy-stored-build-job:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,6 @@ commands:
               trigger-build-deploy)
                 DEPLOY_ENV=dev
               ;;
-              ;;
               deleteme*)
                 DEPLOY_ENV=dev
               ;;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,10 @@ version: 2.1
 references:
   npm_cache_key: &npm_cache_key
                    v1-dependency-npm-{{ checksum "package-lock.json" }}
+  study_keys: &study_keys
+                "osteo brain angio mbc"
+  study_guids: &study_guids
+                "CMI-OSTEO cmi-brain ANGIO cmi-mbc"
 
 # Container for all the builds
 executors:
@@ -29,8 +33,6 @@ commands:
     parameters:
       study_key:
         type: string
-      study_guid:
-        type: string
       skip_build:
         type: boolean
         default: false
@@ -44,7 +46,6 @@ commands:
           - build-app
           - deploy-exploded-build:
               study_key: << parameters.study_key >>
-              study_guid: << parameters.study_guid >>
 
   set-deployment-environment:
     description: "Determine working environment"
@@ -58,6 +59,9 @@ commands:
               ;;
               test)
                 DEPLOY_ENV=test
+              ;;
+              trigger-build-deploy)
+                DEPLOY_ENV=dev
               ;;
               staging)
                 DEPLOY_ENV=staging
@@ -118,13 +122,14 @@ commands:
         type: string
       study_guid:
         type: string
+        default: UNKNOWN
     steps:
       - set-deployment-environment
       - run:
           name: <<parameters.study_key>> generate config files and copy pepperConfig.js
           command: |
             set -u
-            ./build-study.sh v1 $ENVIRONMENT . <<parameters.study_key>> <<parameters.study_guid>> --config
+            ./build-study.sh v1 $ENVIRONMENT . <<parameters.study_key>> "$STUDY_GUID" --config
             cd ddp-workspace
             CONFIG_DIR="${OUTPUT_DIR}/assets/config"
             mkdir -p $CONFIG_DIR
@@ -185,6 +190,12 @@ commands:
       study_key:
         type: string
         default: UNKNOWN
+      study_keys:
+        type: string
+        default: *study_keys
+      study_guids:
+        type: string
+        default: *study_guids
     steps:
       - run:
           name: Set environment variables to build <<parameters.study_key>>
@@ -192,6 +203,21 @@ commands:
             echo "export VAULT_TOKEN=`vault write -field=token auth/approle/login role_id=$VAULT_ROLE_ID secret_id=$VAULT_ROLE_SECRET_ID`" >> $BASH_ENV
             echo 'export PATH=$PATH:~/repo/build-utils' >> $BASH_ENV
             if [[ '<<parameters.study_key>>' != 'UNKNOWN' ]]; then
+              echo 'export STUDY_KEY=<<parameters.study_key>>' >> $BASH_ENV
+              STUDY_KEYS=(<<parameters.study_keys>>)
+              STUDY_GUIDS=(<<parameters.study_guids>>)
+              for i in ${!STUDY_KEYS[@]}; do
+                  currentKey=${STUDY_KEYS[$i]}
+                  if [[ $currentKey == '<<parameters.study_key>>' ]]; then
+                      STUDY_GUID="${STUDY_GUIDS[$i]}"
+                      echo "export STUDY_GUID=${STUDY_GUID}" >> $BASH_ENV
+                      break;
+                  fi
+              done;
+              if [[ -z $STUDY_GUID ]]; then
+                echo "Could not find study guid for <<parameters.study_key>>"
+                exit 1
+              fi
               echo 'export ANGULAR_PROJECT_NAME=ddp-<<parameters.study_key>>' >> $BASH_ENV
               echo 'export ANGULAR_PROJECT_DIR_PATH=projects/ddp-<<parameters.study_key>>' >> $BASH_ENV
               source $BASH_ENV
@@ -259,8 +285,6 @@ commands:
     parameters:
       study_keys:
         type: string
-      study_guids:
-        type: string
     steps:
       - run:
           name: Check << parameters.study_keys >> and launch build if modified
@@ -270,7 +294,6 @@ commands:
             set +x
             # CircleCi does not support arrays as params, so here is my workaround
             STUDY_KEYS=(<< parameters.study_keys >>)
-            STUDY_GUIDS=(<< parameters.study_guids >>)
 
             CHANGED_PROJECTS=$(findmodifiedprojects.sh <<pipeline.git.base_revision >> << pipeline.git.revision >>)
 
@@ -278,7 +301,6 @@ commands:
 
             for i in "${!STUDY_KEYS[@]}"; do
               STUDY_KEY=${STUDY_KEYS[$i]}
-              STUDY_GUID=${STUDY_GUIDS[$i]}
 
               NG_PROJECT_NAME="ddp-$STUDY_KEY"
               CHANGED_DEPENDENCIES=$(echo  $CHANGED_PROJECTS |
@@ -289,7 +311,6 @@ commands:
                                   \"branch\": \"<< pipeline.git.branch >>\",
                                   \"parameters\": {
                                       \"study_key\": \"$STUDY_KEY\",
-                                      \"study_guid\": \"$STUDY_GUID\",
                                       \"do-builds\": true
                                   }
                                 }" https://circleci.com/api/v2/project/gh/broadinstitute/ddp-angular/pipeline
@@ -339,7 +360,6 @@ jobs:
     steps:
       - app-build-and-deploy:
           study_key: << pipeline.parameters.study_key >>
-          study_guid: << pipeline.parameters.study_guid >>
           skip_build: false
 
   conditionally-launch-build-and-deploy-all-job:
@@ -349,9 +369,7 @@ jobs:
       - checkout
       - setup-shared-env
       - conditionally-launch-build-and-deploy:
-          study_keys: "osteo brain angio mbc"
-          study_guids: "CMI-OSTEO cmi-brain ANGIO cmi-mbc"
-
+          study_keys: *study_keys
 
   conditionally-launch-build-and-store-all-job:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -522,6 +522,7 @@ workflows:
                 - test
                 - staging
                 - production
+                - /^deleteme.*/
           study_key: osteo
 
       - deploy-stored-build-job:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -419,7 +419,6 @@ workflows:
             branches:
               only:
                 - develop
-                - trigger-build-deploy
 
   build-and-deploy-workflow:
     when: << pipeline.parameters.do-builds >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,8 +68,8 @@ commands:
                 DEPLOY_ENV=prod
               ;;
               *)
-                echo "Cannot map << pipeline.git.branch >> to a deployment environment"
-                exit 17
+                DEPLOY_ENV=dev
+                echo "We are going to map << pipeline.git.branch >> to dev environment"
               ;;
             esac
             echo "Setting deployment ENVIRONMENT to $DEPLOY_ENV"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -413,62 +413,6 @@ jobs:
       - deploy-stored-build:
           study_key: << parameters.study_key >>
 
-  osteo-deploy-only:
-    executor:
-      name: commit-executor
-    steps:
-      - deploy-stored-build:
-          study_key: osteo
-
-  brain-deploy-only:
-    executor:
-      name: commit-executor
-    steps:
-      - deploy-stored-build:
-          study_key: brain
-
-  angio-deploy-only:
-    executor:
-      name: commit-executor
-    steps:
-      - deploy-stored-build:
-          study_key: angio
-
-  mbc-deploy-only:
-    executor:
-      name: commit-executor
-    steps:
-      - deploy-stored-build:
-          study_key: mbc
-
-  osteo-build-and-deploy:
-    executor:
-      name: commit-executor
-    steps:
-      - app-build-and-deploy:
-          study_key: osteo
-
-  angio-build-and-deploy:
-    executor:
-      name: commit-executor
-    steps:
-      - app-build-and-deploy:
-          study_key: angio
-
-  brain-build-and-deploy:
-    executor:
-      name: commit-executor
-    steps:
-      - app-build-and-deploy:
-          study_key: brain
-
-  mbc-build-and-deploy:
-    executor:
-      name: commit-executor
-    steps:
-      - app-build-and-deploy:
-          study_key: mbc
-
 parameters:
   study_key:
     type: string
@@ -549,11 +493,15 @@ workflows:
               only:
                 - develop
     jobs:
-      - osteo-build-and-deploy:
+      - build-and-deploy-job:
           name: osteo-nightly
-      - angio-build-and-deploy:
+          study_key: osteo
+      - build-and-deploy-job:
           name: angio-nightly
-      - brain-build-and-deploy:
+          study_key: angio
+      - build-and-deploy-job:
           name: brain-nightly
-      - mbc-build-and-deploy:
+          study_key: brain
+      - build-and-deploy-job:
           name: mbc-nightly
+          study_key: mbc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,11 +363,14 @@ commands:
 
 jobs:
   build-and-deploy-job:
+    parameters:
+      study_key:
+        type: string
     executor:
       name: commit-executor
     steps:
       - app-build-and-deploy:
-          study_key: << pipeline.parameters.study_key >>
+          study_key: << parameters.study_key >>
           skip_build: false
 
   conditionally-launch-build-and-deploy-all-job:
@@ -493,7 +496,9 @@ workflows:
   build-and-deploy-workflow:
     when: << pipeline.parameters.do-builds >>
     jobs:
-      - build-and-deploy-job: *build-and-deploy-filters
+      - build-and-deploy-job:
+          <<: *build-and-deploy-filters
+          study_key: << pipeline.parameters.study_key >>
 
   launch-all-app-builds-workflow:
     # using do-builds param to select which of the two workflows using the build-on-tag-filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ references:
 executors:
   commit-executor:
     docker:
-      - image: broadinstitute/study-website-build:03-26-2020A
+      - image: broadinstitute/study-website-build:04-09-2020A
     working_directory: ~/repo
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,14 +56,6 @@ commands:
               develop)
                 DEPLOY_ENV=dev
               ;;
-              # @todo: take this out
-              circle-ci-updates-1)
-                DEPLOY_ENV=dev
-              ;;
-              # @todo take this out
-              play*)
-                DEPLOY_ENV=dev
-              ;;
               test)
                 DEPLOY_ENV=test
               ;;
@@ -464,9 +456,6 @@ workflows:
             branches:
               only:
                 - develop
-                # @TODO remove these when done.
-                - circle-ci-updates-1
-                - /play.*/
 
   build-and-deploy-workflow:
     when: << pipeline.parameters.do-builds >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ commands:
           name: Update GAE dispatch config
           command: |
             set -u
-            gcloud app deploy --project "broad-ddp-${ENVIRONMENT}" "${ANGULAR_PROJECT_DIR_PATH}/output-config/dispatch.yaml"
+            gcloud app deploy --quiet --project "broad-ddp-${ENVIRONMENT}" "${ANGULAR_PROJECT_DIR_PATH}/output-config/dispatch.yaml"
           working_directory: ~/repo/ddp-workspace
       - run:
           name: Update deployments sheet

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,6 @@ commands:
     parameters:
       study_key:
         type: string
-      study_guid:
-        type: string
-        default: NOTNEEDED
       skip_build:
         type: boolean
         default: false

--- a/build-utils/Dockerfile-BuildDeploy
+++ b/build-utils/Dockerfile-BuildDeploy
@@ -107,11 +107,14 @@ COPY --from=dsdetoolbox /etc/consul-template/config/config.json /etc/consul-temp
 COPY --from=dsdetoolbox /usr/local/bin/vault /usr/local/bin/vault
 ENV VAULT_ADDR https://clotho.broadinstitute.org:8200
 
-RUN apk update
-RUN apk upgrade
-RUN apk add curl bash jq
-# Install ruby and ruby-bundler
-RUN apk add ruby ruby-bundler ruby-json
+RUN apk add --no-cache --virtual .build-deps \
+    curl \
+    bash \
+    jq \
+    ruby \
+    ruby-bundler \
+    ruby-json \
+&& apk del. build-deps
 
 # Setting up Angular CLI globally
 ENV ANGULAR_CLI @angular/cli@8.3.23

--- a/build-utils/Dockerfile-BuildDeploy
+++ b/build-utils/Dockerfile-BuildDeploy
@@ -107,14 +107,14 @@ COPY --from=dsdetoolbox /etc/consul-template/config/config.json /etc/consul-temp
 COPY --from=dsdetoolbox /usr/local/bin/vault /usr/local/bin/vault
 ENV VAULT_ADDR https://clotho.broadinstitute.org:8200
 
-RUN apk add --no-cache --virtual .build-deps \
+RUN apk  --no-cache add \
     curl \
     bash \
     jq \
     ruby \
     ruby-bundler \
-    ruby-json \
-&& apk del .build-deps
+    ruby-json  \
+    && rm -rf /var/cache/apk/*
 
 # Setting up Angular CLI globally
 ENV ANGULAR_CLI @angular/cli@8.3.23

--- a/build-utils/Dockerfile-BuildDeploy
+++ b/build-utils/Dockerfile-BuildDeploy
@@ -114,7 +114,7 @@ RUN apk add --no-cache --virtual .build-deps \
     ruby \
     ruby-bundler \
     ruby-json \
-&& apk del. build-deps
+&& apk del .build-deps
 
 # Setting up Angular CLI globally
 ENV ANGULAR_CLI @angular/cli@8.3.23

--- a/build-utils/Dockerfile-BuildDeploy
+++ b/build-utils/Dockerfile-BuildDeploy
@@ -111,7 +111,7 @@ RUN apk update
 RUN apk upgrade
 RUN apk add curl bash jq
 # Install ruby and ruby-bundler
-RUN apk add ruby ruby-bundler
+RUN apk add ruby ruby-bundler ruby-json
 
 # Setting up Angular CLI globally
 ENV ANGULAR_CLI @angular/cli@8.3.23

--- a/build-utils/Dockerfile-BuildDeploy
+++ b/build-utils/Dockerfile-BuildDeploy
@@ -1,50 +1,105 @@
 # To make our config generation "compatible" with official dsdetoolbox, extract what is needed from it (this is not the base image)
 FROM broadinstitute/dsde-toolbox:consul-template-20-0.0.1 AS dsdetoolbox
 
-FROM google/cloud-sdk:279.0.0
-
-# Setting up Node
-# Adapted from official Node Dockerfile https://github.com/nodejs/docker-node/blob/master/10/buster/Dockerfile
-ENV NODE_VERSION 10.18.1
+FROM google/cloud-sdk:alpine
 
 USER root
 
-RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" \
-  && case "${dpkgArch##*-}" in \
-    amd64) ARCH='x64';; \
-    ppc64el) ARCH='ppc64le';; \
-    s390x) ARCH='s390x';; \
-    arm64) ARCH='arm64';; \
-    armhf) ARCH='armv7l';; \
-    i386) ARCH='x86';; \
-    *) echo "unsupported architecture"; exit 1 ;; \
-  esac \
-  # gpg keys listed at https://github.com/nodejs/node#release-keys
-  && set -ex \
+# Setting up Node
+# Adapted from official Node Dockerfile https://github.com/nodejs/docker-node/blob/master/10/alpine3.11/Dockerfile
+ENV NODE_VERSION 10.20.0
+
+RUN addgroup -g 1000 node \
+    && adduser -u 1000 -G node -s /bin/sh -D node \
+    && apk add --no-cache \
+        libstdc++ \
+    && apk add --no-cache --virtual .build-deps \
+        curl \
+    && ARCH= && alpineArch="$(apk --print-arch)" \
+      && case "${alpineArch##*-}" in \
+        x86_64) \
+          ARCH='x64' \
+          CHECKSUM="741532f10edeb3ad05e2b179ad42b708fbfd5e1642a163580da7b73dfc7a18a4" \
+          ;; \
+        *) ;; \
+      esac \
+  && if [ -n "${CHECKSUM}" ]; then \
+    set -eu; \
+    curl -fsSLO --compressed "https://unofficial-builds.nodejs.org/download/release/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz"; \
+    echo "$CHECKSUM  node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" | sha256sum -c - \
+      && tar -xJf "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+      && ln -s /usr/local/bin/node /usr/local/bin/nodejs; \
+  else \
+    echo "Building from source" \
+    # backup build
+    && apk add --no-cache --virtual .build-deps-full \
+        binutils-gold \
+        g++ \
+        gcc \
+        gnupg \
+        libgcc \
+        linux-headers \
+        make \
+        python \
+    # gpg keys listed at https://github.com/nodejs/node#release-keys
+    && for key in \
+      94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+      FD3A5288F042B6850C66B31F09FE44734EB7990E \
+      71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+      DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+      C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+      B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+      77984A986EBC2AA786BC0F66B01FBB92821C587A \
+      8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
+      4ED778F539E3634C779C87C6D7062848A1AB005C \
+      A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
+      B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+    ; do \
+      gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+      gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+      gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+    done \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz" \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+    && grep " node-v$NODE_VERSION.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xf "node-v$NODE_VERSION.tar.xz" \
+    && cd "node-v$NODE_VERSION" \
+    && ./configure \
+    && make -j$(getconf _NPROCESSORS_ONLN) V= \
+    && make install \
+    && apk del .build-deps-full \
+    && cd .. \
+    && rm -Rf "node-v$NODE_VERSION" \
+    && rm "node-v$NODE_VERSION.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt; \
+  fi \
+  && rm -f "node-v$NODE_VERSION-linux-$ARCH-musl.tar.xz" \
+  && apk del .build-deps \
+  # smoke tests
+  && node --version \
+  && npm --version
+
+ENV YARN_VERSION 1.22.4
+
+RUN apk add --no-cache --virtual .build-deps-yarn curl gnupg tar \
   && for key in \
-    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
-    FD3A5288F042B6850C66B31F09FE44734EB7990E \
-    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
-    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
-    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
-    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
-    77984A986EBC2AA786BC0F66B01FBB92821C587A \
-    8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
-    4ED778F539E3634C779C87C6D7062848A1AB005C \
-    A48C2BEE680E841632CD4E44F07496B3EB3C1762 \
-    B9E2F5981AA6E0CD28160D9FF13993A75599653C \
+    6A010C5166006599AA17F08146C2130DFD2497F5 \
   ; do \
     gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
     gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
     gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done \
-  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
-  && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
-  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
-  && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
-  && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
-  && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-  && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
+  && curl -fsSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
+  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && mkdir -p /opt \
+  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/ \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarn /usr/local/bin/yarn \
+  && ln -s /opt/yarn-v$YARN_VERSION/bin/yarnpkg /usr/local/bin/yarnpkg \
+  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
+  && apk del .build-deps-yarn \
+  # smoke test
+  && yarn --version
 
 # Copying necessary artifacts to enable configure.rb that lives in our own repo.
 COPY --from=dsdetoolbox /usr/local/bin/consul-template /usr/local/bin/consul-template
@@ -52,12 +107,11 @@ COPY --from=dsdetoolbox /etc/consul-template/config/config.json /etc/consul-temp
 COPY --from=dsdetoolbox /usr/local/bin/vault /usr/local/bin/vault
 ENV VAULT_ADDR https://clotho.broadinstitute.org:8200
 
-
-RUN apt-get update && apt-get install -y \
-    ruby:amd64=1:2.5.1 \
-    jq \
-   && rm -rf /var/lib/apt/lists/*
-
+RUN apk update
+RUN apk upgrade
+RUN apk add curl bash jq
+# Install ruby and ruby-bundler
+RUN apk add ruby ruby-bundler
 
 # Setting up Angular CLI globally
 ENV ANGULAR_CLI @angular/cli@8.3.23

--- a/build-utils/findmodifiedprojects.sh
+++ b/build-utils/findmodifiedprojects.sh
@@ -11,10 +11,10 @@ do
 done
 NG_PROJECT_PATH_PREFIX='ddp-workspace\/projects\/'
 SHARED='_SHARED_'
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-  SED_CMD='sed -E'
-elif [[ "$OSTYPE" == "darwin"* ]]; then
+if [[ "$OSTYPE" == "darwin"* ]]; then
   SED_CMD='gsed -E'
+else
+  SED_CMD='sed -E'
 fi
 git diff --name-only $1 $2 |
 ${EXCLUDE_CMD} | # Exclude from changes files that we want to ignore

--- a/build-utils/startbuilddeploy.sh
+++ b/build-utils/startbuilddeploy.sh
@@ -2,7 +2,6 @@
 CI_PROJECT_SLUG='gh/broadinstitute/ddp-angular'
 DEFAULT_BRANCH=develop
 STUDY_KEY=$1
-STUDY_GUID=$2
 
 CI_TOKEN=$(xargs <  ~/.circleci-token)
 if [[ -z $CI_TOKEN ]]; then
@@ -11,20 +10,19 @@ if [[ -z $CI_TOKEN ]]; then
   exit 1
 fi
 
-if [[ -z $STUDY_KEY ]] || [[ -z $STUDY_GUID ]]; then
-  echo "usage: $(basename "$0") STUDY_KEY STUDY_GUID [BRANCH]"
+if [[ -z $STUDY_KEY ]] ; then
+  echo "usage: $(basename "$0") STUDY_KEY [BRANCH]"
   echo "Will build from branch $DEFAULT_BRANCH if not provided"
   exit 1
 fi
 
-BRANCH=${3-$DEFAULT_BRANCH}
+BRANCH=${2-$DEFAULT_BRANCH}
 
 echo "Will try to initiate build from branch: $BRANCH"
 curl -u "${CI_TOKEN}:" -X POST --header "Content-Type: application/json" -d "{
                                   \"branch\": \"$BRANCH\",
                                   \"parameters\": {
                                       \"study_key\": \"$STUDY_KEY\",
-                                      \"study_guid\": \"$STUDY_GUID\",
                                       \"do-builds\": true
                                   }
 }" "https://circleci.com/api/v2/project/${CI_PROJECT_SLUG}/pipeline"

--- a/build-utils/startbuilddeploy.sh
+++ b/build-utils/startbuilddeploy.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+CI_PROJECT_SLUG='gh/broadinstitute/ddp-angular'
+DEFAULT_BRANCH=develop
+STUDY_KEY=$1
+STUDY_GUID=$2
+
+CI_TOKEN=$(xargs <  ~/.circleci-token)
+if [[ -z $CI_TOKEN ]]; then
+  echo "Need to store personal circleci token value at \$HOME/.circleci-token"
+  echo "You can generate it from this URL: https://circleci.com/account/api"
+  exit 1
+fi
+
+if [[ -z $STUDY_KEY ]] || [[ -z $STUDY_GUID ]]; then
+  echo "usage: $(basename "$0") STUDY_KEY STUDY_GUID [BRANCH]"
+  echo "Will build from branch $DEFAULT_BRANCH if not provided"
+  exit 1
+fi
+
+BRANCH=${3-$DEFAULT_BRANCH}
+
+echo "Will try to initiate build from branch: $BRANCH"
+curl -u "${CI_TOKEN}:" -X POST --header "Content-Type: application/json" -d "{
+                                  \"branch\": \"$BRANCH\",
+                                  \"parameters\": {
+                                      \"study_key\": \"$STUDY_KEY\",
+                                      \"study_guid\": \"$STUDY_GUID\",
+                                      \"do-builds\": true
+                                  }
+}" "https://circleci.com/api/v2/project/${CI_PROJECT_SLUG}/pipeline"


### PR DESCRIPTION
Added script for situations where we need to deploy to dev from own branch and want to avoid hacking config.yml script further.
**Updates on April 9, 2020**
- Some refactoring of the CircleCi configuration. Objective was to remove need to keep passing around study guids (we should know what they are) and to remove repetitive volume.
- Script for remote build deploys no longer needs the study guid to be specified.
- Updated Docker file to be based on Alpine . It is __**MUCH**__ faster! Loading the image from CircleCi went down from 50 to 80 seconds down to 10 to 15 sec.
Image size went from 760MB to 160MB. Whoa!

Comments added throughout.
