### PR TITLE
Add label to picklist question if one exists

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/radiobuttonsActivityPicklistQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/radiobuttonsActivityPicklistQuestion.component.ts
@@ -8,7 +8,8 @@ import { NGXTranslateService } from '../../../services/internationalization/ngxT
     selector: 'ddp-activity-radiobuttons-picklist-question',
     template: `
     <div>
-        <mat-radio-group class="ddp-radio-group-column">
+        <label id="radio-group-label" *ngIf="block.label" [innerHTML]="block.label"></label>
+        <mat-radio-group class="ddp-radio-group-column" aria-labelledby="radio-group-label">
             <div *ngFor="let option of block.picklistOptions" class="margin-5">
                 <mat-radio-button
                             [checked]="getOptionSelection(option.stableId)"


### PR DESCRIPTION
Took stab at trying to add a label to radio groups in composite questions. Label is there but not happy with it. Looking for input there. This is what it looks like with the change I introduced, right above "Positive":
<img width="683" alt="Screen Shot 2020-05-24 at 1 15 13 PM" src="https://user-images.githubusercontent.com/29984380/82760319-bc7fdf80-9dc0-11ea-8df1-c1c6e554048f.png">

On client we create a label attribute that holds the child question text.
But radio groups are different than other Angular material input widgets. Labels are not part of mat-form-fields.
I added label following example at https://material.angular.io/components/radio/examples
But styling just looks off in COVID survey. And not sure that even if we had exact same styling as the label for the date, it would look right anyways.
Maybe not using mat-label for this question at all? Not sure how to do this for this question in testboston.
I don't have a good solution for this at this point.
A separate but related issue: one thing that would appear to improve appearance in the covid survey would be to layout the radio options horizontally rather than vertically. I this is what that would look like:

<img width="605" alt="Screen Shot 2020-05-24 at 1 22 02 PM" src="https://user-images.githubusercontent.com/29984380/82760472-b2121580-9dc1-11ea-9f3b-5c5d54981e11.png">

