### PR TITLE
Move recaptcha site key to vault and read value from pepperConfig.js

### DIFF
--- a/config/pepperConfig.js.ctmpl
+++ b/config/pepperConfig.js.ctmpl
@@ -1,13 +1,18 @@
 {{ $environment := env "ENVIRONMENT"}}
 {{ $version := env "VERSION"}}
-{{ with secret (printf "secret/pepper/%s/%s/conf" $environment $version) }}
+{{$study := env "STUDY_KEY"}}
 {{ $study_guid := env "STUDY_GUID"}}
 
 var DDP_ENV = {
     auth0SilentRenewUrl: location.origin + '/silentRenew',
     loginLandingUrl: location.origin + '/login-landing',
     doLocalRegistration:false,
+    {{ with secret (printf "secret/pepper/%s/%s/conf" $environment $version) }}
     mapsApiKey:"{{.Data.mapsApiKey}}",
+    {{end}}
+    {{with secret (printf "secret/pepper/%s/%s/%s/conf" $environment $version $study) }}
+    recaptchaSiteClientKey:"{{.Data.recaptchaSiteClientKey}}",
+    {{end}}
     studyGuid:"{{$study_guid}}",
     tcellbaseurl:"https://us.agent.tcell.insight.rapid7.com/api/v1"
 };
@@ -134,4 +139,3 @@ var DDP_ENV = {
     {{end}}
 {{end}}
 
-{{end}}

--- a/ddp-workspace/projects/ddp-testboston/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-testboston/src/app/app.module.ts
@@ -64,7 +64,7 @@ toolkitConfig.covidSurveyGuid = AppGuids.Covid;
 toolkitConfig.dashboardGuid = AppGuids.Dashboard;
 toolkitConfig.phone = '1-617-123-4567';
 toolkitConfig.infoEmail = 'info@testboston.org';
-toolkitConfig.recaptchaSiteKey = '6LdxFPsUAAAAAFdX1VHmLIbxAD8f151Kg0wk9KwJ';
+toolkitConfig.recaptchaSiteClientKey = DDP_ENV.recaptchaSiteClientKey;
 toolkitConfig.agreeConsent = true;
 
 export const sdkConfig = new ConfigurationService();

--- a/ddp-workspace/projects/ddp-testboston/src/app/components/user-registration-prequal/user-registration-prequal.component.html
+++ b/ddp-workspace/projects/ddp-testboston/src/app/components/user-registration-prequal/user-registration-prequal.component.html
@@ -19,7 +19,7 @@
                     <input matInput formControlName="zip" minlength="5" maxlength="5"
                         placeholder="Enter mailing zip code" pattern="[0-9]{5}">
                 </mat-form-field>
-                <re-captcha [siteKey]="config.recaptchaSiteKey" size="normal" formControlName="recaptchaToken">
+                <re-captcha [siteKey]="config.recaptchaSiteClientKey" size="normal" formControlName="recaptchaToken">
                 </re-captcha>
                 <div class="invitation-form__button">
                     <button class="button button_primary" type="submit" [disabled]="formGroup.invalid"

--- a/ddp-workspace/projects/toolkit/src/lib/services/toolkitConfiguration.service.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/services/toolkitConfiguration.service.ts
@@ -64,6 +64,5 @@ export class ToolkitConfigurationService {
     blogUrl: string;
     agreeConsent: boolean;
 
-    // security
-    recaptchaSiteKey: string;
+    recaptchaSiteClientKey: string;
 }


### PR DESCRIPTION
To allow for different keys in different environments. Will be also renaming on server side as name I had in there that left out that it was server or client was confusing me.