### PR TITLE
testboston: enable local registration

### DIFF
--- a/ddp-workspace/projects/ddp-testboston/src/app/app-routes.ts
+++ b/ddp-workspace/projects/ddp-testboston/src/app/app-routes.ts
@@ -5,6 +5,7 @@ export const AppRoutes = {
     Error: 'error',
     Join: 'join',
     LoginLanding: 'login-landing',
+    LocalAuth: 'auth',
     Consent: 'consent',
     CovidSurvey: 'covid-survey',
     Dashboard: 'dashboard',

--- a/ddp-workspace/projects/ddp-testboston/src/app/app-routing.module.ts
+++ b/ddp-workspace/projects/ddp-testboston/src/app/app-routing.module.ts
@@ -8,6 +8,7 @@ import { WelcomeComponent } from './components/welcome/welcome.component';
 import { UserRegistrationPrequalComponent } from './components/user-registration-prequal/user-registration-prequal.component';
 
 import {
+  Auth0CodeCallbackComponent,
   AuthGuard,
   IrbGuard
 } from 'ddp-sdk';
@@ -93,6 +94,11 @@ const routes: Routes = [
     canActivate: [
       IrbGuard
     ]
+  },
+  {
+    path: AppRoutes.LocalAuth,
+    component: Auth0CodeCallbackComponent,
+    canActivate: [IrbGuard]
   },
   {
     path: AppRoutes.Error,


### PR DESCRIPTION
Adding local registration to `testboston` so I can more easily make changes locally. Backend changes are needed (see https://github.com/broadinstitute/ddp-study-server/pull/236).