### PR TITLE
DDP-4600 improve date validations

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityDateQuestionBlock.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityDateQuestionBlock.ts
@@ -3,6 +3,9 @@ import { QuestionType } from './questionType';
 import { DatePickerValue } from '../datePickerValue';
 import { DateField } from './dateField';
 import { DateRenderMode } from './dateRenderMode';
+import { ActivityDayRequiredDateValidationRule } from '../../services/activity/validators/dateValidators/activityDayRequiredDateValidationRule'
+import { ActivityMonthRequiredDateValidationRule } from '../../services/activity/validators/dateValidators/activityMonthRequiredDateValidationRule'
+import { ActivityYearRequiredDateValidationRule } from '../../services/activity/validators/dateValidators/activityYearRequiredDateValidationRule'
 
 export class ActivityDateQuestionBlock extends ActivityQuestionBlock<DatePickerValue> {
     public renderMode: DateRenderMode;
@@ -30,5 +33,29 @@ export class ActivityDateQuestionBlock extends ActivityQuestionBlock<DatePickerV
             }
         }
         return true;
+    }
+
+    public hasRequiredFields(value: DatePickerValue): boolean {
+        let hasFieldRule = false;
+        for (const validator of this.validators) {
+            if (validator instanceof ActivityDayRequiredDateValidationRule) {
+                hasFieldRule = true;
+                if (value.day == null) {
+                    return false;
+                }
+            } else if (validator instanceof ActivityMonthRequiredDateValidationRule) {
+                hasFieldRule = true;
+                if (value.month == null) {
+                    return false;
+                }
+            } else if (validator instanceof ActivityYearRequiredDateValidationRule) {
+                hasFieldRule = true;
+                if (value.year == null) {
+                    return false;
+                }
+            }
+        }
+        // There are field rules and date has value for those rules, so return true.
+        return hasFieldRule;
     }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityDateQuestionBlock.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityDateQuestionBlock.ts
@@ -3,9 +3,9 @@ import { QuestionType } from './questionType';
 import { DatePickerValue } from '../datePickerValue';
 import { DateField } from './dateField';
 import { DateRenderMode } from './dateRenderMode';
