### PR TITLE
Dispatch.yaml fixes for DSM on GAE

### DIFF
--- a/config/deployment/dev/dispatch.yaml
+++ b/config/deployment/dev/dispatch.yaml
@@ -20,5 +20,9 @@ dispatch:
     service: pepper-backend
   - url: "dsm.dev.datadonationplatform.org/api/*"
     service: study-manager-backend
+  - url: "dsm.dev.datadonationplatform.org/app/*"
+    service: study-manager-backend
+  - url: "dsm.dev.datadonationplatform.org/info/*"
+    service: study-manager-backend
   - url: "dsm.dev.datadonationplatform.org/*"
     service: study-manager-ui


### PR DESCRIPTION
Added two new dispatch paths to fix calls from study-server that were getting blobs of html instead of APIs.