### PR TITLE
Fix circleci repo paths, etc.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,9 @@ commands:
               staging)
                 DEPLOY_ENV=staging
               ;;
+              deletemedummy:
+                DEPLOY_ENV=dev
+              ;;
               production)
                 DEPLOY_ENV=prod
               ;;
@@ -407,7 +410,8 @@ jobs:
     executor:
       name: build-executor
     steps:
-      - checkout
+      - checkout:
+          path: *repo_path
       - conditionally-launch-build-and-store:
           study_key: osteo
       - conditionally-launch-build-and-store:
@@ -494,6 +498,7 @@ workflows:
                 - test
                 - staging
                 - production
+                - deletemedummy
           study_key: osteo
 
       - deploy-stored-build-job:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,6 +254,7 @@ commands:
       - run:
           name: Install dependencies
           command: |
+            echo "the PWD is $PWD"
             if [[ ! -d node_modules ]]; then
               npm ci
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,9 @@ references:
 
 # Container for all the builds
 executors:
-  commit-executor:
+  build-executor:
     docker:
-      - image: broadinstitute/study-website-build:04-09-2020A
+      - image: broadinstitute/study-website-build:05-06-2020A
     working_directory: *ng_workspace_path
     resource_class: medium+
 
@@ -379,7 +379,7 @@ jobs:
       study_key:
         type: string
     executor:
-      name: commit-executor
+      name: build-executor
     steps:
       - app-build-and-deploy:
           study_key: << parameters.study_key >>
@@ -388,7 +388,7 @@ jobs:
   conditionally-launch-build-and-deploy-all-job:
     working_directory: *ng_workspace_path
     executor:
-      name: commit-executor
+      name: build-executor
     steps:
       - checkout
       - setup-shared-env
@@ -398,7 +398,7 @@ jobs:
   conditionally-launch-build-and-store-all-job:
     working_directory: *ng_workspace_path
     executor:
-      name: commit-executor
+      name: build-executor
     steps:
       - checkout
       - conditionally-launch-build-and-store:
@@ -413,7 +413,7 @@ jobs:
   app-build-and-store-job:
     working_directory: *ng_workspace_path
     executor:
-      name: commit-executor
+      name: build-executor
     steps:
       - app-build-and-store:
           study_key: << pipeline.parameters.study_key >>
@@ -424,7 +424,7 @@ jobs:
       study_key:
         type: string
     executor:
-      name: commit-executor
+      name: build-executor
     steps:
       - deploy-stored-build:
           study_key: << parameters.study_key >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ commands:
               staging)
                 DEPLOY_ENV=staging
               ;;
-              deletemedummy:
+              deletemedummy)
                 DEPLOY_ENV=dev
               ;;
               production)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,6 +312,8 @@ commands:
             set -u
             set +e
             set +x
+            echo "The path is $PATH"
+            ls -l /home/circleci/repo/build-utils
             # CircleCi does not support arrays as params, so here is my workaround
             STUDY_KEYS=(<< parameters.study_keys >>)
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ references:
   ng_workspace_path: &ng_workspace_path
       /home/circleci/repo/ddp-workspace
   npm_cache_key: &npm_cache_key
-    v1-dependency-npm1-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+    v1-dependency-npm2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
   npm_cache_restore_key: &npm_cache_restore_key
     keys:
       - *npm_cache_key
@@ -34,6 +34,7 @@ commands:
         type: string
     steps:
       - setup-build-workspace
+      - set-deployment-environment
       - setup-shared-env:
           study_key: << parameters.study_key >>
       - build-app

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -396,7 +396,8 @@ jobs:
     executor:
       name: build-executor
     steps:
-      - checkout
+      - checkout:
+          path: *repo_path
       - setup-shared-env
       - conditionally-launch-build-and-deploy:
           study_keys: *study_keys

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,8 +314,11 @@ commands:
             set +x
             echo "The path is $PATH"
             ls -l /home/circleci/repo/build-utils
+            echo "The current PWD is $PWD"
+            ls -l /home/circleci/repo
             # CircleCi does not support arrays as params, so here is my workaround
             STUDY_KEYS=(<< parameters.study_keys >>)
+
 
             CHANGED_PROJECTS=$(findmodifiedprojects.sh <<pipeline.git.base_revision >> << pipeline.git.revision >>)
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,6 +255,7 @@ commands:
           name: Install dependencies
           command: |
             echo "the PWD is $PWD"
