### PR TITLE
Ddp 4773 auth0 internationalization support

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/changeLanguageRedirect.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/changeLanguageRedirect.component.ts
@@ -1,0 +1,91 @@
+import { Component, Inject, OnInit } from "@angular/core";
+import { ActivatedRoute, Router } from "@angular/router";
+import { Observable } from "rxjs";
+import { map, take } from "rxjs/operators";
+import { StudyLanguage } from "../models/studyLanguage";
+import { ConfigurationService } from "../services/configuration.service";
+import { LanguageService} from "../services/languageService.service";
+import { LanguageServiceAgent } from "../services/serviceAgents/languageServiceAgent.service";
+
+@Component({
+  selector: 'ddp-change-language-redirect',
+  template: `<ng-container></ng-container>`
+})
+export class ChangeLanguageRedirectComponent implements OnInit {
+  private lang: string = null;
+  private supportedLanguages: StudyLanguage[] = null;
+
+  //The destination to redirect to, relative to the main site
+  private dest: string = null;
+
+  //Optionally, a parameter to pass through to the destination to redirect to
+  private queryParamValue: string = null;
+
+  constructor(
+    private languageService: LanguageService,
+    private languageServiceAgent: LanguageServiceAgent,
+    private route: ActivatedRoute,
+    private router: Router,
+    @Inject('ddp.config') private config: ConfigurationService) {
+  }
+
+  public ngOnInit(): void {
+    //Get the specified language and specified destination and store for later
+    let paramPromise: Promise<void> = this.getParamInfo();
+
+    //Get any parameters to pass through to specified destination
+    let queryParamPromise: Promise<void> = this.getQueryParamInfo();
+
+    //Get the study's configured languages and store for later
+    let supportedLanguagesPromise: Promise<void> = this.getSupportedLanguagesPromise();
+
+    //Attempt to change language and redirect
+    Promise.all([paramPromise, queryParamPromise, supportedLanguagesPromise])
+      .then(() => {
+        //Add the configured languages
+        this.languageService.addLanguages(this.supportedLanguages.map(x => x.languageCode));
+
+        //Try to switch to the specified language
+        let langChangePromise: Promise<any> = this.languageService.changeLanguagePromise(this.lang);
+        langChangePromise.catch(reason => {
+          console.log(`Could not change language to ${this.lang}: ${reason}.`);
+        }).then(() => {
+          console.log(`Changed language to ${this.languageService.getCurrentLanguage()}`);
+        }).finally(() => {
+          //Do the redirect
+          let destName = this.dest;
+          if (this.queryParamValue) {
+            destName = destName + '/' + this.queryParamValue;
+          }
+
+          this.router.navigate([destName], {relativeTo: this.route.root});
+          });
+      });
+  }
+
+  private getSupportedLanguagesPromise(): Promise<void> {
+    return this.getPromiseFromObservable(this.languageServiceAgent.getConfiguredLanguages(this.config.studyGuid),
+      (languages => {this.supportedLanguages = languages}));
+  }
+
+  private getParamInfo(): Promise<void> {
+    return this.getPromiseFromObservable(this.route.paramMap, (params => {
+      this.lang = params.get('language');
+      this.dest = params.get('destination');
+    }));
+  }
+
+  private getQueryParamInfo(): Promise<void> {
+    return this.getPromiseFromObservable(this.route.queryParamMap, (queryParams => {
+      if (queryParams.has('destParamValue')) {
+        this.queryParamValue = queryParams.get('destParamValue');
+      }
+    }));
+  }
+
+  private getPromiseFromObservable(obs: Observable<any>, callback: (obsResult: any) => any): Promise<void> {
+    //Return a promise that calls the provided callback with the first value returned from the observable
+    return obs.pipe(take(1))
+      .pipe(map(x => callback(x))).toPromise();
+  }
+}

--- a/ddp-workspace/projects/ddp-sdk/src/lib/ddp.module.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/ddp.module.ts
@@ -170,6 +170,7 @@ import { RenewSessionNotifier } from './services/renewSessionNotifier.service';
 import { AuthInterceptor } from './interceptors/auth-interceptor.service';
 import { InvitationCodeFormatterDirective } from './directives/invitationCodeFormatter.directive';
 import { LanguageSelectorComponent } from "./components/languageSelector.component";
