### PR TITLE
DDP-4602: Dashboard for participants

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/user/activities/userActivities.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/user/activities/userActivities.component.ts
@@ -197,9 +197,7 @@ export class UserActivitiesComponent implements OnInit, OnDestroy, OnChanges, Af
           // observable stream from main data source, so we will get
           // single final result when both statuses and activity
           // instances will be loaded
-          mergeMap(x => {
-            return this.dataSource.isNull;
-          }, (x, y) => y)
+          mergeMap(x => this.dataSource.isNull)
           // here is the final subscription, on which we will update
           // 'loaded' flag
         ).subscribe(x => this.loaded = !x);

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/user/activities/userActivities.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/user/activities/userActivities.component.ts
@@ -7,6 +7,7 @@ import { UserActivityServiceAgent } from '../../../services/serviceAgents/userAc
 import { ActivityInstanceStatusServiceAgent } from '../../../services/serviceAgents/activityInstanceStatusServiceAgent.service';
 import { AnalyticsEventsService } from '../../../services/analyticsEvents.service';
 import { AnalyticsEventCategories } from '../../../models/analyticsEventCategories';
+import { DashboardColumns } from '../../../models/dashboardColumns';
 import { BehaviorSubject, Subscription } from 'rxjs';
 import { tap, mergeMap } from 'rxjs/operators';
 
@@ -165,8 +166,8 @@ import { tap, mergeMap } from 'rxjs/operators';
 })
 export class UserActivitiesComponent implements OnInit, OnDestroy, OnChanges, AfterContentInit {
   @Input() studyGuid: string;
+  @Input() displayedColumns: Array<DashboardColumns> = ['name', 'summary', 'date', 'status', 'actions'];
   @Output() open: EventEmitter<string> = new EventEmitter();
-  public displayedColumns = ['name', 'summary', 'date', 'status', 'actions'];
   public dataSource: UserActivitiesDataSource;
   public loaded: boolean;
   private states: Array<ActivityInstanceState> | null;

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/dashboardColumns.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/dashboardColumns.ts
@@ -1,0 +1,1 @@
+export type DashboardColumns = 'name' | 'summary' | 'date' | 'status' | 'actions';

--- a/ddp-workspace/projects/ddp-sdk/src/public-api.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/public-api.ts
@@ -40,6 +40,7 @@ export * from './lib/models/analyticsEventActions';
 export * from './lib/models/address';
 export * from './lib/models/ddpError';
 export * from './lib/models/errorType';
+export * from './lib/models/dashboardColumns';
 
 export * from './lib/services/logging.service';
 export * from './lib/services/serviceAgents/userActivityServiceAgent.service';

--- a/ddp-workspace/projects/ddp-testboston/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-testboston/src/app/app.module.ts
@@ -66,6 +66,7 @@ toolkitConfig.phone = '1-617-123-4567';
 toolkitConfig.infoEmail = 'info@testboston.org';
 toolkitConfig.recaptchaSiteClientKey = DDP_ENV.recaptchaSiteClientKey;
 toolkitConfig.agreeConsent = true;
+toolkitConfig.dashboardDisplayedColumns = ['name', 'status', 'actions'];
 
 export const sdkConfig = new ConfigurationService();
 sdkConfig.backendUrl = DDP_ENV.basePepperUrl;

--- a/ddp-workspace/projects/ddp-testboston/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-testboston/src/assets/i18n/en.json
@@ -166,7 +166,7 @@
     },
     "Toolkit": {
         "Dashboard": {
-            "Title": "My Dashboard"
+            "Title": "Dashboard"
         },
         "Password": {
             "Title": "Please enter the password",
@@ -195,7 +195,7 @@
         "NextButton": "Next",
         "PreviousButton": "Back",
         "SavingButton": "Saving",
-        "EditButton": "View/Edit",
+        "EditButton": "Continue",
         "ReviewButton": "View",
         "AgreeButton": "I agree",
         "NotAgreeButton": "I am not ready to agree",

--- a/ddp-workspace/projects/ddp-testboston/src/style/activity.scss
+++ b/ddp-workspace/projects/ddp-testboston/src/style/activity.scss
@@ -16,3 +16,11 @@
         }
     }
 }