+            ls -l
             if [[ ! -d node_modules ]]; then
               npm ci
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,7 +315,7 @@ commands:
             echo "The path is $PATH"
             ls -l /home/circleci/repo/build-utils
             echo "The current PWD is $PWD"
-            ls -l /home/circleci/repo
+            ls -l /home/circleci/repo/ddp-workspace
             # CircleCi does not support arrays as params, so here is my workaround
             STUDY_KEYS=(<< parameters.study_keys >>)
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,9 +78,6 @@ commands:
               staging)
                 DEPLOY_ENV=staging
               ;;
-              deletemedummy)
-                DEPLOY_ENV=dev
-              ;;
               production)
                 DEPLOY_ENV=prod
               ;;
@@ -258,8 +255,6 @@ commands:
       - run:
           name: Install dependencies
           command: |
-            echo "the PWD is $PWD"
-            ls -l
             if [[ ! -d node_modules ]]; then
               npm ci
             else
@@ -315,13 +310,8 @@ commands:
             set -u
             set +e
             set +x
-            echo "The path is $PATH"
-            ls -l /home/circleci/repo/build-utils
-            echo "The current PWD is $PWD"
-            ls -l /home/circleci/repo/ddp-workspace
             # CircleCi does not support arrays as params, so here is my workaround
             STUDY_KEYS=(<< parameters.study_keys >>)
-
 
             CHANGED_PROJECTS=$(findmodifiedprojects.sh <<pipeline.git.base_revision >> << pipeline.git.revision >>)
 
@@ -462,7 +452,6 @@ workflows:
             branches:
               only:
                 - develop
-                - fix_circleci_paths
 
   build-and-deploy-workflow:
     when: << pipeline.parameters.do-builds >>
@@ -481,7 +470,6 @@ workflows:
               only:
                 - /^rc.*/
                 - /^hotfix.*/
-                - fix_circleci_paths
 
   build-app-workflow:
     when: << pipeline.parameters.do-builds >>
@@ -498,7 +486,6 @@ workflows:
                 - test
                 - staging
                 - production
-                - deletemedummy
           study_key: osteo
 
       - deploy-stored-build-job:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,10 @@
 version: 2.1
 
 references:
+  repo_path: &repo_path
+      /home/circleci/repo
+  ng_workspace_path: &ng_workspace_path
+      /home/circleci/repo/ddp-workspace
   npm_cache_key: &npm_cache_key
     v1-dependency-npm1-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
   npm_cache_restore_key: &npm_cache_restore_key
@@ -19,7 +23,7 @@ executors:
   commit-executor:
     docker:
       - image: broadinstitute/study-website-build:04-09-2020A
-    working_directory: ~/repo/ddp-workspace
+    working_directory: *ng_workspace_path
     resource_class: medium+
 
 commands:
@@ -94,7 +98,7 @@ commands:
         type: string
     steps:
       - checkout:
-          path: ~/repo
+          path: *repo_path
       - setup-shared-env:
           study_key: << parameters.study_key >>
       - set-deployment-environment
@@ -114,7 +118,6 @@ commands:
             fi
             TAR_FILE_PATH="/tmp/$(basename -- $TAR_FILE_URL)"
             gsutil cp  $TAR_FILE_URL $TAR_FILE_PATH
-            cd ~/repo/ddp-workspace
             mkdir -p $OUTPUT_DIR && tar -xvf $TAR_FILE_PATH -C $OUTPUT_DIR
             echo "Contents of extracted archive at $OUTPUT_DIR"
             ls -l $OUTPUT_DIR
@@ -143,7 +146,7 @@ commands:
             echo "$CONFIG_FILE_SRC_PATH has been copied to $CONFIG_DIR"
           environment: #Setting this ENV variable prevents launching a new Docker within build-study-sh script
             USE_DOCKER: false
-          working_directory: ~/repo
+          working_directory: *repo_path
       - run:
           name: Setup gcloud context
           command: |
@@ -161,7 +164,7 @@ commands:
             set -u
             DISPATCH_FILE_PATH="<< parameters.config_deploy_dir >>/${ENVIRONMENT}/dispatch.yaml"
             gcloud app deploy --quiet --project "broad-ddp-${ENVIRONMENT}" "${DISPATCH_FILE_PATH}"
