### PR TITLE
DDP-4713 Show dashboard question count selectively

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activityInstance.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activityInstance.ts
@@ -11,4 +11,6 @@ export interface ActivityInstance {
     icon: string;
     createdAt: number;
     readonly: boolean;
+    numQuestions: number;
+    numQuestionsAnswered: number;
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/configuration.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/configuration.service.ts
@@ -24,4 +24,9 @@ export class ConfigurationService {
     studyGuid: string;
     // country code if limiting app to just one country
     supportedCountry: string | null = null;
+    // whether dashboard status should display a count of questions
+    dashboardShowQuestionCount = false;
+    // if dashboardShowQuestionCount is true, exclude activity guids listed here from showing
+    // their question count
+    dashboardShowQuestionCountExceptions: string[] = [];
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/userActivityServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/userActivityServiceAgent.service.ts
@@ -6,7 +6,7 @@ import { ConfigurationService } from '../configuration.service';
 import { SessionMementoService } from '../sessionMemento.service';
 import { ActivityInstance } from '../../models/activityInstance';
 import { Observable, of } from 'rxjs';
-import { flatMap } from 'rxjs/operators';
+import { mergeMap } from 'rxjs/operators';
 
 @Injectable()
 export class UserActivityServiceAgent extends UserServiceAgent<Array<ActivityInstance>> {
@@ -18,15 +18,9 @@ export class UserActivityServiceAgent extends UserServiceAgent<Array<ActivityIns
         super(session, configuration, http, logger);
     }
 
-    public getActivities(studyGuid: Observable<string | null>):
-        Observable<Array<ActivityInstance> | null> {
+    public getActivities(studyGuid: Observable<string | null>): Observable<Array<ActivityInstance> | null> {
         return studyGuid.pipe(
-            flatMap(x => {
-                if (!x) {
-                    return of(null);
-                }
-                return this.getObservable(`/studies/${x}/activities`);
-            }, (x, y) => y)
-        );
+            mergeMap(x => x ? this.getObservable(`/studies/${x}/activities`)
+                : of(null)));
     }
 }

--- a/ddp-workspace/projects/ddp-testboston/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-testboston/src/app/app.module.ts
@@ -86,6 +86,8 @@ sdkConfig.mapsApiKey = DDP_ENV.mapsApiKey;
 sdkConfig.auth0Audience = DDP_ENV.auth0Audience;
 sdkConfig.projectGAToken = DDP_ENV.projectGAToken;
 sdkConfig.supportedCountry = 'US';
+sdkConfig.dashboardShowQuestionCount = true;
+sdkConfig.dashboardShowQuestionCountExceptions = ['CONSENT'];
 
 export function translateFactory(translate: TranslateService, injector: Injector): any {
     return () => new Promise<any>((resolve: any) => {

--- a/ddp-workspace/projects/ddp-testboston/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-testboston/src/assets/i18n/en.json
@@ -231,7 +231,8 @@
             "Summary": "Summary",
             "ActivityStatus": "Status",
             "ActivityDate": "Created",
-            "ActivityActions": "Actions"
+            "ActivityActions": "Actions",
+            "ActivityQuestionCount": "{{questionsAnswered}} of {{questionTotal}} Answered"
         },
         "ManageParticipants": {
             "GovernedParticipants": "Governed participants",


### PR DESCRIPTION
Aim here was to do the least possible to deliver requirements and still be backwards compatible. Dashboard configuration could very well be something that gets revisited in future. Ticket has details.