+import { ChangeLanguageRedirectComponent } from "./components/changeLanguageRedirect.component";
 import { LanguageServiceAgent } from "./services/serviceAgents/languageServiceAgent.service";
 
 import { InvitationPipe } from './pipes/invitationFormatter.pipe';
@@ -302,6 +303,7 @@ export function createTranslateLoader(http: HttpClient): TranslateHttpLoader {
     UserPreferencesComponent,
     UserActivitiesComponent,
     DashboardComponent,
+    ChangeLanguageRedirectComponent,
 
     // activity form
     ActivityComponent,
@@ -361,6 +363,7 @@ export function createTranslateLoader(http: HttpClient): TranslateHttpLoader {
     ParticipantProfileComponent,
     UserActivitiesComponent,
     DashboardComponent,
+    ChangeLanguageRedirectComponent,
 
     ActivityComponent,
     ActivityRedesignedComponent,

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/authentication/auth0Adapter.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/authentication/auth0Adapter.service.ts
@@ -125,13 +125,13 @@ export class Auth0AdapterService implements OnDestroy {
      * Shows the auth0 modal with the ability to login, but not signup
      */
     public login(additionalParams?: Record<string, string>): void {
-      const params = {
-        ...(additionalParams && {
-          ...additionalParams
-        }),
-        language: this.language.getCurrentLanguage()
-      };
-      this.showAuth0Modal(Auth0Mode.LoginOnly, params);
+        const params = {
+          ...(additionalParams && {
+            ...additionalParams
+          }),
+          language: this.language.getCurrentLanguage()
+        };
+        this.showAuth0Modal(Auth0Mode.LoginOnly, params);
     }
 
     /**

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/authentication/auth0Adapter.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/authentication/auth0Adapter.service.ts
@@ -125,7 +125,13 @@ export class Auth0AdapterService implements OnDestroy {
      * Shows the auth0 modal with the ability to login, but not signup
      */
     public login(additionalParams?: Record<string, string>): void {
-        this.showAuth0Modal(Auth0Mode.LoginOnly, additionalParams);
+      const params = {
+        ...(additionalParams && {
+          ...additionalParams
+        }),
+        language: this.language.getCurrentLanguage()
+      };
+      this.showAuth0Modal(Auth0Mode.LoginOnly, params);
     }
 
     /**

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/languageService.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/languageService.service.ts
@@ -29,6 +29,17 @@ export class LanguageService {
       return null;
     }
 
+    public changeLanguagePromise(languageCode: string): Promise<any> {
+      if (this.canUseLanguage(languageCode)) {
+        localStorage.setItem('studyLanguage', languageCode);
+        return this.translate.use(languageCode).toPromise();
+      }
+      else {
+        console.log(`Error: cannot use language ${languageCode}`);
+        return null;
+      }
+    }
+
     public changeLanguage(languageCode: string): boolean {
       if (this.canUseLanguage(languageCode)) {
         this.translate.use(languageCode);

--- a/ddp-workspace/projects/ddp-sdk/src/public-api.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/public-api.ts
@@ -75,6 +75,7 @@ export * from './lib/services/serviceAgents/subjectInvitationServiceAgent.servic
 export * from './lib/components/login/auth0-code-callback.component';
 export * from './lib/components/address/addressEmbedded.component';
 export * from './lib/components/activityForm/activity.component';
+export * from './lib/components/changeLanguageRedirect.component';
 
 export * from './lib/guards/auth.guard';
 export * from './lib/guards/adminAuth.guard';


### PR DESCRIPTION
See DDP-4773.  This contains some changes I made to support Prion's need to have the language selector also appear on Auth0 pages.  This adds a change language redirect component that changes the language to a specified language and redirects to a specified component, which can be used to implement a language selector in the Auth0 pages.  This also fixes a discrepancy in Auth0AdapterService where the language and additional parameters get passed to the sign up page but not the login page.  Additionally, this adds a method to the language service that changes the language in storage and returns a Promise that will change the language used by ngx-translate.  The purpose of this method is to make it possible for the change language redirect component to wait until the language has actually been changed before redirecting.