+
+// info box
+.infobox {
+    border: 2px solid mat-color($app-theme, 1200);
+    border-radius: 8px;
+    background-color: rgba(113, 84, 255, 0.06);
+    padding: 1rem;
+}

--- a/ddp-workspace/projects/ddp-testboston/src/style/buttons.scss
+++ b/ddp-workspace/projects/ddp-testboston/src/style/buttons.scss
@@ -101,6 +101,12 @@
         }
     }
 
+    &_small {
+        padding: 0.2rem 0;
+        font-size: 1.125rem;
+        line-height: 2.125rem;
+    }
+
     &__spinner {
         margin-left: 5px;
         height: 20px !important;

--- a/ddp-workspace/projects/ddp-testboston/src/style/dashboard.scss
+++ b/ddp-workspace/projects/ddp-testboston/src/style/dashboard.scss
@@ -49,6 +49,11 @@
         line-height: 1.75rem !important;
     }
 
+    .mat-header-cell:last-of-type,
+    .mat-cell:last-of-type {
+        padding-right: 10px !important;
+    }
+
     .dashboard-mobile-label {
         color: rgba(0, 0, 0, 0.54);
     }

--- a/ddp-workspace/projects/ddp-testboston/src/style/dashboard.scss
+++ b/ddp-workspace/projects/ddp-testboston/src/style/dashboard.scss
@@ -107,3 +107,10 @@
 .dashboard-activity-button:hover {
     color: mat-color($app-theme, 650) !important;
 }
+
+
+@media only screen and (max-width: 480px) {
+    .dashboard-section {
+        margin: 2rem 0 4rem 0;
+    }
+}

--- a/ddp-workspace/projects/ddp-testboston/src/style/dashboard.scss
+++ b/ddp-workspace/projects/ddp-testboston/src/style/dashboard.scss
@@ -49,6 +49,11 @@
         line-height: 1.75rem !important;
     }
 
+    .mat-header-cell:first-of-type,
+    .mat-cell:first-of-type {
+        padding-left: 10px !important;
+    }
+
     .mat-header-cell:last-of-type,
     .mat-cell:last-of-type {
         padding-right: 10px !important;
@@ -88,6 +93,11 @@
         .mat-row {
             align-items: flex-start !important;
             padding: 5px 0 !important;
+        }
+
+        .mat-header-cell:first-of-type,
+        .mat-cell:first-of-type {
+            padding-left: 0px !important;
         }
     }
 }

--- a/ddp-workspace/projects/ddp-testboston/src/style/dashboard.scss
+++ b/ddp-workspace/projects/ddp-testboston/src/style/dashboard.scss
@@ -1,0 +1,104 @@
+@import '../app-theme.scss';
+
+.dashboard-title-section {
+    background-color: #CCE0FB;
+
+    &__title {
+        font-weight: 600;
+        font-size: 2rem;
+        line-height: 2.75rem;
+        margin: 2.75rem 0;
+    }
+}
+
+.dashboard-section {
+    margin: 5rem 0 15rem 0;
+}
+
+.dashboard-content {
+    margin: 2rem 0 0 0;
+}
+
+.dashboard-content_table {
+    margin: 2rem 0;
+}
+
+.infobox_dashboard {
+    padding: 1.5rem 2rem;
+    position: relative;
+
+    .close-button {
+        position: absolute;
+        top: 0;
+        right: 0;
+    }
+}
+
+.infobox-text_small {
+    font-size: 1rem;
+    line-height: 1.5rem;
+    color: mat-color($app-theme, 700);
+}
+
+.ddp-dashboard {
+
+    .mat-cell,
+    .mat-header-cell,
+    .dashboard-mobile-label {
+        font-size: 1.125rem !important;
+        line-height: 1.75rem !important;
+    }
+
+    .dashboard-mobile-label {
+        color: rgba(0, 0, 0, 0.54);
+    }
+
+    .mat-column-actions {
+        flex: 0 0 20%;
+    }
+
+    .mat-row {
+        align-items: center !important;
+        padding: 15px 0 !important;
+    }
+
+    .dashboard-status-container__img {
+        height: 25px !important;
+        width: 25px !important;
+        padding: 0 8px 0 0;
+    }
+
+    .Link {
+        color: mat-color($app-theme, 700);
+        white-space: normal;
+    }
+
+    @media(max-width: 650px) {
+        .mat-column-actions {
+            .dashboard-mobile-label {
+                line-height: 1.125rem !important;
+            }
+        }
+
+        .mat-row {
+            align-items: flex-start !important;
+            padding: 5px 0 !important;
+        }
+    }
+}
+
+.dashboard-activity-button {
+    font-size: 1.125rem;
+    line-height: 1.75rem;
+    font-family: inherit;
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    text-decoration: none;
+    text-align: left;
+}
+
+.dashboard-activity-button:hover {
+    color: mat-color($app-theme, 650) !important;
+}

