### PR TITLE
Ddp 4719 language selector

### DIFF
--- a/ddp-workspace/projects/ddp-angio/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-angio/src/assets/i18n/en.json
@@ -16,7 +16,8 @@
             "HeaderLogo": "Angiosarcoma<br>Project",
             "DataRelease": "Data Release",
             "LearnMore": "Learn More",
-            "CountMeIn": "count me in"
+            "CountMeIn": "count me in",
+            "LanguageSelection": "language selection"
         },
         "Footer": {
             "FooterLogo": "Angiosarcoma<br>Project",

--- a/ddp-workspace/projects/ddp-angio/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-angio/src/assets/i18n/en.json
@@ -16,8 +16,7 @@
             "HeaderLogo": "Angiosarcoma<br>Project",
             "DataRelease": "Data Release",
             "LearnMore": "Learn More",
-            "CountMeIn": "count me in",
-            "LanguageSelection": "language selection"
+            "CountMeIn": "count me in"
         },
         "Footer": {
             "FooterLogo": "Angiosarcoma<br>Project",
@@ -478,6 +477,9 @@
         "SignInOut": {
             "SignIn": "Sign In",
             "SignOut": "Sign Out"
+        },
+        "LanguageSelector": {
+            "LanguageSelection": "language selection"
         },
         "UserActivities": {
             "ActivityName": "Form",

--- a/ddp-workspace/projects/ddp-angio/src/assets/images/globe.svg
+++ b/ddp-workspace/projects/ddp-angio/src/assets/images/globe.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 55.2 (78181) - https://sketchapp.com -->
+    <title>Globe@1x</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <g id="Language-Selector-3" transform="translate(-1243.000000, -20.000000)">
+            <g id="nav-bar" transform="translate(1.000000, 0.000000)">
+                <g id="Globe" transform="translate(1243.000000, 21.000000)">
+                    <g id="earth-3">
+                        <g stroke-width="1.5">
+                            <circle id="Oval" cx="11" cy="11" r="10.3125"></circle>
+                            <path d="M8.51491667,21.0109167 C7.11975,18.9649167 6.1875,15.2469167 6.1875,11 C6.1875,6.75308333 7.11975,3.03508333 8.51491667,0.989083333" id="Shape"></path>
+                            <path d="M0.6875,11 L21.3125,11" id="Shape"></path>
+                            <path d="M2.27516667,16.5 L19.7248333,16.5" id="Shape"></path>
+                            <path d="M2.27516667,5.5 L19.7248333,5.5" id="Shape"></path>
+                            <path d="M13.4850833,0.989083333 C14.88025,3.03508333 15.8125,6.75308333 15.8125,11 C15.8125,15.2469167 14.88025,18.9649167 13.4850833,21.0109167" id="Shape"></path>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/ddp-workspace/projects/ddp-angio/src/styles.scss
+++ b/ddp-workspace/projects/ddp-angio/src/styles.scss
@@ -310,6 +310,7 @@ a:focus {
     stroke: mat-color($app-theme, 100);
     fill: transparent;
     vertical-align: middle;
+    transition: stroke 0.3s ease;
 }
 
 .SimpleButton--Scrolled .ddp-globe {

--- a/ddp-workspace/projects/ddp-angio/src/styles.scss
+++ b/ddp-workspace/projects/ddp-angio/src/styles.scss
@@ -306,6 +306,35 @@ a:focus {
     color: mat-color($app-theme, 600);
 }
 
+.SimpleButton .ddp-globe {
+    stroke: mat-color($app-theme, 100);
+    fill: transparent;
+    vertical-align: middle;
+}
+
+.SimpleButton--Scrolled .ddp-globe {
+    stroke: mat-color($app-theme, 600);
+    fill: transparent;
+}
+
+.SimpleButton:hover .ddp-globe {
+    stroke: mat-color($app-theme, 700);
+    fill: transparent;
+}
+
+.SimpleButton:active .ddp-globe {
+    stroke: mat-color($app-theme, 600);
+    fill: transparent;
+}
+
+.ddp-current-language {
+    vertical-align: middle;
+}
+
+mat-icon.ddp-dropdown-arrow {
+    vertical-align: middle;
+}
+
 .LastUpdatedText {
     text-align: right;
     font-weight: 300;

--- a/ddp-workspace/projects/ddp-brain/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-brain/src/assets/i18n/en.json
@@ -14,7 +14,8 @@
         "Header": {
             "HeaderLogo": "Brain<br>Cancer<br>Project",
             "LearnMore": "Learn More",
-            "CountMeIn": "count me in"
+            "CountMeIn": "count me in",
+            "LanguageSelection": "language selection"
         },
         "Footer": {
             "FooterLogo": "Brain<br>Cancer<br>Project",

--- a/ddp-workspace/projects/ddp-brain/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-brain/src/assets/i18n/en.json
@@ -14,8 +14,7 @@
         "Header": {
             "HeaderLogo": "Brain<br>Cancer<br>Project",
             "LearnMore": "Learn More",
-            "CountMeIn": "count me in",
-            "LanguageSelection": "language selection"
+            "CountMeIn": "count me in"
         },
         "Footer": {
             "FooterLogo": "Brain<br>Cancer<br>Project",
@@ -483,6 +482,9 @@
         "SignInOut": {
             "SignIn": "Sign In",
             "SignOut": "Sign Out"
+        },
+        "LanguageSelector": {
+            "LanguageSelection": "language selection"
         },
         "UserActivities": {
             "ActivityName": "Form",

--- a/ddp-workspace/projects/ddp-brain/src/assets/images/globe.svg
+++ b/ddp-workspace/projects/ddp-brain/src/assets/images/globe.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 55.2 (78181) - https://sketchapp.com -->
+    <title>Globe@1x</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <g id="Language-Selector-3" transform="translate(-1243.000000, -20.000000)">
+            <g id="nav-bar" transform="translate(1.000000, 0.000000)">
+                <g id="Globe" transform="translate(1243.000000, 21.000000)">
+                    <g id="earth-3">
+                        <g stroke-width="1.5">
+                            <circle id="Oval" cx="11" cy="11" r="10.3125"></circle>
+                            <path d="M8.51491667,21.0109167 C7.11975,18.9649167 6.1875,15.2469167 6.1875,11 C6.1875,6.75308333 7.11975,3.03508333 8.51491667,0.989083333" id="Shape"></path>
+                            <path d="M0.6875,11 L21.3125,11" id="Shape"></path>
+                            <path d="M2.27516667,16.5 L19.7248333,16.5" id="Shape"></path>
+                            <path d="M2.27516667,5.5 L19.7248333,5.5" id="Shape"></path>
+                            <path d="M13.4850833,0.989083333 C14.88025,3.03508333 15.8125,6.75308333 15.8125,11 C15.8125,15.2469167 14.88025,18.9649167 13.4850833,21.0109167" id="Shape"></path>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/ddp-workspace/projects/ddp-brain/src/styles.scss
+++ b/ddp-workspace/projects/ddp-brain/src/styles.scss
@@ -309,6 +309,7 @@ a:focus {
     stroke: mat-color($app-theme, 100);
     fill: transparent;
     vertical-align: middle;
+    transition: stroke 0.3s ease;
 }
 
 .SimpleButton--Scrolled .ddp-globe {

--- a/ddp-workspace/projects/ddp-brain/src/styles.scss
+++ b/ddp-workspace/projects/ddp-brain/src/styles.scss
@@ -305,6 +305,35 @@ a:focus {
     color: mat-color($app-theme, 600);
 }
 
+.SimpleButton .ddp-globe {
+    stroke: mat-color($app-theme, 100);
+    fill: transparent;
+    vertical-align: middle;
+}
+
+.SimpleButton--Scrolled .ddp-globe {
+    stroke: mat-color($app-theme, 600);
+    fill: transparent;
+}
+
+.SimpleButton:hover .ddp-globe {
+    stroke: mat-color($app-theme, 700);
+    fill: transparent;
+}
+
+.SimpleButton:active .ddp-globe {
+    stroke: mat-color($app-theme, 600);
+    fill: transparent;
+}
+
+.ddp-current-language {
+    vertical-align: middle;
+}
+
+mat-icon.ddp-dropdown-arrow {
+    vertical-align: middle;
+}
+
 // Footer
 .Footer {
     position: absolute;

--- a/ddp-workspace/projects/ddp-mbc/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-mbc/src/assets/i18n/en.json
@@ -53,7 +53,8 @@
             "HeaderLogo": "Metastatic<br>Breast Cancer<br>Project",
             "DataRelease": "Data Release",
             "LearnMore": "Learn More",
-            "CountMeIn": "count me <span class=\"icon-silhouette\"></span>n"
+            "CountMeIn": "count me <span class=\"icon-silhouette\"></span>n",
+            "LanguageSelection": "language selection"
         },
         "Footer": {
             "FooterLogo": "Metastatic<br>Breast Cancer<br>Project",

--- a/ddp-workspace/projects/ddp-mbc/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-mbc/src/assets/i18n/en.json
@@ -53,8 +53,7 @@
             "HeaderLogo": "Metastatic<br>Breast Cancer<br>Project",
             "DataRelease": "Data Release",
             "LearnMore": "Learn More",
-            "CountMeIn": "count me <span class=\"icon-silhouette\"></span>n",
-            "LanguageSelection": "language selection"
+            "CountMeIn": "count me <span class=\"icon-silhouette\"></span>n"
         },
         "Footer": {
             "FooterLogo": "Metastatic<br>Breast Cancer<br>Project",
@@ -525,6 +524,9 @@
         "SignInOut": {
             "SignIn": "Sign In",
             "SignOut": "Sign Out"
+        },
+        "LanguageSelector": {
+            "LanguageSelection": "language selection"
         },
         "UserActivities": {
             "ActivityName": "Form",

--- a/ddp-workspace/projects/ddp-mbc/src/assets/images/globe.svg
+++ b/ddp-workspace/projects/ddp-mbc/src/assets/images/globe.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 55.2 (78181) - https://sketchapp.com -->
+    <title>Globe@1x</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <g id="Language-Selector-3" transform="translate(-1243.000000, -20.000000)">
+            <g id="nav-bar" transform="translate(1.000000, 0.000000)">
+                <g id="Globe" transform="translate(1243.000000, 21.000000)">
+                    <g id="earth-3">
+                        <g stroke-width="1.5">
+                            <circle id="Oval" cx="11" cy="11" r="10.3125"></circle>
+                            <path d="M8.51491667,21.0109167 C7.11975,18.9649167 6.1875,15.2469167 6.1875,11 C6.1875,6.75308333 7.11975,3.03508333 8.51491667,0.989083333" id="Shape"></path>
+                            <path d="M0.6875,11 L21.3125,11" id="Shape"></path>
+                            <path d="M2.27516667,16.5 L19.7248333,16.5" id="Shape"></path>
+                            <path d="M2.27516667,5.5 L19.7248333,5.5" id="Shape"></path>
+                            <path d="M13.4850833,0.989083333 C14.88025,3.03508333 15.8125,6.75308333 15.8125,11 C15.8125,15.2469167 14.88025,18.9649167 13.4850833,21.0109167" id="Shape"></path>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/ddp-workspace/projects/ddp-mbc/src/styles.scss
+++ b/ddp-workspace/projects/ddp-mbc/src/styles.scss
@@ -299,6 +299,7 @@ a:focus {
     stroke: mat-color($app-theme, 100);
     fill: transparent;
     vertical-align: middle;
+    transition: stroke 0.3s ease;
 }
 
 .SimpleButton--Scrolled .ddp-globe {

--- a/ddp-workspace/projects/ddp-mbc/src/styles.scss
+++ b/ddp-workspace/projects/ddp-mbc/src/styles.scss
@@ -295,6 +295,35 @@ a:focus {
     color: mat-color($app-theme, 600);
 }
 
+.SimpleButton .ddp-globe {
+    stroke: mat-color($app-theme, 100);
+    fill: transparent;
+    vertical-align: middle;
+}
+
+.SimpleButton--Scrolled .ddp-globe {
+    stroke: mat-color($app-theme, 600);
+    fill: transparent;
+}
+
+.SimpleButton:hover .ddp-globe {
+    stroke: mat-color($app-theme, 700);
+    fill: transparent;
+}
+
+.SimpleButton:active .ddp-globe {
+    stroke: mat-color($app-theme, 600);
+    fill: transparent;
+}
+
+.ddp-current-language {
+    vertical-align: middle;
+}
+
+mat-icon.ddp-dropdown-arrow {
+    vertical-align: middle;
+}
+
 // Footer
 .Footer {
     position: absolute;

--- a/ddp-workspace/projects/ddp-osteo/src/assets/images/globe.svg
+++ b/ddp-workspace/projects/ddp-osteo/src/assets/images/globe.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 55.2 (78181) - https://sketchapp.com -->
+    <title>Globe@1x</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <g id="Language-Selector-3" transform="translate(-1243.000000, -20.000000)">
+            <g id="nav-bar" transform="translate(1.000000, 0.000000)">
+                <g id="Globe" transform="translate(1243.000000, 21.000000)">
+                    <g id="earth-3">
+                        <g stroke-width="1.5">
+                            <circle id="Oval" cx="11" cy="11" r="10.3125"></circle>
+                            <path d="M8.51491667,21.0109167 C7.11975,18.9649167 6.1875,15.2469167 6.1875,11 C6.1875,6.75308333 7.11975,3.03508333 8.51491667,0.989083333" id="Shape"></path>
+                            <path d="M0.6875,11 L21.3125,11" id="Shape"></path>
+                            <path d="M2.27516667,16.5 L19.7248333,16.5" id="Shape"></path>
+                            <path d="M2.27516667,5.5 L19.7248333,5.5" id="Shape"></path>
+                            <path d="M13.4850833,0.989083333 C14.88025,3.03508333 15.8125,6.75308333 15.8125,11 C15.8125,15.2469167 14.88025,18.9649167 13.4850833,21.0109167" id="Shape"></path>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/ddp-workspace/projects/ddp-prion/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-prion/src/assets/i18n/en.json
@@ -14,8 +14,7 @@
         "Header": {
             "HeaderLogo": "Prion<br>Registry",
             "LearnMore": "Learn More",
-            "CountMeIn": "count me in",
-            "LanguageSelection": "language selection"
+            "CountMeIn": "count me in"
         },
         "Footer": {
             "FooterLogo": "Prion<br>Registry",
@@ -231,6 +230,9 @@
         "SignInOut": {
             "SignIn": "Sign In",
             "SignOut": "Sign Out"
+        },
+        "LanguageSelector": {
+            "LanguageSelection": "language selection"
         },
         "UserActivities": {
             "ActivityName": "Form",

--- a/ddp-workspace/projects/ddp-prion/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-prion/src/assets/i18n/en.json
@@ -14,7 +14,8 @@
         "Header": {
             "HeaderLogo": "Prion<br>Registry",
             "LearnMore": "Learn More",
-            "CountMeIn": "count me in"
+            "CountMeIn": "count me in",
+            "LanguageSelection": "language selection"
         },
         "Footer": {
             "FooterLogo": "Prion<br>Registry",

--- a/ddp-workspace/projects/ddp-prion/src/assets/images/globe.svg
+++ b/ddp-workspace/projects/ddp-prion/src/assets/images/globe.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 55.2 (78181) - https://sketchapp.com -->
+    <title>Globe@1x</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <g id="Language-Selector-3" transform="translate(-1243.000000, -20.000000)">
+            <g id="nav-bar" transform="translate(1.000000, 0.000000)">
+                <g id="Globe" transform="translate(1243.000000, 21.000000)">
+                    <g id="earth-3">
+                        <g stroke-width="1.5">
+                            <circle id="Oval" cx="11" cy="11" r="10.3125"></circle>
+                            <path d="M8.51491667,21.0109167 C7.11975,18.9649167 6.1875,15.2469167 6.1875,11 C6.1875,6.75308333 7.11975,3.03508333 8.51491667,0.989083333" id="Shape"></path>
+                            <path d="M0.6875,11 L21.3125,11" id="Shape"></path>
+                            <path d="M2.27516667,16.5 L19.7248333,16.5" id="Shape"></path>
+                            <path d="M2.27516667,5.5 L19.7248333,5.5" id="Shape"></path>
+                            <path d="M13.4850833,0.989083333 C14.88025,3.03508333 15.8125,6.75308333 15.8125,11 C15.8125,15.2469167 14.88025,18.9649167 13.4850833,21.0109167" id="Shape"></path>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/ddp-workspace/projects/ddp-prion/src/styles.scss
+++ b/ddp-workspace/projects/ddp-prion/src/styles.scss
@@ -310,6 +310,7 @@ a:focus {
     stroke: mat-color($app-theme, 100);
     fill: transparent;
     vertical-align: middle;
+    transition: stroke 0.3s ease;
 }
 
 .SimpleButton--Scrolled .ddp-globe {

--- a/ddp-workspace/projects/ddp-prion/src/styles.scss
+++ b/ddp-workspace/projects/ddp-prion/src/styles.scss
@@ -290,20 +290,62 @@ a:focus {
     font-weight: 300;
     text-decoration: none;
     color: mat-color($app-theme, 100);
+    //stroke: mat-color($app-theme, 100); //TODO: Maybe put back
+    //fill: transparent;  //TODO: Maybe put back
 }
 
 .SimpleButton--Scrolled {
     color: mat-color($app-theme, 600);
+    //stroke: mat-color($app-theme, 600);  //TODO: Maybe put back
+    //fill: transparent;  //TODO: Maybe put back
 }
 
 .SimpleButton:hover {
     color: mat-color($app-theme, 700);
+    //stroke: mat-color($app-theme, 700);  //TODO: Maybe put back
+    //fill: transparent; //TODO: Maybe put back
     text-decoration: none;
 }
 
 .SimpleButton:active {
     text-decoration: none;
     color: mat-color($app-theme, 600);
+    //stroke: mat-color($app-theme, 600); //TODO: Maybe put back
+    //fill: transparent; //TODO: Maybe put back
+}
+
+//TODO: Make changes to stylesheets for other studies
+.SimpleButton .ddp-globe {
+    stroke: mat-color($app-theme, 100); //TODO: Maybe put back
+    fill: transparent;  //TODO: Maybe put back
+    height: 24px;
+    width: 24px;
+    vertical-align: bottom;
+}
+
+.SimpleButton--Scrolled .ddp-globe {
+    stroke: mat-color($app-theme, 600);  //TODO: Maybe put back
+    fill: transparent;  //TODO: Maybe put back
+}
+
+.SimpleButton:hover .ddp-globe {
+    stroke: mat-color($app-theme, 700);  //TODO: Maybe put back
+    fill: transparent; //TODO: Maybe put back
+}
+
+.SimpleButton:active .ddp-globe {
+    stroke: mat-color($app-theme, 600); //TODO: Maybe put back
+    fill: transparent; //TODO: Maybe put back
+}
+
+//TODO: Figure out the below stuff
+.ddp-current-language {
+  line-height: 1.6em;
+  min-height: 24px;
+}
+
+mat-icon.ddp-dropdown-arrow {
+    vertical-align: bottom;
 }
 
 .LastUpdatedText {

--- a/ddp-workspace/projects/ddp-prion/src/styles.scss
+++ b/ddp-workspace/projects/ddp-prion/src/styles.scss
@@ -290,62 +290,49 @@ a:focus {
     font-weight: 300;
     text-decoration: none;
     color: mat-color($app-theme, 100);
-    //stroke: mat-color($app-theme, 100); //TODO: Maybe put back
-    //fill: transparent;  //TODO: Maybe put back
 }
 
 .SimpleButton--Scrolled {
     color: mat-color($app-theme, 600);
-    //stroke: mat-color($app-theme, 600);  //TODO: Maybe put back
-    //fill: transparent;  //TODO: Maybe put back
 }
 
 .SimpleButton:hover {
     color: mat-color($app-theme, 700);
-    //stroke: mat-color($app-theme, 700);  //TODO: Maybe put back
-    //fill: transparent; //TODO: Maybe put back
     text-decoration: none;
 }
 
 .SimpleButton:active {
     text-decoration: none;
     color: mat-color($app-theme, 600);
-    //stroke: mat-color($app-theme, 600); //TODO: Maybe put back
-    //fill: transparent; //TODO: Maybe put back
 }
 
-//TODO: Make changes to stylesheets for other studies
 .SimpleButton .ddp-globe {
-    stroke: mat-color($app-theme, 100); //TODO: Maybe put back
-    fill: transparent;  //TODO: Maybe put back
-    height: 24px;
-    width: 24px;
-    vertical-align: bottom;
+    stroke: mat-color($app-theme, 100);
+    fill: transparent;
+    vertical-align: middle;
 }
 
 .SimpleButton--Scrolled .ddp-globe {
-    stroke: mat-color($app-theme, 600);  //TODO: Maybe put back
-    fill: transparent;  //TODO: Maybe put back
+    stroke: mat-color($app-theme, 600);
+    fill: transparent;
 }
 
 .SimpleButton:hover .ddp-globe {
-    stroke: mat-color($app-theme, 700);  //TODO: Maybe put back
-    fill: transparent; //TODO: Maybe put back
+    stroke: mat-color($app-theme, 700);
+    fill: transparent;
 }
 
 .SimpleButton:active .ddp-globe {
-    stroke: mat-color($app-theme, 600); //TODO: Maybe put back
-    fill: transparent; //TODO: Maybe put back
+    stroke: mat-color($app-theme, 600);
+    fill: transparent;
 }
 
-//TODO: Figure out the below stuff
 .ddp-current-language {
-  line-height: 1.6em;
-  min-height: 24px;
+  vertical-align: middle;
 }
 
 mat-icon.ddp-dropdown-arrow {
-    vertical-align: bottom;
+  vertical-align: middle;
 }
 
 .LastUpdatedText {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/languageSelector.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/languageSelector.component.ts
@@ -1,0 +1,97 @@
+import { Component, Input, OnInit } from "@angular/core";
+import { StudyLanguage } from "../models/studyLanguage";
+import { LanguageServiceAgent } from "../services/serviceAgents/languageServiceAgent.service";
+import { LanguageService } from "ddp-sdk";
+
+@Component({
+  selector: 'ddp-language-selector',
+  template: `
+    <div [hidden]="!loaded">
+      <button class="SimpleButton" [ngClass]="{'SimpleButton--Scrolled': isScrolled}" *ngIf="currentLanguage !== null && currentLanguage !== undefined" [matMenuTriggerFor]="menu">
+        <svg class="ddp-globe">
+          <use href="assets/images/globe.svg#Language-Selector-3" height="24px" width="24px"></use>
+        </svg>
+        <span class="ddp-current-language">{{currentLanguage.displayName}}</span>
+        <mat-icon class="ddp-dropdown-arrow">arrow_drop_down</mat-icon>
+      </button>
+      
+      <mat-menu #menu="matMenu">
+        <button mat-menu-item *ngFor="let lang of getUnselectedLanguages()" (click)="changeLanguage(lang)">{{lang.displayName}}</button>
+      </mat-menu>
+    </div>
+  `
+})
+export class LanguageSelectorComponent implements OnInit {
+
+  //TODO: Figure out if all of these fields are necessary
+  @Input() studyGuid: string;
+  @Input() isScrolled: boolean;
+  public loaded: boolean;
+  private studyLanguages: Array<StudyLanguage>;
+  private defaultLanguage: StudyLanguage;
+  private currentLanguage: StudyLanguage;
+  public isLoadingError = false;
+  public isNoDefaultFoundError = false;
+
+  constructor (
+    private serviceAgent: LanguageServiceAgent
+  ) { }
+
+  public ngOnInit(): void {
+    //TODO: Figure out if this can be simplified
+    //TODO: Do something with the error messages
+    //TODO: Handle case where exactly one language is configured
+    //TODO: Make sure we handle the case where no languages have been configured cleanly
+    //TODO: Handle case where user is logged in and we can get the language from the profile
+    //TODO: Store current language in session storage and check session storage in case we are returning from Auth0 or something
+    //TODO: Test navigating to different pages
+    this.serviceAgent.getConfiguredLanguages(this.studyGuid).subscribe(x => {
+      if (x) {
+        console.log('got configured languages: ' + JSON.stringify(x));
+        this.isLoadingError = false;
+        this.studyLanguages = x;
+        this.findDefaultLanguage();
+        if (this.currentLanguage == null) {
+          this.currentLanguage = this.defaultLanguage;
+        }
+        if (this.studyLanguages === null) {
+          this.isLoadingError = true;
+        }
+        else {
+          this.loaded = true;
+        }
+      } else {
+        this.isLoadingError = true;
+      }
+    });
+  }
+
+  private findDefaultLanguage(): void {
+    //TODO: Check if this can be simplified
+    this.isNoDefaultFoundError = false;
+    let lang: StudyLanguage = this.studyLanguages.find(element => element.isDefault === true);
+    if (lang !== undefined && lang !== null) {
+      this.defaultLanguage = lang;
+    } else {
+      this.isNoDefaultFoundError = true;
+    }
+  }
+
+  private getUnselectedLanguages(): Array<StudyLanguage> {
+    //TODO: Check if this can be simplified
+    if (this.studyLanguages !== null  && this.studyLanguages !== undefined) {
+      return this.studyLanguages.filter(elem => elem !== this.currentLanguage);
+    }
+   return null;
+  }
+
+  public changeLanguage(lang: StudyLanguage) {
+    this.currentLanguage = lang;
+
+
+
+    //TODO: Implement this!
+  }
+
+
+}

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/languageSelector.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/languageSelector.component.ts
@@ -9,7 +9,8 @@ import { TranslateService } from "@ngx-translate/core";
   template: `
     <div [hidden]="!loaded">
       <button class="SimpleButton" [ngClass]="{'SimpleButton--Scrolled': isScrolled}" *ngIf="currentLanguage !== null && currentLanguage !== undefined" [matMenuTriggerFor]="menu">
-        <svg class="ddp-globe" height="24px" width="24px">
+        <svg class="ddp-globe" height="24px" width="24px" aria-live="title">
+          <title id="title" [lang]="currentLanguage.languageCode" translate>Toolkit.Header.LanguageSelection</title>
           <use href="assets/images/globe.svg#Language-Selector-3"></use>
         </svg>
         <span class="ddp-current-language">{{currentLanguage.displayName}}</span>

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/languageSelector.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/languageSelector.component.ts
@@ -12,7 +12,7 @@ import { Subscription } from "rxjs";
     <div [hidden]="!loaded">
       <button class="SimpleButton" [ngClass]="{'SimpleButton--Scrolled': isScrolled}" *ngIf="currentLanguage !== null && currentLanguage !== undefined" [matMenuTriggerFor]="menu">
         <svg class="ddp-globe" height="24px" width="24px">
-          <title id="title" [lang]="currentLanguage.languageCode" translate>Toolkit.Header.LanguageSelection</title>
+          <title id="title" [lang]="currentLanguage.languageCode" translate>SDK.LanguageSelector.LanguageSelection</title>
           <use [attr.href]="iconURL"></use>
         </svg>
         <span class="ddp-current-language">{{currentLanguage.displayName}}</span>

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/languageSelector.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/languageSelector.component.ts
@@ -8,8 +8,8 @@ import { LanguageService } from "ddp-sdk";
   template: `
     <div [hidden]="!loaded">
       <button class="SimpleButton" [ngClass]="{'SimpleButton--Scrolled': isScrolled}" *ngIf="currentLanguage !== null && currentLanguage !== undefined" [matMenuTriggerFor]="menu">
-        <svg class="ddp-globe">
-          <use href="assets/images/globe.svg#Language-Selector-3" height="24px" width="24px"></use>
+        <svg class="ddp-globe" height="24px" width="24px">
+          <use href="assets/images/globe.svg#Language-Selector-3"></use>
         </svg>
         <span class="ddp-current-language">{{currentLanguage.displayName}}</span>
         <mat-icon class="ddp-dropdown-arrow">arrow_drop_down</mat-icon>
@@ -44,7 +44,6 @@ export class LanguageSelectorComponent implements OnInit {
     //TODO: Make sure we handle the case where no languages have been configured cleanly
     //TODO: Handle case where user is logged in and we can get the language from the profile
     //TODO: Store current language in session storage and check session storage in case we are returning from Auth0 or something
-    //TODO: Test navigating to different pages
     this.serviceAgent.getConfiguredLanguages(this.studyGuid).subscribe(x => {
       if (x) {
         console.log('got configured languages: ' + JSON.stringify(x));

--- a/ddp-workspace/projects/ddp-sdk/src/lib/ddp.module.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/ddp.module.ts
@@ -169,6 +169,8 @@ import { RenewSessionNotifier } from './services/renewSessionNotifier.service';
 
 import { AuthInterceptor } from './interceptors/auth-interceptor.service';
 import { InvitationCodeFormatterDirective } from './directives/invitationCodeFormatter.directive';
+import { LanguageSelectorComponent } from "./components/languageSelector.component";
+import { LanguageServiceAgent } from "./services/serviceAgents/languageServiceAgent.service";
 
 import { InvitationPipe } from './pipes/invitationFormatter.pipe';
 
@@ -252,6 +254,7 @@ export function createTranslateLoader(http: HttpClient): TranslateHttpLoader {
     PrequalifierServiceAgent,
     GovernedParticipantsServiceAgent,
     ActivityInstanceStatusServiceAgent,
+    LanguageServiceAgent,
     MailingListServiceAgent,
     ActivityValidatorBuilder,
     ActivitySuggestionBuilder,
@@ -327,6 +330,7 @@ export function createTranslateLoader(http: HttpClient): TranslateHttpLoader {
     LoadingComponent,
     LoaderComponent,
     UserMenuComponent,
+    LanguageSelectorComponent,
     ManageParticipantsComponent,
     Auth0CodeCallbackComponent,
     RedirectToAuth0LoginComponent,
@@ -386,6 +390,7 @@ export function createTranslateLoader(http: HttpClient): TranslateHttpLoader {
     LoadingComponent,
     LoaderComponent,
     UserMenuComponent,
+    LanguageSelectorComponent,
     ManageParticipantsComponent,
     RedirectToAuth0LoginComponent,
     Auth0CodeCallbackComponent,

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/studyLanguage.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/studyLanguage.ts
@@ -1,0 +1,5 @@
+export class StudyLanguage {
+  languageCode: string;
+  displayName: string;
+  isDefault: boolean;
+}

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/configuration.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/configuration.service.ts
@@ -33,4 +33,6 @@ export class ConfigurationService {
     // their question count
     dashboardShowQuestionCountExceptions: string[] = [];
     tooltipIconUrl: string = '';
+    // must be a 24x24 svg icon.  To make sure colors match, do not specify a stroke color
+    languageSelectorIconURL: string | null = null;
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/languageService.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/languageService.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import { isNullOrUndefined } from "util";
 
 @Injectable()
 export class LanguageService {
@@ -7,5 +8,34 @@ export class LanguageService {
 
     public getCurrentLanguage(): string {
         return this.translate.currentLang;
+    }
+
+    public canUseLanguage(languageCode: string): boolean {
+      if (isNullOrUndefined(languageCode)) {
+        return false;
+      }
+      return this.translate.getLangs().includes(languageCode);
+    }
+
+    public addLanguages(languageCodes: Array<string>): void {
+      this.translate.addLangs(languageCodes);
+    }
+
+    public useStoredLanguage(): string {
+      let loadedCode: string = localStorage.getItem('studyLanguage');
+      if (this.changeLanguage(loadedCode)) {
+        return loadedCode;
+      }
+      return null;
+    }
+
+    public changeLanguage(languageCode: string): boolean {
+      if (this.canUseLanguage(languageCode)) {
+        this.translate.use(languageCode);
+        localStorage.setItem('studyLanguage', languageCode);
+        return true;
+      }
+
+      return false;
     }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/languageServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/languageServiceAgent.service.ts
@@ -1,0 +1,21 @@
+import { Inject, Injectable } from "@angular/core";
+import { StudyLanguage } from "../../models/studyLanguage";
+import { NotAuthenticatedServiceAgent } from "./notAuthenticatedServiceAgent.service";
+import { LoggingService } from '../logging.service';
+import { ConfigurationService } from '../configuration.service';
+import { Observable } from "rxjs";
+import { HttpClient } from "@angular/common/http";
+
+@Injectable()
+export class LanguageServiceAgent extends NotAuthenticatedServiceAgent<Array<StudyLanguage>> {
+  constructor(
+    @Inject('ddp.config') configuration: ConfigurationService,
+    http: HttpClient,
+    logger: LoggingService) {
+    super(configuration, http, logger);
+  }
+
+  public getConfiguredLanguages(studyGuid: string): Observable<Array<StudyLanguage>> {
+    return this.getObservable(`/studies/${studyGuid}/languages`);
+  }
+}

--- a/ddp-workspace/projects/ddp-testboston/src/assets/images/globe.svg
+++ b/ddp-workspace/projects/ddp-testboston/src/assets/images/globe.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 55.2 (78181) - https://sketchapp.com -->
+    <title>Globe@1x</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <g id="Language-Selector-3" transform="translate(-1243.000000, -20.000000)">
+            <g id="nav-bar" transform="translate(1.000000, 0.000000)">
+                <g id="Globe" transform="translate(1243.000000, 21.000000)">
+                    <g id="earth-3">
+                        <g stroke-width="1.5">
+                            <circle id="Oval" cx="11" cy="11" r="10.3125"></circle>
+                            <path d="M8.51491667,21.0109167 C7.11975,18.9649167 6.1875,15.2469167 6.1875,11 C6.1875,6.75308333 7.11975,3.03508333 8.51491667,0.989083333" id="Shape"></path>
+                            <path d="M0.6875,11 L21.3125,11" id="Shape"></path>
+                            <path d="M2.27516667,16.5 L19.7248333,16.5" id="Shape"></path>
+                            <path d="M2.27516667,5.5 L19.7248333,5.5" id="Shape"></path>
+                            <path d="M13.4850833,0.989083333 C14.88025,3.03508333 15.8125,6.75308333 15.8125,11 C15.8125,15.2469167 14.88025,18.9649167 13.4850833,21.0109167" id="Shape"></path>
+                        </g>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/ddp-workspace/projects/toolkit/src/lib/components/header/header.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/header/header.component.ts
@@ -29,6 +29,9 @@ import { AnalyticsEventsService, BrowserContentService, WindowRef, AnalyticsEven
     </div>
     <nav class="Header-nav" ngClass.xs="Header-nav--small">
         <ul class="Header-navList" ngClass.xs="Header-navList--small">
+            <li class="Header-navItem">
+              <ddp-language-selector [studyGuid]="toolkitConfiguration.studyGuid" [isScrolled]="isScrolled"></ddp-language-selector>
+            </li>
             <li *ngIf="showButtons && showDataRelease" class="Header-navItem" fxShow="false" fxShow.gt-sm>
                 <span [routerLink]="['/data-release']" class="SimpleButton" [ngClass]="{'SimpleButton--Scrolled': isScrolled}" translate>
                     Toolkit.Header.DataRelease

--- a/ddp-workspace/projects/toolkit/src/lib/components/header/header.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/header/header.component.ts
@@ -30,7 +30,7 @@ import { AnalyticsEventsService, BrowserContentService, WindowRef, AnalyticsEven
     <nav class="Header-nav" ngClass.xs="Header-nav--small">
         <ul class="Header-navList" ngClass.xs="Header-navList--small">
             <li class="Header-navItem">
-              <ddp-language-selector [studyGuid]="toolkitConfiguration.studyGuid" [isScrolled]="isScrolled"></ddp-language-selector>
+              <ddp-language-selector [isScrolled]="isScrolled"></ddp-language-selector>
             </li>
             <li *ngIf="showButtons && showDataRelease" class="Header-navItem" fxShow="false" fxShow.gt-sm>
                 <span [routerLink]="['/data-release']" class="SimpleButton" [ngClass]="{'SimpleButton--Scrolled': isScrolled}" translate>


### PR DESCRIPTION
This pull request covers DDP-4719.  It adds a language selector component to the header for studies with more than one configured language.  This does not cover the work to read the user's language from the profile or write the user's language to the profile or the work to pass the language to the Auth0 universal login (or to display the language selector on the Auth0 universal login page).  This does cover the work to do the translations for an unauthenticated user.