### PR TITLE
DDP-3894: If a user's session is timed out, the timed out user could try to load a new user's activity

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/interceptors/auth-interceptor.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/interceptors/auth-interceptor.service.ts
@@ -12,7 +12,7 @@ export class AuthInterceptor implements HttpInterceptor {
 
     public intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
         if (this.session.isSessionExpired()) {
-            this.auth0.logout('session-expired');
+            this.auth0.handleExpiredSession();
         } else {
             return next.handle(req);
         }


### PR DESCRIPTION
I've tried to reproduce the issue but it looks like we get rid of it when added AuthInterceptor and started to check session state on page visibility change event. I've just a bit updated the interceptor because we should handle the expired session gentler.