--- a/ddp-workspace/projects/ddp-testboston/src/styles.scss
+++ b/ddp-workspace/projects/ddp-testboston/src/styles.scss
@@ -1,6 +1,7 @@
 @import 'app-theme.scss';
 @import './style/buttons.scss';
 @import './style/activity.scss';
+@import './style/dashboard.scss';
 
 $custom-typography: mat-typography-config($font-family: 'Nunito');
 
@@ -87,6 +88,10 @@ li {
     margin: 0 auto;
     padding: 0 1.5625rem;
     max-width: 700px;
+
+    &_wide {
+        max-width: 1200px;
+    }
 }
 
 .center {

--- a/ddp-workspace/projects/toolkit/src/lib/components/dashboard/dashboard-redesigned.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/dashboard/dashboard-redesigned.component.ts
@@ -10,8 +10,8 @@ import { AnnouncementsServiceAgent } from 'ddp-sdk';
     template: `
         <main class="main">
             <section class="section dashboard-title-section">
-                <div class="content content_medium">
-                    <h1 translate>Toolkit.Dashboard.Title</h1>
+                <div class="content content_medium content_wide">
+                    <h1 class="dashboard-title-section__title" translate>Toolkit.Dashboard.Title</h1>
                 </div>
             </section>
             <ng-container *ngFor="let announcement of announcementMessages; let i = index">
@@ -34,6 +34,7 @@ import { AnnouncementsServiceAgent } from 'ddp-sdk';
                 <div class="content content_medium">
                     <div class="dashboard-content dashboard-content_table">
                         <ddp-user-activities [studyGuid]="studyGuid"
+                                             [displayedColumns]="config.dashboardDisplayedColumns"
                                              (open)="navigate($event)">
                         </ddp-user-activities>
                     </div>
@@ -46,8 +47,8 @@ export class DashboardRedesignedComponent extends DashboardComponent implements 
         private headerConfig: HeaderConfigurationService,
         private _router: Router,
         private _announcements: AnnouncementsServiceAgent,
-        @Inject('toolkit.toolkitConfig') private _toolkitConfiguration: ToolkitConfigurationService) {
-        super(_router, _announcements, _toolkitConfiguration);
+        @Inject('toolkit.toolkitConfig') public config: ToolkitConfigurationService) {
+        super(_router, _announcements, config);
     }
 
     public ngOnInit(): void {

--- a/ddp-workspace/projects/toolkit/src/lib/services/toolkitConfiguration.service.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/services/toolkitConfiguration.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { DashboardColumns } from 'ddp-sdk';
 
 @Injectable()
 export class ToolkitConfigurationService {
@@ -53,16 +54,18 @@ export class ToolkitConfigurationService {
     twitterAccountId: string;
     facebookGroupId: string;
     instagramId: string;
-    lightswitchInstagramWidgetId?: string;
     cBioPortalLink: string;
     countMeInUrl: string;
+    blogUrl: string;
 
     // Layout settings
     showDataRelease: boolean;
     showInfoForPhysicians: boolean;
     showBlog: boolean;
-    blogUrl: string;
     agreeConsent: boolean;
+    dashboardDisplayedColumns: Array<DashboardColumns>;
 
+    // Keys and tokens
     recaptchaSiteClientKey: string;
+    lightswitchInstagramWidgetId: string;
 }


### PR DESCRIPTION
Dashboard layout updated following last mockups:
![image](https://user-images.githubusercontent.com/30126907/83262017-f4be5e00-a1c4-11ea-813f-9ad1149da0d5.png)
This PR doesn't include status updates. As I know it's still in discussions.

@MocanaAtBroad, if changes look good for you, can we merge PR now without statuses updates? Because the current dashboard looks awful. And when statuses stuff will be defined I back on it.