### PR TITLE
DDP-4507: Testboston homepage - add Our Team section

### DIFF
--- a/ddp-workspace/projects/ddp-testboston/src/app/components/welcome/welcome.component.html
+++ b/ddp-workspace/projects/ddp-testboston/src/app/components/welcome/welcome.component.html
@@ -33,7 +33,7 @@
             </ul>
         </div>
     </section>
-    <section class="section">
+    <section class="section question-section">
         <div id="q&a" class="anchor"></div>
         <div class="content question-block">
             <h2 class="center semi-bold" translate>HomePage.FaqSection.Title</h2>
@@ -58,6 +58,20 @@
                     </mat-expansion-panel>
                 </ng-container>
             </mat-accordion>
+        </div>
+    </section>
+    <section class="section">
+        <div id="who-we-are" class="anchor"></div>
+        <div class="content team-block">
+            <h2 class="semi-bold" translate>HomePage.TeamSection.Title</h2>
+            <p translate>HomePage.TeamSection.Text</p>
+            <ul class="team-list">
+                <li class="member" *ngFor="let teammate of 'HomePage.TeamSection.List' | translate">
+                    <h5 class="member__title">{{teammate.Name}}</h5>
+                    <p class="member__affiliations">{{teammate.Affiliations}}</p>
+                    <p class="member__info">{{teammate.Info}}</p>
+                </li>
+            </ul>
         </div>
     </section>
     <section class="section mailing-list-section">

--- a/ddp-workspace/projects/ddp-testboston/src/app/components/welcome/welcome.component.scss
+++ b/ddp-workspace/projects/ddp-testboston/src/app/components/welcome/welcome.component.scss
@@ -4,6 +4,17 @@
     margin: 6rem auto;
 }
 
+@mixin member {
+    margin: 0.8rem 0;
+    line-height: 2rem;
+}
+
+@mixin reset-list {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+}
+
 .anchor {
     display: block;
     padding-top: 6rem;
@@ -42,8 +53,7 @@
 }
 
 .about-list {
-    padding: 0;
-    list-style-type: none;
+    @include reset-list;
 
     &__item {
         margin: 0.7rem 0;
@@ -52,6 +62,10 @@
             margin-right: 1rem;
         }
     }
+}
+
+.question-section {
+    background-color: mat-color($app-theme, 3200);
 }
 
 .question-block {
@@ -77,6 +91,38 @@
     }
 }
 
+.team-block {
+    @include block-margin;
+}
+
+.team-list {
+    @include reset-list;
+}
+
+.member {
+    margin: 3.5rem 0;
+
+    &__title {
+        color: mat-color($app-theme, 1200);
+        font-size: 1.625rem;
+        font-weight: 600;
+        @include member;
+    }
+
+    &__affiliations {
+        color: mat-color($app-theme, 700);
+        font-size: 1.375rem;
+        font-weight: 600;
+        @include member;
+    }
+
+    &__info {
+        color: mat-color($app-theme, 700);
+        font-size: 1.25rem;
+        @include member;
+    }
+}
+
 .mailing-list-section {
     background-color: mat-color($app-theme, 1600);
 
@@ -99,6 +145,7 @@
     border-radius: unset !important;
     box-shadow: unset !important;
     border-top: 1px solid mat-color($app-theme, 500);
+    background-color: mat-color($app-theme, 3200);
 }
 
 .mat-expansion-panel-header {

--- a/ddp-workspace/projects/ddp-testboston/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-testboston/src/assets/i18n/en.json
@@ -148,6 +148,27 @@
                 }
             ]
         },
+        "TeamSection": {
+            "Title": "Our Team",
+            "Text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+            "List": [
+                {
+                    "Name": "Ann E. Woolley, MD",
+                    "Affiliations": "Infectious Disease",
+                    "Info": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+                },
+                {
+                    "Name": "Lisa A. Cosimi, MD",
+                    "Affiliations": "Assistant Professor, Harvard Medical School Infectious Disease, Global Health Equity",
+                    "Info": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+                },
+                {
+                    "Name": "Deborah T. Hung, MD, PhD",
+                    "Affiliations": "Associate Professor, Harvard Medical School Infectious Disease, Pulmonary and Critical Care",
+                    "Info": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+                }
+            ]
+        },
         "MailingSection": {
             "Title": "TestBoston enrollment is currently invite-only. ",
             "Text": "We understand that more people may want to participate, and we are trying to open TestBoston up to a larger group in the future. To receive updates on enrollment, please join our mailing list:"
@@ -351,10 +372,10 @@
                     "Zip Code": "Zip Code",
                     "Postal Code": "Postal Code",
                     "Zip/Postal Code": "Zip/Postal Code"
-                   },
+                },
                 "Choose": "Choose {{field}} ..."
             },
-            "Suggestion":{
+            "Suggestion": {
                 "Title": "We have checked your address entry and have suggested changes that could help ensure delivery.",
                 "Subtitle": "Click \"Suggested\" to update form. You will be able to click \"As entered\" to restore your original entries.",
                 "Suggested": "Suggested:",


### PR DESCRIPTION
Added new Our Team section between FAQ and Mailing list, mockups:
https://projects.invisionapp.com/d/main/#/console/19934732/417321205/inspect
Content is not finalized, but let's merge, to help Jen and Erin understand where are we with implementing mockups.