### PR TITLE
Header menu improvement

### DIFF
--- a/ddp-workspace/projects/ddp-angio/src/styles.scss
+++ b/ddp-workspace/projects/ddp-angio/src/styles.scss
@@ -1707,6 +1707,35 @@ select:-webkit-autofill {
     top: $warning-height !important;
 }
 
+// move user menu to the side panel on the small screens
+.user-menu-panel {
+    display: none;
+
+    .SimpleButton {
+        font-size: 1.1rem !important;
+        color: mat-color($app-theme, 600) !important;
+    }
+
+    .SimpleButton:hover {
+        color: mat-color($app-theme, 700) !important;
+    }
+}
+
+@media only screen and (max-width: 480px) {
+    .user-menu-panel {
+        display: block;
+
+        .ddp-user {
+            color: mat-color($app-theme, 600) !important;
+        }
+    }
+
+    .user-menu-header {
+        display: none;
+        padding: 0;
+    }
+}
+
 .ddp-list {
     margin: 20px;
     padding: 0;

--- a/ddp-workspace/projects/ddp-brain/src/styles.scss
+++ b/ddp-workspace/projects/ddp-brain/src/styles.scss
@@ -1561,6 +1561,35 @@ ul {
     text-decoration: underline !important;
 }
 
+// move user menu to the side panel on the small screens
+.user-menu-panel {
+    display: none;
+
+    .SimpleButton {
+        font-size: 1.1rem !important;
+        color: mat-color($app-theme, 600) !important;
+    }
+
+    .SimpleButton:hover {
+        color: mat-color($app-theme, 700) !important;
+    }
+}
+
+@media only screen and (max-width: 350px) {
+    .user-menu-panel {
+        display: block;
+    }
+
+    .user-menu-header {
+        display: none;
+        padding: 0;
+    }
+
+    .ddp-user {
+        color: mat-color($app-theme, 600) !important;
+    }
+}
+
 .ddp-activity-validation {
     .ErrorMessageList {
         list-style-type: square;

--- a/ddp-workspace/projects/ddp-mbc/src/styles.scss
+++ b/ddp-workspace/projects/ddp-mbc/src/styles.scss
@@ -1447,6 +1447,35 @@ ul {
     text-decoration: underline !important;
 }
 
+// move user menu to the side panel on the small screens
+.user-menu-panel {
+    display: none;
+
+    .SimpleButton {
+        font-size: 1.1rem !important;
+        color: mat-color($app-theme, 600) !important;
+    }
+
+    .SimpleButton:hover {
+        color: mat-color($app-theme, 2100) !important;
+    }
+}
+
+@media only screen and (max-width: 480px) {
+    .user-menu-panel {
+        display: block;
+
+        .ddp-user {
+            color: mat-color($app-theme, 600);
+        }
+    }
+
+    .user-menu-header {
+        display: none;
+        padding: 0;
+    }
+}
+
 .ddp-activity-validation {
     .ErrorMessageList {
         list-style-type: square;

--- a/ddp-workspace/projects/ddp-mpc/src/styles.scss
+++ b/ddp-workspace/projects/ddp-mpc/src/styles.scss
@@ -1589,6 +1589,35 @@ select:-webkit-autofill {
     top: $warning-height !important;
 }
 
+// move user menu to the side panel on the small screens
+.user-menu-panel {
+    display: none;
+
+    .SimpleButton {
+        font-size: 1.1rem !important;
+        color: mat-color($app-theme, 2200) !important;
+    }
+
+    .SimpleButton:hover {
+        color: mat-color($app-theme, 600) !important;
+    }
+}
+
+@media only screen and (max-width: 480px) {
+    .user-menu-panel {
+        display: block;
+
+        .ddp-user {
+            color: mat-color($app-theme, 2200);
+        }
+    }
+
+    .user-menu-header {
+        display: none;
+        padding: 0;
+    }
+}
+
 // .ddp-list {
 //     margin: 20px;
 //     padding: 0;
@@ -1749,26 +1778,26 @@ select:-webkit-autofill {
 //     font-weight: 900;
 // }
 
-// .ddp-user-menu-button {
-//     outline: none;
-//     font-size: 1rem;
-//     font-weight: 300;
-//     color: mat-color($app-theme, 1000);
-// }
+.ddp-user-menu-button {
+    outline: none;
+    font-size: 1rem;
+    font-weight: 300;
+    color: mat-color($app-theme, 1000);
+}
 
-// .ddp-user-menu-button:active,
-// .ddp-user-menu-button:focus,
-// .ddp-user-menu-button:hover {
-//     color: mat-color($app-theme, 1000);
-// }
+.ddp-user-menu-button:active,
+.ddp-user-menu-button:focus,
+.ddp-user-menu-button:hover {
+    color: mat-color($app-theme, 1000);
+}
 
-// .ddp-user {
-//     color: mat-color($app-theme, 100);
-// }
+.ddp-user {
+    color: mat-color($app-theme, 100);
+}
 
-// .ddp-user--scrolled {
-//     color: mat-color($app-theme, 600);
-// }
+.ddp-user--scrolled {
+    color: mat-color($app-theme, 2200);
+}
 
 // .ddp-institutions-form,
 // .ddp-activity-question {

--- a/ddp-workspace/projects/toolkit/src/lib/components/app/app.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/app/app.component.ts
@@ -1,4 +1,5 @@
 import { AfterViewInit, Component, Inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Router, NavigationEnd } from '@angular/router';
 import { MatDialog, MatDialogRef, MatSidenav } from '@angular/material';
 import { NoopScrollStrategy } from '@angular/cdk/overlay';
 import { TranslateService } from '@ngx-translate/core';
@@ -57,6 +58,9 @@ declare global {
                 <li *ngIf="showInfoForPhysicians">
                     <a [routerLink]="['physician.pdf']" target="_blank" class="Link" translate>App.Info</a>
                 </li>
+                <li class="user-menu-panel">
+                    <ddp-user-menu class="Link"></ddp-user-menu>
+                </li>
                 <li class="NoPadding TopMarginMedium">
                     <a class="twitter-timeline" data-tweet-limit="20" data-theme="light" [href]="twitterUrl">App.Twitter</a>
                 </li>
@@ -94,6 +98,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
         private renewNotifier: RenewSessionNotifier,
         private windowRef: WindowRef,
         private userProfile: UserProfileServiceAgent,
+        private router: Router,
         @Inject('toolkit.toolkitConfig') private toolkitConfiguration: ToolkitConfigurationService) { }
 
     public ngOnInit(): void {
@@ -101,6 +106,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
         this.initBrowserWarningListener();
         this.initSessionWillExpireListener();
         this.initTranslate();
+        this.initRouterListener();
         this.twitterUrl = `https://twitter.com/${this.toolkitConfiguration.twitterAccountId}`;
         this.blogUrl = this.toolkitConfiguration.blogUrl;
         this.unsupportedBrowser = this.browserContent.unsupportedBrowser();
@@ -233,5 +239,13 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
             const locale = JSON.parse(session).locale;
             this.translate.use(locale);
         }
+    }
+
+    private initRouterListener(): void {
+        this.router.events.subscribe(event => {
+            if (event instanceof NavigationEnd) {
+                this.closeNav();
+            }
+        });
     }
 }

--- a/ddp-workspace/projects/toolkit/src/lib/components/header/header.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/header/header.component.ts
@@ -42,7 +42,7 @@ import { AnalyticsEventsService, BrowserContentService, WindowRef, AnalyticsEven
                     Toolkit.Header.LearnMore
                 </span>
             </li>
-            <li *ngIf="showUserMenu && !unsupportedBrowser" class="Header-navItem">
+            <li *ngIf="showUserMenu && !unsupportedBrowser" class="Header-navItem user-menu-header">
                 <ddp-user-menu [isScrolled]="isScrolled">
                 </ddp-user-menu>
             </li>


### PR DESCRIPTION
On some small-screen devices header menu looks ugly:
![image](https://user-images.githubusercontent.com/30126907/86765250-94d39680-c051-11ea-90d5-5a0558d0de81.png)
So, let's move the Sign In button on the side menu on the small screens.