### PR TITLE
DDP-4744 pass user timezone during signup

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/login/auth0-code-callback.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/login/auth0-code-callback.component.ts
@@ -48,6 +48,9 @@ export class Auth0CodeCallbackComponent implements OnInit, OnDestroy {
                 ...(params['invitation_id'] && {
                     invitationId: params['invitation_id']
                 }),
+                ...(params['time_zone'] && {
+                    timeZone: params['time_zone']
+                }),
                 ...(params['language'] && {
                     languageCode: params['language']
                 })

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/authentication/auth0Adapter.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/authentication/auth0Adapter.service.ts
@@ -140,6 +140,7 @@ export class Auth0AdapterService implements OnDestroy {
             ...(additionalParams && {
                 ...additionalParams
             }),
+            time_zone: Intl.DateTimeFormat().resolvedOptions().timeZone || null,
             language: this.language.getCurrentLanguage(),
             // @todo : hack delete when done
             serverUrl: this.configuration.backendUrl


### PR DESCRIPTION
When signing up new user, pass along their timezone to Auth0.

See https://github.com/broadinstitute/ddp-study-server/pull/262.