### PR TITLE
Added dispatch.yaml entries for dsm running on GAE

### DIFF
--- a/config/deployment/dev/dispatch.yaml
+++ b/config/deployment/dev/dispatch.yaml
@@ -18,3 +18,7 @@ dispatch:
     service: pepper-backend
   - url: "pepper-dev.datadonationplatform.org/*"
     service: pepper-backend
+  - url: "dsm.dev.datadonationplatform.org/api/*"
+    service: study-manager-backend
+  - url: "dsm.dev.datadonationplatform.org/*"
+    service: study-manager-ui

--- a/config/deployment/prod/dispatch.yaml
+++ b/config/deployment/prod/dispatch.yaml
@@ -13,3 +13,7 @@ dispatch:
     service: pepper-backend
   - url: "pepper.datadonationplatform.org/*"
     service: pepper-backend
+  - url: "dsm.datadonationplatform.org/api/*"
+    service: study-manager-backend
+  - url: "dsm.datadonationplatform.org/*"
+    service: study-manager-ui

--- a/config/deployment/staging/dispatch.yaml
+++ b/config/deployment/staging/dispatch.yaml
@@ -13,3 +13,7 @@ dispatch:
     service: pepper-backend
   - url: "pepper-staging.datadonationplatform.org/*"
     service: pepper-backend
+  - url: "dsm.staging.datadonationplatform.org/api/*"
+    service: study-manager-backend
+  - url: "dsm.staging.datadonationplatform.org/*"
+    service: study-manager-ui

--- a/config/deployment/test/dispatch.yaml
+++ b/config/deployment/test/dispatch.yaml
@@ -13,3 +13,7 @@ dispatch:
     service: pepper-backend
   - url: "pepper-test.datadonationplatform.org/*"
     service: pepper-backend
+  - url: "dsm.test.datadonationplatform.org/api/*"
+    service: study-manager-backend
+  - url: "dsm.test.datadonationplatform.org/*"
+    service: study-manager-ui


### PR DESCRIPTION
As part of [DSM migration to GAE](https://docs.google.com/document/d/1FcM6eL8tYxJbUxVJP2PczgP22nXzBJg0VA1FzEzpYX8), we needed  to update our `dispatch.yaml`.