-          working_directory: ~/repo
+          working_directory: *repo_path
       - run:
           name: Update deployments sheet
           command: |
@@ -207,12 +210,15 @@ commands:
       study_guids:
         type: string
         default: *study_guids
+      repo_path:
+        type: string
+        default: *repo_path
     steps:
       - run:
           name: Set environment variables to build <<parameters.study_key>>
           command: |
             echo "export VAULT_TOKEN=`vault write -field=token auth/approle/login role_id=$VAULT_ROLE_ID secret_id=$VAULT_ROLE_SECRET_ID`" >> $BASH_ENV
-            echo 'export PATH=$PATH:~/repo/build-utils' >> $BASH_ENV
+            echo 'export PATH=$PATH:<< parameters.repo_path >>/build-utils' >> $BASH_ENV
             if [[ '<<parameters.study_key>>' != 'UNKNOWN' ]]; then
               echo 'export STUDY_KEY=<<parameters.study_key>>' >> $BASH_ENV
               STUDY_KEYS=(<<parameters.study_keys>>)
@@ -243,7 +249,7 @@ commands:
     description: "Setup workspace used by all projects"
     steps:
       - checkout:
-          path: ~/repo
+          path: *repo_path
       - restore_cache: *npm_cache_restore_key
       - run:
           name: Install dependencies
@@ -366,6 +372,7 @@ commands:
 
 jobs:
   build-and-deploy-job:
+    working_directory: *ng_workspace_path
     parameters:
       study_key:
         type: string
@@ -377,6 +384,7 @@ jobs:
           skip_build: false
 
   conditionally-launch-build-and-deploy-all-job:
+    working_directory: *ng_workspace_path
     executor:
       name: commit-executor
     steps:
@@ -386,6 +394,7 @@ jobs:
           study_keys: *study_keys
 
   conditionally-launch-build-and-store-all-job:
+    working_directory: *ng_workspace_path
     executor:
       name: commit-executor
     steps:
@@ -400,6 +409,7 @@ jobs:
           study_key: mbc
 
   app-build-and-store-job:
+    working_directory: *ng_workspace_path
     executor:
       name: commit-executor
     steps:
@@ -407,6 +417,7 @@ jobs:
           study_key: << pipeline.parameters.study_key >>
 
   deploy-stored-build-job:
+    working_directory: *ng_workspace_path
     parameters:
       study_key:
         type: string
@@ -438,6 +449,7 @@ workflows:
             branches:
               only:
                 - develop
+                - fix_circleci_paths
 
   build-and-deploy-workflow:
     when: << pipeline.parameters.do-builds >>
@@ -456,6 +468,7 @@ workflows:
               only:
                 - /^rc.*/
                 - /^hotfix.*/
+                - fix_circleci_paths
 
   build-app-workflow:
     when: << pipeline.parameters.do-builds >>

--- a/build-utils/Dockerfile-BuildDeploy
+++ b/build-utils/Dockerfile-BuildDeploy
@@ -114,6 +114,7 @@ RUN apk  --no-cache add \
     ruby \
     ruby-bundler \
     ruby-json  \
+    make \
     && rm -rf /var/cache/apk/*
 
 # Setting up Angular CLI globally

--- a/build-utils/Dockerfile-BuildDeploy
+++ b/build-utils/Dockerfile-BuildDeploy
@@ -115,6 +115,7 @@ RUN apk  --no-cache add \
     ruby-bundler \
     ruby-json  \
     make \
+    g++ \
     && rm -rf /var/cache/apk/*
 
 # Setting up Angular CLI globally

--- a/build-utils/findmodifiedprojects.sh
+++ b/build-utils/findmodifiedprojects.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Script will list the Angular projects have been modified comparing two git SHAs
+# Can run anywhere within the repo
+# If a file from a common area, like the root diretory was modified, we call that _SHARED_
 set +x
 #ignore these file name patterns when figuring out what modules changed 
 declare -a exclude_patterns=( '^.*\.md' '^.*.pdf' )


### PR DESCRIPTION
Discovered that after a recent tweak paths were messed. Main symptom was that are build-utils scripts could not be found because PATH was not set properly.
Then found that we were getting errors when trying to rebuild the Angular node modules. Needed to include some additional programs installed in supporting Docker image.