### PR TITLE
Add check for admin token in landing flow

### DIFF
--- a/ddp-workspace/projects/toolkit/src/lib/components/login-landing/admin-login-landing.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/login-landing/admin-login-landing.component.ts
@@ -35,9 +35,9 @@ export class AdminLoginLandingComponent implements OnInit, OnDestroy {
       this.redirect();
     }
 
-    // Subscribe to session observable, so once auth session is set, then we redirect.
+    // Subscribe to session observable, so once admin session is set, then we redirect.
     this.anchor = this.sessionService.sessionObservable.pipe(
-      filter(session => session !== null && !!session.idToken),
+      filter(session => session !== null && !!session.idToken && session.isAdmin),
       take(1)
     ).subscribe(() => {
       this.redirect();


### PR DESCRIPTION
When you're already logged in as a regular user and tries to login as an admin, `admin-login-landing` keeps redirect. Added a check to help correct that flow. This is likely a rare case in the real world, but definitely happens in local/dev.