### PR TITLE
Fix mailing address busy bug and highlight missing fields on load

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,7 +273,7 @@ commands:
           name: ng test
           command: |
             mkdir -p /tmp/junit
-            ng test ddp-sdk --watch=false --browsers ChromeHeadlessNoSandbox
+            ng test ddp-sdk --watch=false --browsers ChromeHeadlessNoSandbox --reporters junit
           environment:
             JUNIT_REPORT_PATH: /tmp/junit/
             JUNIT_REPORT_NAME: test-results.xml

--- a/ddp-workspace/projects/ddp-sdk/karma.conf.js
+++ b/ddp-workspace/projects/ddp-sdk/karma.conf.js
@@ -21,7 +21,7 @@ module.exports = function (config) {
       reports: ['html', 'lcovonly'],
       fixWebpackSourcePaths: true
     },
-    reporters: ['junit'],
+    reporters: ['junit', 'kjhtml'],
     junitReporter: {
       outputDir: process.env.JUNIT_REPORT_PATH,
       outputFile: process.env.JUNIT_REPORT_NAME,

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.spec.ts
@@ -290,6 +290,8 @@ describe('AddressEmbeddedComponent', () => {
     spyOnSubmitAnnounced.and.returnValue(hot('--a', {a: (new ActivityResponse('blah'))}));
     // @ts-ignore
     addressServiceSpy.findDefaultAddress.and.returnValue(of(defaultAddress));
+    let componentIsBusy = false;
+    component.componentBusy.subscribe(isBusy => componentIsBusy = isBusy);
     fixture.detectChanges();
     expect(childComponent.address).toBe(defaultAddress);
     expect(addressServiceSpy.getTempAddress).not.toHaveBeenCalled();
@@ -301,6 +303,8 @@ describe('AddressEmbeddedComponent', () => {
     tick();
     fixture.detectChanges();
     expect(addressServiceSpy.saveAddress).toHaveBeenCalledWith(defaultAddress, false);
+    // check for bug where we not setting busy flag back to false if no temp address loaded
+    expect(componentIsBusy).toBe(false);
   }));
   it('test component busy output', fakeAsync(() => {
     component.activityGuid = '123';

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.ts
@@ -11,6 +11,7 @@ import {
   concatMap,
   distinctUntilChanged,
   filter,
+  finalize,
   map,
   mergeMap,
   pluck,
@@ -222,8 +223,7 @@ export class AddressEmbeddedComponent implements OnDestroy, OnInit {
       ),
       tap(([state, defaultAddress]) =>
         defaultAddress && this.stateUpdates$.next({ inputAddress: defaultAddress as Address })),
-      // todo: just for manual testing. delete when done
-      //     tap(([state, defaultAddress]) => this.inputComponentAddress$.next(defaultAddress as Address)),
+      // filter for case where we need to go on to look for a temp address?
       filter(([state, defaultAddress]) => !defaultAddress && !!(state as ComponentState).activityInstanceGuid),
       map(([state, _]) => state as ComponentState),
       mergeMap((state) => this.addressService.getTempAddress(state.activityInstanceGuid)),
@@ -231,7 +231,7 @@ export class AddressEmbeddedComponent implements OnDestroy, OnInit {
       // fake that the address was just entered. Perhaps this can become a separate subject?
       // guess we are saving temp address again. No harm but not nice either.
       tap((tempAddress) => this.inputComponentAddress$.next(tempAddress)),
-      tap(() => busyCounter$.next(-1)),
+      finalize(() => busyCounter$.next(-1))
     );
 
     this.inputComponentAddress$.subscribe(address => console.debug('The new inputcomponentaddress: ' + JSON.stringify(address)));

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.service.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.service.spec.ts
@@ -150,4 +150,26 @@ describe('AddressInputService', () => {
     expect(lastAddressFromStream).toEqual(testAddress);
   }));
 
+  it('Ensure that when we read an address all fields are touched', fakeAsync(() => {
+    const allChildFormControls = Object.values(ais.addressForm.controls);
+    expect(allChildFormControls.length).toBeGreaterThan(4);
+    // Before setting any data all controls are untouched.
+    expect(Object.values(ais.addressForm.controls).filter(control => control.touched).length).toBe(0);
+    const addressData = {
+      name : '',
+      street1 : '1 Mockingbird Lane',
+      street2 : '2nd Floor',
+      country : 'US',
+      state : 'AK',
+      zip: '90120',
+      phone: '867-5309',
+      city: 'Fairbanks',
+      guid: '123'
+    };
+    tick(2);
+    ais.inputAddress$.next(new Address(addressData));
+    // check that when set an address, we ensure the controls are touched
+    expect(Object.values(ais.addressForm.controls).filter(control => !control.touched).length).toBe(0);
+  }));
+
 });

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.service.ts
@@ -365,8 +365,8 @@ export class AddressInputService implements OnDestroy {
         const newFieldValue = address[propName];
         if (formControl && newFieldValue !== formControl.value) {
           formControl.patchValue(newFieldValue, { emitEvent: emitValueChange });
-          markFieldsAsTouched && formControl.markAsTouched();
         }
+        markFieldsAsTouched && formControl.markAsTouched();
       });
       // this line really does look necessary after some updates
       // particularly if updating the FormGroup with data and place holders in fields


### PR DESCRIPTION
This is the bug we observed with Yufeng when walking through TestBoston.
One line fix and test updated to make sure does not happen again.
Also noticed that we did not highlight missing fields in address when loading a temporary or profile address. Have fix and test for that too.