### PR TITLE
DDP-4479 and a couple of other fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ executors:
     docker:
       - image: broadinstitute/study-website-build:04-09-2020A
     working_directory: ~/repo/ddp-workspace
+    resource_class: medium+
 
 commands:
   app-build-and-store:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,11 @@ version: 2.1
 
 references:
   npm_cache_key: &npm_cache_key
-                   v1-dependency-npm-{{ checksum "package-lock.json" }}
+                   v1-dependency-npm1-{{ checksum "package-lock.json" }}
+  npm_cache_restore_key: &npm_cache_restore_key
+    keys:
+      - *npm_cache_key
+      - v1-dependency-npm1
   # Note: important that values of guids and keys have matching order!"
   study_keys: &study_keys
                 "osteo brain angio mbc"
@@ -233,14 +237,10 @@ commands:
     steps:
       - checkout:
           path: ~/repo
-      - restore_cache:
-          keys:
-            - *npm_cache_key
-            - v1-dependency-npm-
+      - restore_cache: *npm_cache_restore_key
       - run:
           name: npm install
           command: npm install
-          working_directory: ~/repo/ddp-workspace
       - save_cache:
           key: *npm_cache_key
           paths:
@@ -357,6 +357,7 @@ commands:
 
 jobs:
   build-and-deploy-job:
+    working_directory: ~/repo/ddp-workspace
     parameters:
       study_key:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,6 +253,7 @@ commands:
           name: ng build
           command: |
             set -u
+            export NODE_OPTIONS='--max_old_space_size=4096'
             ng build $ANGULAR_PROJECT_NAME --prod --aot --base-href=/ --output-path=$OUTPUT_DIR --verbose=true --progress=true
           working_directory: ~/repo/ddp-workspace
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ executors:
   commit-executor:
     docker:
       - image: broadinstitute/study-website-build:04-09-2020A
-    working_directory: ~/repo
+    working_directory: ~/repo/ddp-workspace
 
 commands:
   app-build-and-store:
@@ -134,25 +134,23 @@ commands:
             echo "$CONFIG_FILE_SRC_PATH has been copied to $CONFIG_DIR"
           environment: #Setting this ENV variable prevents launching a new Docker within build-study-sh script
             USE_DOCKER: false
+          working_directory: ~/repo
       - run:
           name: Setup gcloud context
           command: |
             set -u
             readvault.sh secret/pepper/${ENVIRONMENT}/v1/conf .data.gcp.serviceKey | gcloud auth activate-service-account --key-file=-
             gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
-          working_directory: ~/repo
       - run:
           name: Deploy to GAE
           command: |
             set -u
             gcloud app deploy --version="${SHORT_GIT_SHA}" --stop-previous-version --project "broad-ddp-${ENVIRONMENT}" "${ANGULAR_PROJECT_DIR_PATH}/app.yaml"
-          working_directory: ~/repo/ddp-workspace
       - run:
           name: Update GAE dispatch config
           command: |
             set -u
             gcloud app deploy --quiet --project "broad-ddp-${ENVIRONMENT}" "${ANGULAR_PROJECT_DIR_PATH}/output-config/dispatch.yaml"
-          working_directory: ~/repo/ddp-workspace
       - run:
           name: Update deployments sheet
           command: |
@@ -186,7 +184,6 @@ commands:
               gcloud app versions delete --quiet --service "$SERVICE" "$VERSION_TO_DELETE" --project "broad-ddp-${ENVIRONMENT}"
             done;
             exit 0;
-          working_directory: ~/repo/ddp-workspace
 
   setup-shared-env:
     description: "Setup shared ENV vars used by multiple scripts"
@@ -253,9 +250,7 @@ commands:
           name: ng build
           command: |
             set -u
-            export NODE_OPTIONS='--max_old_space_size=4096'
             ng build $ANGULAR_PROJECT_NAME --prod --aot --base-href=/ --output-path=$OUTPUT_DIR --verbose=true --progress=true
-          working_directory: ~/repo/ddp-workspace
 
   store-app-build:
     description: "Copy build to cloud storage"
