### PR TITLE
DDP-4607: Handling for non-consent

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-redesigned.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-redesigned.component.ts
@@ -105,7 +105,7 @@ import { SubmissionManager } from '../../services/serviceAgents/submissionManage
                     <ng-container *ngIf="model.lastUpdatedText">
                         <span>{{model.lastUpdatedText}} </span>
                     </ng-container>
-                    <div class="activity-buttons">
+                    <div class="activity-buttons" [ngClass]="{'activity-buttons_mobile': (!isStepped || isLastStep) && isAgree() && isLoaded}">
                         <ng-container *ngIf="isLoaded && isStepped">
                             <button *ngIf="!isFirstStep"
                                     [disabled]="(isPageBusy | async) || dataEntryDisabled"
@@ -165,7 +165,7 @@ import { SubmissionManager } from '../../services/serviceAgents/submissionManage
 })
 export class ActivityRedesignedComponent extends ActivityComponent implements OnInit, OnDestroy, AfterViewInit {
     @Input() agreeConsent = false;
-    
+
     constructor(
         windowRef: WindowRef,
         renderer: Renderer2,

--- a/ddp-workspace/projects/ddp-testboston/src/style/activity.scss
+++ b/ddp-workspace/projects/ddp-testboston/src/style/activity.scss
@@ -43,3 +43,18 @@
     background-color: rgba(113, 84, 255, 0.06);
     padding: 1rem;
 }
+
+@media only screen and (max-width: 560px) {
+    .activity-buttons_mobile {
+        flex-direction: column;
+        align-items: center;
+
+        .button {
+            width: 20rem;
+        }
+
+        .button:not(:last-child) {
+            margin-bottom: 1.5rem;
+        }
+    }
+}


### PR DESCRIPTION
I've noticed that I forgot about consent buttons for the mobile version.
Now it looks good:
![image](https://user-images.githubusercontent.com/30126907/83492806-7e6b7580-a4bc-11ea-8436-e3615b409d86.png)