-import { ActivityDayRequiredDateValidationRule } from '../../services/activity/validators/dateValidators/activityDayRequiredDateValidationRule'
-import { ActivityMonthRequiredDateValidationRule } from '../../services/activity/validators/dateValidators/activityMonthRequiredDateValidationRule'
-import { ActivityYearRequiredDateValidationRule } from '../../services/activity/validators/dateValidators/activityYearRequiredDateValidationRule'
+import { ActivityDayRequiredDateValidationRule } from '../../services/activity/validators/dateValidators/activityDayRequiredDateValidationRule';
+import { ActivityMonthRequiredDateValidationRule } from '../../services/activity/validators/dateValidators/activityMonthRequiredDateValidationRule';
+import { ActivityYearRequiredDateValidationRule } from '../../services/activity/validators/dateValidators/activityYearRequiredDateValidationRule';
 
 export class ActivityDateQuestionBlock extends ActivityQuestionBlock<DatePickerValue> {
     public renderMode: DateRenderMode;
@@ -40,17 +40,17 @@ export class ActivityDateQuestionBlock extends ActivityQuestionBlock<DatePickerV
         for (const validator of this.validators) {
             if (validator instanceof ActivityDayRequiredDateValidationRule) {
                 hasFieldRule = true;
-                if (value.day == null) {
+                if (value.day === null) {
                     return false;
                 }
             } else if (validator instanceof ActivityMonthRequiredDateValidationRule) {
                 hasFieldRule = true;
-                if (value.month == null) {
+                if (value.month === null) {
                     return false;
                 }
             } else if (validator instanceof ActivityYearRequiredDateValidationRule) {
                 hasFieldRule = true;
-                if (value.year == null) {
+                if (value.year === null) {
                     return false;
                 }
             }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/dateValidators/activityDateRangeValidationRule.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/dateValidators/activityDateRangeValidationRule.ts
@@ -15,7 +15,7 @@ export class ActivityDateRangeValidationRule extends ActivityAbstractValidationR
         if (this.question.answer != null) {
             const dateQuestion = this.question as ActivityDateQuestionBlock;
             const value = this.question.answer as DatePickerValue;
-            if (dateQuestion.isSpecifiedFieldsPresent(value)) {
+            if (dateQuestion.isSpecifiedFieldsPresent(value) || dateQuestion.hasRequiredFields(value)) {
                 const valid = this.isWithinRange(this.question.answer);
                 this.result = (valid ? null : this.message);
                 return valid;

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/dateValidators/activityDayRequiredDateValidationRule.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/dateValidators/activityDayRequiredDateValidationRule.ts
@@ -11,7 +11,7 @@ export class ActivityDayRequiredDateValidationRule extends ActivityAbstractValid
     public recalculate(): boolean {
         if (this.question.answer != null) {
             const value = this.question.answer;
-            if (!this.isBlank(value) && value.day == null) {
+            if (!this.isBlank(value) && value.day === null) {
                 this.result = this.message;
                 return false;
             }
@@ -21,6 +21,6 @@ export class ActivityDayRequiredDateValidationRule extends ActivityAbstractValid
     }
 
     private isBlank(value: DatePickerValue): boolean {
-        return value.year == null && value.month == null && value.day == null;
+        return value.year === null && value.month === null && value.day === null;
     }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/dateValidators/activityDayRequiredDateValidationRule.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/dateValidators/activityDayRequiredDateValidationRule.ts
@@ -11,12 +11,16 @@ export class ActivityDayRequiredDateValidationRule extends ActivityAbstractValid
     public recalculate(): boolean {
         if (this.question.answer != null) {
             const value = this.question.answer;
-            if (value.day == null) {
+            if (!this.isBlank(value) && value.day == null) {
                 this.result = this.message;
                 return false;
             }
         }
         this.result = null;
         return true;
+    }
+
+    private isBlank(value: DatePickerValue): boolean {
+        return value.year == null && value.month == null && value.day == null;
     }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/dateValidators/activityMonthRequiredDateValidationRule.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/dateValidators/activityMonthRequiredDateValidationRule.ts
@@ -11,12 +11,16 @@ export class ActivityMonthRequiredDateValidationRule extends ActivityAbstractVal
     public recalculate(): boolean {
         if (this.question.answer != null) {
             const value = this.question.answer;
-            if (value.month == null) {
+            if (!this.isBlank(value) && value.month == null) {
                 this.result = this.message;
                 return false;
             }
         }
         this.result = null;
         return true;
+    }
+
+    private isBlank(value: DatePickerValue): boolean {
+        return value.year == null && value.month == null && value.day == null;
     }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/dateValidators/activityMonthRequiredDateValidationRule.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/dateValidators/activityMonthRequiredDateValidationRule.ts
@@ -11,7 +11,7 @@ export class ActivityMonthRequiredDateValidationRule extends ActivityAbstractVal
     public recalculate(): boolean {
         if (this.question.answer != null) {
             const value = this.question.answer;
-            if (!this.isBlank(value) && value.month == null) {
+            if (!this.isBlank(value) && value.month === null) {
                 this.result = this.message;
                 return false;
             }
@@ -21,6 +21,6 @@ export class ActivityMonthRequiredDateValidationRule extends ActivityAbstractVal
     }
 
     private isBlank(value: DatePickerValue): boolean {
-        return value.year == null && value.month == null && value.day == null;
+        return value.year === null && value.month === null && value.day === null;
     }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/dateValidators/activityYearRequiredDateValidationRule.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/dateValidators/activityYearRequiredDateValidationRule.ts
@@ -11,12 +11,16 @@ export class ActivityYearRequiredDateValidationRule extends ActivityAbstractVali
     public recalculate(): boolean {
         if (this.question.answer != null) {
             const value = this.question.answer;
-            if (value.year == null) {
+            if (!this.isBlank(value) && value.year == null) {
                 this.result = this.message;
                 return false;
             }
         }
         this.result = null;
         return true;
+    }
+
+    private isBlank(value: DatePickerValue): boolean {
+        return value.year == null && value.month == null && value.day == null;
     }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/dateValidators/activityYearRequiredDateValidationRule.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/dateValidators/activityYearRequiredDateValidationRule.ts
@@ -11,7 +11,7 @@ export class ActivityYearRequiredDateValidationRule extends ActivityAbstractVali
     public recalculate(): boolean {
         if (this.question.answer != null) {
             const value = this.question.answer;
-            if (!this.isBlank(value) && value.year == null) {
+            if (!this.isBlank(value) && value.year === null) {
                 this.result = this.message;
                 return false;
             }
@@ -21,6 +21,6 @@ export class ActivityYearRequiredDateValidationRule extends ActivityAbstractVali
     }
 
     private isBlank(value: DatePickerValue): boolean {
-        return value.year == null && value.month == null && value.day == null;
+        return value.year === null && value.month === null && value.day === null;
     }
 }


### PR DESCRIPTION
Changed the way we do date validations to satisfy requirements for `testboston`'s Covid Survey.

* The various "date field required" rules now does not require date to be answered. If there's no date value object or it's blank then we don't run rule. It is blank if user de-selects all the fields. But if user did select at least one field, then that particular field for the rule must have something selected.
* The DATE_RANGE now plays nice with the "date field required" rules. If user did not select a full date but has enough fields selected to satisfy "date field required" rules, then we check the date range.

I think this is a breaking change. But since no existing studies use the "date field required" rules I think this is fine.

See corresponding backend change: https://github.com/broadinstitute/ddp-study-server/pull/237.