### PR TITLE
DDP-4729 initialize picklist exclusive state

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/baseActivityPicklistQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/baseActivityPicklistQuestion.component.ts
@@ -38,6 +38,22 @@ export class BaseActivityPicklistQuestion implements OnChanges, OnDestroy {
         this.anchor.unsubscribe();
     }
 
+    public hasSelectedExclusiveOption(): boolean {
+        const allOptions = new Map();
+        this.block.picklistGroups
+            .forEach(group => group.options
+                .forEach(option => allOptions.set(option.stableId, option)));
+        this.block.picklistOptions.forEach(option => allOptions.set(option.stableId, option));
+        let hasExclusive = false;
+        if (this.block.answer) {
+            hasExclusive = this.block.answer.some(selected => {
+                const option = allOptions.get(selected.stableId);
+                return option && option.exclusive;
+            });
+        }
+        return hasExclusive;
+    }
+
     public updateCharactersLeftIndicator(id: string, value?: string): void {
         const answer = (value || value === '') ? value : this.getSavedAnswer(id);
         let difference = this.block.detailMaxLength - answer.length;

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/checkboxesActivityPicklistQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/checkboxesActivityPicklistQuestion.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { BaseActivityPicklistQuestion } from './baseActivityPicklistQuestion.component';
 import { ActivityPicklistAnswerDto } from '../../../models/activity/activityPicklistAnswerDto';
 import { PicklistSelectMode } from './../../../models/activity/picklistSelectMode';
@@ -81,7 +81,7 @@ import { NGXTranslateService } from '../../../services/internationalization/ngxT
     }
     `]
 })
-export class CheckboxesActivityPicklistQuestion extends BaseActivityPicklistQuestion {
+export class CheckboxesActivityPicklistQuestion extends BaseActivityPicklistQuestion implements OnInit {
     /**
      * If an option is marked exclusive, then when it's selected all other options should be de-selected.
      */
@@ -93,6 +93,10 @@ export class CheckboxesActivityPicklistQuestion extends BaseActivityPicklistQues
 
     constructor(private translate: NGXTranslateService) {
         super(translate);
+    }
+
+    public ngOnInit(): void {
+        this.exclusiveChosen = this.hasSelectedExclusiveOption();
     }
 
     public setDetailText(id: string): string | null {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/dropdownActivityPicklistQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/dropdownActivityPicklistQuestion.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { MatSelectChange } from '@angular/material/select';
 import { BaseActivityPicklistQuestion } from './baseActivityPicklistQuestion.component';
 import { ActivityPicklistAnswerDto } from '../../../models/activity/activityPicklistAnswerDto';
@@ -62,7 +62,7 @@ import { NGXTranslateService } from '../../../services/internationalization/ngxT
         }
     `]
 })
-export class DropdownActivityPicklistQuestion extends BaseActivityPicklistQuestion {
+export class DropdownActivityPicklistQuestion extends BaseActivityPicklistQuestion implements OnInit {
     public details: ActivityPicklistDetails;
     /**
      * If an option is marked exclusive, then when it's selected all other options should be de-selected.
@@ -72,6 +72,10 @@ export class DropdownActivityPicklistQuestion extends BaseActivityPicklistQuesti
     constructor(private translate: NGXTranslateService) {
         super(translate);
         this.details = new ActivityPicklistDetails();
+    }
+
+    public ngOnInit(): void {
+        this.exclusiveChosen = this.hasSelectedExclusiveOption();
     }
 
     public setMaterialSelected(): Array<string> | string {


### PR DESCRIPTION
Fixes DDP-4729. Issue is that we're not initializing the `exclusiveChosen` flag appropriately upon first rendering the picklist.