### PR TITLE
DDP-4707 Hide mail address country via configuration for testboston

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activitySection.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activitySection.component.ts
@@ -60,7 +60,7 @@ import { ConfigurationService } from '../../services/configuration.service';
                 </div>
                 <div *ngIf="isMailAddress(block)">
                     <ddp-address-embedded [block]="block"
-                                          [country]="config.country"
+                                          [country]="config.supportedCountry"
                                           [readonly]="readonly"
                                           [activityGuid]="activityGuid"
                                           (validStatusChanged)="updateEmbeddedComponentValidationStatus(1, $event)"

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activitySection.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activitySection.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Inject, Input, Output } from '@angular/core';
 import { ActivitySection } from '../../models/activity/activitySection';
 import { ActivityBlock } from '../../models/activity/activityBlock';
 import { BlockType } from '../../models/activity/blockType';
@@ -8,6 +8,7 @@ import { ActivityInstitutionBlock } from '../../models/activity/activityInstitut
 import { AbstractActivityQuestionBlock } from '../../models/activity/abstractActivityQuestionBlock';
 import { BlockVisibility } from '../../models/activity/blockVisibility';
 import { ConditionalBlock } from '../../models/activity/conditionalBlock';
+import { ConfigurationService, UserActivityServiceAgent } from 'ddp-sdk';
 
 @Component({
     selector: 'ddp-activity-section',
@@ -59,6 +60,7 @@ import { ConditionalBlock } from '../../models/activity/conditionalBlock';
                 </div>
                 <div *ngIf="isMailAddress(block)">
                     <ddp-address-embedded [block]="block"
+                                          [country]="config.country"
                                           [readonly]="readonly"
                                           [activityGuid]="activityGuid"
                                           (validStatusChanged)="updateEmbeddedComponentValidationStatus(1, $event)"
@@ -90,6 +92,9 @@ export class ActivitySectionComponent {
     @Output() embeddedComponentsValidationStatus: EventEmitter<boolean> = new EventEmitter();
     @Output() embeddedComponentBusy: EventEmitter<boolean> = new EventEmitter(true);
     private embeddedValidationStatus: boolean[] = new Array(2).fill(true);
+
+    constructor(@Inject('ddp.config') public config: ConfigurationService) {
+    }
 
     public updateVisibility(visibility: BlockVisibility[]): void {
         this.visibilityChanged.emit(visibility);

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activitySection.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activitySection.component.ts
@@ -8,7 +8,7 @@ import { ActivityInstitutionBlock } from '../../models/activity/activityInstitut
 import { AbstractActivityQuestionBlock } from '../../models/activity/abstractActivityQuestionBlock';
 import { BlockVisibility } from '../../models/activity/blockVisibility';
 import { ConditionalBlock } from '../../models/activity/conditionalBlock';
-import { ConfigurationService, UserActivityServiceAgent } from 'ddp-sdk';
+import { ConfigurationService } from '../../services/configuration.service';
 
 @Component({
     selector: 'ddp-activity-section',

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.spec.ts
@@ -25,8 +25,8 @@ import { AddressVerificationResponse } from '../../models/addressVerificationRes
 })
 class FakeAddressInputComponent {
   private _address: Address | null;
+  private _readonly = false;
   @Output()valueChanged = new EventEmitter();
-  @Input()readonly;
   @Input()addressErrors;
   @Input()country;
   @Input()
@@ -41,6 +41,14 @@ class FakeAddressInputComponent {
     ais = {currentAddress$: new Subject<Address>()};
   public clearVerificationErrors(): void {
     console.log('verifications cleared!');
+  }
+  @Input()
+  set readonly(val: boolean) {
+    console.log('set readonly called with: %o', val);
+    this._readonly = val;
+  }
+  get readonly(): boolean {
+    return this._readonly;
   }
 }
 
@@ -437,6 +445,34 @@ describe('AddressEmbeddedComponent', () => {
     expect(addressServiceSpy.saveTempAddress).toHaveBeenCalledWith(addressFromChild, activityGuid);
     expect(addressServiceSpy.saveTempAddress).toHaveBeenCalledTimes(2);
     expect(addressServiceSpy.deleteTempAddress).not.toHaveBeenCalled();
+  }));
+
+  it('hide country field when property is set', fakeAsync(() => {
+    fixture.detectChanges();
+    expect(childComponent.country).toBeNull();
+    component.country = 'US';
+    component.ngOnInit();
+    fixture.detectChanges();
+    expect(childComponent.country).toBe('US');
+    component.country = null;
+    component.ngOnInit();
+    fixture.detectChanges();
+    expect(childComponent.country).toBeNull();
+    component.activityGuid = '123';
+    component.country = 'US';
+    let tempAddress = new Address({country: 'CA'});
+    addressServiceSpy.getTempAddress.and.returnValue(of(tempAddress));
+    component.ngOnInit();
+    fixture.detectChanges();
+
+    expect(childComponent.country).toBeNull();
+    component.activityGuid = '123';
+    component.country = 'CA';
+    tempAddress = new Address({country: 'CA'});
+    addressServiceSpy.getTempAddress.and.returnValue(of(tempAddress));
+    component.ngOnInit();
+    fixture.detectChanges();
+    expect(childComponent.country).toBe('CA');
   }));
 
   it('test component busy output', fakeAsync(() => {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.spec.ts
@@ -28,6 +28,7 @@ class FakeAddressInputComponent {
   @Input()address;
   @Input()readonly;
   @Input()addressErrors;
+  @Input()country;
   ais = {currentAddress$: new Subject<Address>()};
   public clearVerificationErrors(): void {
     console.log('verifications cleared!');

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.ts
@@ -502,6 +502,7 @@ export class AddressEmbeddedComponent implements OnDestroy, OnInit {
         filter(([_, addressToSave]) => this.enoughDataToSave(addressToSave)),
         tap(() => busyCounter$.next(1)),
         concatMap(([_, addressToSave]) => this.addressService.saveAddress(addressToSave, false)),
+        removeTempAddressOperator(),
         tap(() => busyCounter$.next(-1)),
         share()
     );
@@ -543,7 +544,6 @@ export class AddressEmbeddedComponent implements OnDestroy, OnInit {
         verifyInputComponentSparseAddress$,
         handleAddressSuggestionAction$,
         saveRealAddressAction$,
-        removeTempAddressAction$,
         emitValueChangedAction$,
         updateInputComponentWithSavedAddressAction$,
         emitComponentBusyAction$,
@@ -612,7 +612,9 @@ export class AddressEmbeddedComponent implements OnDestroy, OnInit {
   }
 
   ngOnDestroy(): void {
-    this.componentBusy.pipe(
+      // finding that some slow http operations
+      // killed if we destroy too early
+      this.componentBusy.pipe(
         filter(busy => !busy),
         tap(() => {
           this.ngUnsubscribe.next();

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.ts
@@ -260,8 +260,8 @@ export class AddressEmbeddedComponent implements OnDestroy, OnInit {
     this.staticCountry$ = this.state$.pipe(
         map(compState => {
           // ok to look at country at ngOnInit. We don't want to do this more than once
-          if ((this.country && (!(compState.inputAddress) || (compState.inputAddress.country === this.theCountry)))) {
-            return this.theCountry;
+          if ((this.country && (!(compState.inputAddress) || (compState.inputAddress.country === this.country)))) {
+            return this.country;
           } else {
             return null;
           }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.component.ts
@@ -25,7 +25,7 @@ import { AddressInputService } from '../address/addressInput.service';
           <mat-error>{{getFieldErrorMessage('name') | async}}</mat-error>
         </mat-form-field>
 
-        <mat-form-field>
+        <mat-form-field *ngIf="!country">
           <mat-select [placeholder]="getLabelForControl('country') | async"
                       formControlName="country"
                       required>
@@ -44,7 +44,7 @@ import { AddressInputService } from '../address/addressInput.service';
                  required
                  addressgoogleautocomplete
                  (addressChanged)="ais.googleAutocompleteAddress$.next($event)"
-                 [autocompleteRestrictCountryCode]="ais.addressForm.get('country')?.value">
+                 [autocompleteRestrictCountryCode]="ais.addressForm.get('country')?.value || country">
           <mat-error>{{getFieldErrorMessage('street1') | async}}</mat-error>
         </mat-form-field>
 
@@ -158,6 +158,8 @@ export class AddressInputComponent implements OnInit, OnDestroy {
   set readonly(val: boolean) {
     this.ais.inputIsReadOnly$.next(val);
   }
+  @Input()
+  country: string | null;
 
   /**
    * Set the errors in the input component. If list is empty, errors will be cleared.

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/user/activities/userActivities.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/user/activities/userActivities.component.ts
@@ -169,8 +169,8 @@ export class UserActivitiesComponent implements OnInit, OnDestroy, OnChanges, Af
   @Input() displayedColumns: Array<DashboardColumns> = ['name', 'summary', 'date', 'status', 'actions'];
   @Output() open: EventEmitter<string> = new EventEmitter();
   public dataSource: UserActivitiesDataSource;
-  public loaded: boolean;
-  private states: Array<ActivityInstanceState> | null;
+  public loaded = false;
+  private states: Array<ActivityInstanceState> | null = null;
   private studyGuidObservable: BehaviorSubject<string | null>;
   private loadingAnchor: Subscription;
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/configuration.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/configuration.service.ts
@@ -22,4 +22,6 @@ export class ConfigurationService {
     mapsApiKey: string;
     projectGAToken: string;
     studyGuid: string;
+    // country code if limiting app to just one country
+    country: string | null = null;
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/configuration.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/configuration.service.ts
@@ -23,5 +23,5 @@ export class ConfigurationService {
     projectGAToken: string;
     studyGuid: string;
     // country code if limiting app to just one country
-    country: string | null = null;
+    supportedCountry: string | null = null;
 }

--- a/ddp-workspace/projects/ddp-testboston/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-testboston/src/app/app.module.ts
@@ -85,6 +85,7 @@ sdkConfig.doLocalRegistration = DDP_ENV.doLocalRegistration;
 sdkConfig.mapsApiKey = DDP_ENV.mapsApiKey;
 sdkConfig.auth0Audience = DDP_ENV.auth0Audience;
 sdkConfig.projectGAToken = DDP_ENV.projectGAToken;
+sdkConfig.country = 'US';
 
 export function translateFactory(translate: TranslateService, injector: Injector): any {
     return () => new Promise<any>((resolve: any) => {

--- a/ddp-workspace/projects/ddp-testboston/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-testboston/src/app/app.module.ts
@@ -85,7 +85,7 @@ sdkConfig.doLocalRegistration = DDP_ENV.doLocalRegistration;
 sdkConfig.mapsApiKey = DDP_ENV.mapsApiKey;
 sdkConfig.auth0Audience = DDP_ENV.auth0Audience;
 sdkConfig.projectGAToken = DDP_ENV.projectGAToken;
-sdkConfig.country = 'US';
+sdkConfig.supportedCountry = 'US';
 
 export function translateFactory(translate: TranslateService, injector: Injector): any {
     return () => new Promise<any>((resolve: any) => {


### PR DESCRIPTION
Main objective here was to hide country field and have it fixed for mailing address. Driven by obviously limiting addresses to be in US for testboston .
Found a couple of other little problems in mailing address and dashboard described in comments.
Finally, added more tests to mailing address embedded component.