### PR TITLE
Add API spec to dispatch rules

### DIFF
--- a/config/deployment/dev/dispatch.yaml
+++ b/config/deployment/dev/dispatch.yaml
@@ -1,5 +1,9 @@
 
 dispatch:
+  - url: "pepper-dev.datadonationplatform.org/docs*"
+    service: pepper-api-spec
+  - url: "pepper-dev.datadonationplatform.org/spec/*"
+    service: pepper-api-spec
   - url: "angio.dev.datadonationplatform.org/*"
     service: angio
   - url: "mbc.dev.datadonationplatform.org/*"


### PR DESCRIPTION
Adds dispatch rule for API docs:
https://pepper-dev.datadonationplatform.org/docs
But still keeps rule pointing to pepper back end:
https://pepper-dev.datadonationplatform.org/v1/healthcheck