### PR TITLE
Fix SDK test

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/irbPassword.service.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/irbPassword.service.spec.ts
@@ -1,3 +1,4 @@
+import { HttpTestingController, HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { CookieService } from 'ngx-cookie';
@@ -8,29 +9,41 @@ import { LoggingService } from './logging.service';
 describe('IrbPasswordService', () => {
     let service: IrbPasswordService;
     let httpClient: HttpClient;
+    let httpTestingController: HttpTestingController;
     const config = new ConfigurationService();
-    config.backendUrl = 'https://pepper-dev.datadonationplatform.org';
-    // config.backendUrl = 'http://localhost:5555';
-    config.studyGuid = 'ANGIO';
+    config.backendUrl = 'https://pepper-mock-backend.org';
+    config.studyGuid = 'study';
+    const mockRequestUrl = `${config.backendUrl}/pepper/v1/studies/${config.studyGuid}/irb-password-check`;
     // Faking out the cookieservice
     const cookieServiceSpy: jasmine.SpyObj<CookieService> = jasmine.createSpyObj('CookieService', ['put']);
     // called within the parent class
     const loggingServiceSpy: jasmine.SpyObj<LoggingService> = jasmine.createSpyObj('LoggingService', ['logException']);
+
     beforeEach(() => {
         TestBed.configureTestingModule({
             // this the import to get a real httpclient
-            imports: [HttpClientModule],
-            providers: [IrbPasswordService, { provide: CookieService, useValue: cookieServiceSpy },
-                { provide: 'ddp.config', useValue: config }, LoggingService]
+            imports: [
+                HttpClientModule,
+                HttpClientTestingModule
+            ],
+            providers: [
+                IrbPasswordService,
+                CookieService,
+                LoggingService,
+                { provide: 'ddp.config', useValue: config }
+            ]
         });
         // For some reason TestBed is willing to inject Configuration into service, but not httpclient
         // So we need to instantiate ourselves
         httpClient = TestBed.get(HttpClient);
+        httpTestingController = TestBed.get(HttpTestingController);
         service = new IrbPasswordService(config, cookieServiceSpy, httpClient, loggingServiceSpy);
+    });
 
-    });
     afterEach(() => {
+        httpTestingController.verify();
     });
+
     it('Check http password call', (done) => {
         // spy on handle error. Checking that we can make call cleanly
         // not the callThrough!!!!
@@ -40,10 +53,11 @@ describe('IrbPasswordService', () => {
             expect(result).toBe(false, 'We were expecting a false from server!');
             expect(handleErrorSpy).not.toHaveBeenCalled();
             done();
-        }, (error) => {
-            fail(error);
-            done();
-
+        });
+        // mock backend request
+        const request = httpTestingController.expectOne(mockRequestUrl);
+        request.flush({
+            result: false
         });
     });
 });


### PR DESCRIPTION
Tests shouldn't rely on the real backend, right now backend doesn't work, so one test crashes and we can deploy frontend.
I changed a real backend call with a mock call.