@@ -274,14 +269,12 @@ commands:
             tar -czvf ${TAR_PATH} .
             echo "Tar file created at ${TAR_PATH}"
             ls -l $TAR_PATH
-          working_directory: ~/repo/ddp-workspace
       - run:
           name: Store build archive
           command: |
             set -u
             readvault.sh secret/pepper/prod/v1/conf .data.gcp.serviceKey | gcloud auth activate-service-account --key-file=-
             gsutil cp  ${TAR_PATH} "gs://${BUILDS_BUCKET}/${ANGULAR_PROJECT_NAME}/${TAR_NAME}"
-          working_directory: ~/repo
 
   conditionally-launch-build-and-deploy:
     description: Launch build and deploy if project has changed
@@ -358,7 +351,6 @@ commands:
 
 jobs:
   build-and-deploy-job:
-    working_directory: ~/repo/ddp-workspace
     parameters:
       study_key:
         type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,11 +171,19 @@ commands:
             AWK_COMMMAND="NR > 1 && !/${SHORT_GIT_SHA}/ {print \$2}"
             VERSIONS_TO_DELETE=$(gcloud app versions list --service "$SERVICE" --project "broad-ddp-${ENVIRONMENT}" | awk "${AWK_COMMMAND}")
 
+            # Sometime deleting versions fails. If there are less than 3 versions then we are not going to worry about it
+            # and set flag so this job step does not fail when exit error value is generated
+            if [[ ! -z $VERSIONS_TO_DELETE ]] && [[ "${#VERSIONS_TO_DELETE[@]}" -lt 3 ]]; then
+              set +e
+            fi
+
             for VERSION_TO_DELETE in $VERSIONS_TO_DELETE; do
               echo "Deleting version $VERSION_TO_DELETE of service $SERVICE"
               gcloud app versions delete --quiet --service "$SERVICE" "$VERSION_TO_DELETE" --project "broad-ddp-${ENVIRONMENT}"
             done;
+            exit 0;
           working_directory: ~/repo/ddp-workspace
+
   setup-shared-env:
     description: "Setup shared ENV vars used by multiple scripts"
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,7 +161,6 @@ commands:
       - run:
           name: Delete previous versions of service
           command: |
-            set -u
             set +x
             # extract the service name from the GAE yaml file
             CONFIG_FILE="${ANGULAR_PROJECT_DIR_PATH}/app.yaml"

--- a/build-utils/reportdeploy.sh
+++ b/build-utils/reportdeploy.sh
@@ -37,6 +37,8 @@ COMPONENT=$2
 ENVIRONMENT=$3
 CIRCLE_BUILD_NUM=$4
 CIRCLE_BUILD_URL=$5
+# Stick both into one column with a formula
+CIRCLE_BUILD_HYPERLINK="=HYPERLINK(\"$CIRCLE_BUILD_URL\",\"$CIRCLE_BUILD_NUM\")"
 
 TZ=America/New_York
 DATE=`TZ=$TZ date +%F`
@@ -51,4 +53,4 @@ OTHER_BRANCHES=$(other_branches_same_commit | xargs)
 AUTHOR=$(commit_author)
 # Passing to sheetappend the GCP credentials we are expecting to be piped into this script
 cat /dev/stdin |
-   sheetappend $RELEASE_SHEET_ID $DATE $TIME "$COMPONENT" $ENVIRONMENT $BRANCH "$TAG" $SHORT_GIT_SHA "$AUTHOR" $CIRCLE_BUILD_NUM "$CIRCLE_BUILD_URL" "$OTHER_BRANCHES"
+   sheetappend $RELEASE_SHEET_ID $DATE $TIME "$COMPONENT" $ENVIRONMENT $BRANCH "$TAG" $SHORT_GIT_SHA "$AUTHOR" "$CIRCLE_BUILD_HYPERLINK" "" "$OTHER_BRANCHES"


### PR DESCRIPTION
We had a couple of builds "fail" because previous versions of GAE Angular apps could not be removed.
Copied approach from pepper-apis that allows for deletion to fail a few times (out of our control).
Also noticed that our npm caching was not working. I have updated it and confirms that it now works.
Also took opportunity to update the information we write to deployment spreadsheet. See comments for details.