### PR TITLE
Prion: DDP-4806, persist selected language when participant signs up …

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/languageSelector.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/languageSelector.component.ts
@@ -121,7 +121,7 @@ export class LanguageSelectorComponent implements OnInit, OnDestroy {
   }
 
   //Find the current language and return true if successful or false otherwise
-  public findCurrentLanguage(): Observable<Boolean> {
+  public findCurrentLanguage(): Observable<boolean> {
     //Check for a language in the profile
     let profileLangObservable: Observable<StudyLanguage> = this.getProfileLangObservable();
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/languageSelector.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/languageSelector.component.ts
@@ -1,10 +1,15 @@
 import { Component, Inject, Input, OnDestroy, OnInit, Output, EventEmitter } from '@angular/core';
+import { CompositeDisposable} from '../compositeDisposable';
+import { UserProfile } from '../models/userProfile';
 import { StudyLanguage } from '../models/studyLanguage';
 import { ConfigurationService } from '../services/configuration.service';
 import { LanguageService } from '../services/languageService.service';
+import { SessionMementoService } from '../services/sessionMemento.service';
+import { UserProfileServiceAgent} from '../services/serviceAgents/userProfileServiceAgent.service';
 import { LanguageServiceAgent } from '../services/serviceAgents/languageServiceAgent.service';
 import { isNullOrUndefined } from 'util';
-import { Subscription } from 'rxjs';
+import { iif, Observable, of, Subscription } from 'rxjs';
+import { concatMap, flatMap, map, take } from 'rxjs/operators';
 
 @Component({
   selector: 'ddp-language-selector',
@@ -32,25 +37,29 @@ export class LanguageSelectorComponent implements OnInit, OnDestroy {
   public currentLanguage: StudyLanguage;
   public iconURL: string;
   private studyLanguages: StudyLanguage[];
-  private anchor: Subscription;
+  private anchor: CompositeDisposable;
 
   constructor(
     private serviceAgent: LanguageServiceAgent,
     private language: LanguageService,
-    @Inject('ddp.config') private config: ConfigurationService) { }
+    private profileServiceAgent: UserProfileServiceAgent,
+    @Inject('ddp.config') private config: ConfigurationService,
+    private session: SessionMementoService) { }
 
   public ngOnInit(): void {
+    this.anchor = new CompositeDisposable();
     this.iconURL = this.config.languageSelectorIconURL ? this.config.languageSelectorIconURL : "assets/images/globe.svg#Language-Selector-3";
-    this.anchor = this.serviceAgent.getConfiguredLanguages(this.config.studyGuid).subscribe(x => {
+    let sub: Subscription = this.serviceAgent.getConfiguredLanguages(this.config.studyGuid).subscribe(x => {
       if (x) {
         //Only use language selector if multiple languages are configured!
         if (x.length > 1) {
           this.studyLanguages = x;
           this.language.addLanguages(this.studyLanguages.map(x => x.languageCode));
-          if (this.findCurrentLanguage()) {
-            this.loaded = true;
-            this.isVisible.emit(true);
-          }
+          let sub2: Subscription = this.findCurrentLanguage().subscribe(x => {
+            this.loaded = x.valueOf();
+            this.isVisible.emit(x.valueOf());
+          });
+          this.anchor.addNew(sub2);
         } else {
           this.isVisible.emit(false);
         }
@@ -59,10 +68,13 @@ export class LanguageSelectorComponent implements OnInit, OnDestroy {
         this.isVisible.emit(false);
       }
     });
+    this.anchor.addNew(sub);
   }
 
   public ngOnDestroy(): void {
-    this.anchor.unsubscribe();
+    if (this.anchor) {
+      this.anchor.removeAll();
+    }
   }
 
   public getUnselectedLanguages(): Array<StudyLanguage> {
@@ -73,43 +85,134 @@ export class LanguageSelectorComponent implements OnInit, OnDestroy {
   }
 
   public changeLanguage(lang: StudyLanguage): void {
+    if (!isNullOrUndefined(this.currentLanguage) && this.currentLanguage.languageCode === lang.languageCode) {
+      return;
+    }
+
     if (this.language.canUseLanguage(lang.languageCode)) {
       this.currentLanguage = lang;
-      this.language.changeLanguage(lang.languageCode);
+      if (this.language.getCurrentLanguage() !== lang.languageCode) {
+        this.language.changeLanguage(lang.languageCode);
+        if (this.session.isAuthenticatedSession()) {
+          this.updateProfileLanguage();
+        }
+      }
     }
     else {
       console.error('Error: The specified language: ' + JSON.stringify(lang) + ' is not configured for the study.');
     }
   }
 
+  //Update the language in the profile to the current language
+  private updateProfileLanguage(): void {
+    // Create observable that gets the user's profile and creates a copy with updated preferred language
+    let getProfileObservable: Observable<UserProfile> = this.profileServiceAgent.profile
+      .pipe(map(x => {
+        return {...x.profile, preferredLanguage: this.currentLanguage.languageCode};
+      })).pipe(take(1));
+
+    // When we get the new profile value, save it
+    let updateProfileObservable: Observable<any> = getProfileObservable
+      .pipe(concatMap(profile => this.profileServiceAgent.saveProfile(false, profile)));
+
+    //Subscribe to the combined observable
+    let sub: Subscription = updateProfileObservable.subscribe(() => this.language.notifyOfProfileLanguageUpdate(true));
+    this.anchor.addNew(sub);
+  }
+
   //Find the current language and return true if successful or false otherwise
-  public findCurrentLanguage(): boolean {
-    //Check if we already have a current language
-    if (!isNullOrUndefined(this.currentLanguage)) {
-      this.changeLanguage(this.currentLanguage);
-      return true;
-    }
+  public findCurrentLanguage(): Observable<Boolean> {
+    //Check for a language in the profile
+    let profileLangObservable: Observable<StudyLanguage> = this.getProfileLangObservable();
 
-    //Check storage
-    let loadedCode: string = this.language.useStoredLanguage();
-    if (loadedCode) {
-      let loadedLang: StudyLanguage = this.studyLanguages.find(x => x.languageCode === loadedCode);
-      if (!isNullOrUndefined(loadedLang)) {
-        this.currentLanguage = loadedLang;
-        return true;
-      }
-    }
-
-    //TODO: Check user profile for configured language--will happen in a later ticket
+    //Use the current language if it exists or check for a stored language
+    let currentStoredLangObservable: Observable<StudyLanguage> = this.getCurrentStoredLangObservable();
 
     //Check for a default language
-    let lang: StudyLanguage = this.studyLanguages.find(element => element.isDefault = true);
-    if (!isNullOrUndefined(lang)) {
-      this.changeLanguage(lang);
-      return true;
-    }
+    let defaultLangObservable: Observable<StudyLanguage> = this.getDefaultLangObservable();
 
-    console.error('Error: no default language found');
-    return false;
+    //Create an observable that will check each applicable option and return the first valid language found, if any
+    let langObservable: Observable<StudyLanguage> = profileLangObservable.pipe(
+      flatMap(x => {
+        return this.getNextObservable(x, currentStoredLangObservable);
+      })
+    ).pipe(
+      flatMap(y => {
+        return this.getNextObservable(y, defaultLangObservable);
+      })
+    );
+
+    //Return an observable that uses langObservable to get the language and if found, sets the language and
+    // returns true, or otherwise logs an error and returns false
+    return langObservable.pipe(map(x => {
+      if (this.foundLanguage(x)) {
+        this.changeLanguage(x);
+        return true;
+      }
+      else {
+        console.error('Error: no stored, profile, or default language found');
+        return false;
+      }
+    }));
+  }
+
+  private getNextObservable(lang: StudyLanguage, obs: Observable<StudyLanguage>): Observable<StudyLanguage> {
+    if (this.foundLanguage(lang)) {
+      return of(lang);
+    }
+    else {
+      return obs;
+    }
+  }
+
+  private getCurrentStoredLangObservable(): Observable<StudyLanguage> {
+    return new Observable<StudyLanguage>(subscriber => {
+      //Use the current language if it exists
+      if (!isNullOrUndefined(this.currentLanguage)) {
+        subscriber.next(this.currentLanguage);
+      }
+      else {
+        //Check for a stored language
+        let loadedCode: string = this.language.useStoredLanguage();
+        if (loadedCode) {
+          let lang: StudyLanguage = this.studyLanguages.find(x => x.languageCode === loadedCode);
+          subscriber.next(isNullOrUndefined(lang) ? null : lang);
+        }
+        else {
+          subscriber.next(null);
+        }
+      }
+      subscriber.complete();
+    });
+  }
+
+  private getProfileLangObservable(): Observable<StudyLanguage> {
+    let profileLangObservable: Observable<StudyLanguage> = this.profileServiceAgent.profile
+      .pipe(map(x => {
+        if (x && x.profile.preferredLanguage) {
+          return this.studyLanguages.find(y => y.languageCode === x.profile.preferredLanguage);
+        }
+        else {
+          return null;
+        }
+      }));
+    return iif(() => this.session.isAuthenticatedSession(), profileLangObservable, of(null));
+  }
+
+  private getDefaultLangObservable(): Observable<StudyLanguage> {
+    return new Observable<StudyLanguage>(subscriber => {
+      let lang: StudyLanguage = this.studyLanguages.find(element => element.isDefault = true);
+      if (!isNullOrUndefined(lang)) {
+        subscriber.next(lang);
+      }
+      else {
+        subscriber.next(null);
+      }
+      subscriber.complete();
+    });
+  }
+
+  private foundLanguage(lang: StudyLanguage): boolean {
+    return !isNullOrUndefined(lang) && this.language.canUseLanguage(lang.languageCode);
   }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/languageSelector.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/languageSelector.component.ts
@@ -135,8 +135,7 @@ export class LanguageSelectorComponent implements OnInit, OnDestroy {
     let langObservable: Observable<StudyLanguage> = profileLangObservable.pipe(
       flatMap(x => {
         return this.getNextObservable(x, currentStoredLangObservable);
-      })
-    ).pipe(
+      }),
       flatMap(y => {
         return this.getNextObservable(y, defaultLangObservable);
       })

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/address.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/address.service.ts
@@ -22,8 +22,8 @@ export class AddressService extends UserServiceAgent<Address> {
         http: HttpClient,
         logger: LoggingService,
         private translate: NGXTranslateService,
-        private _language: LanguageService) {
-        super(session, configuration, http, logger, _language);
+        private __language: LanguageService) {
+        super(session, configuration, http, logger, __language);
     }
 
     public verifyAddress(address: Address): Observable<AddressVerificationResponse> {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/address.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/address.service.ts
@@ -4,6 +4,7 @@ import { UserServiceAgent } from './serviceAgents/userServiceAgent.service';
 import { LoggingService } from './logging.service';
 import { ConfigurationService } from './configuration.service';
 import { SessionMementoService } from './sessionMemento.service';
+import { LanguageService } from "./languageService.service";
 import { AddressVerificationStatus } from '../models/addressVerificationStatus';
 import { Address } from '../models/address';
 import { Observable, throwError } from 'rxjs';
@@ -20,8 +21,9 @@ export class AddressService extends UserServiceAgent<Address> {
         @Inject('ddp.config') configuration: ConfigurationService,
         http: HttpClient,
         logger: LoggingService,
-        private translate: NGXTranslateService) {
-        super(session, configuration, http, logger);
+        private translate: NGXTranslateService,
+        private _language: LanguageService) {
+        super(session, configuration, http, logger, _language);
     }
 
     public verifyAddress(address: Address): Observable<AddressVerificationResponse> {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/addressCountry.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/addressCountry.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { LoggingService } from './logging.service';
 import { ConfigurationService } from './configuration.service';
 import { SessionMementoService } from './sessionMemento.service';
+import { LanguageService } from "./languageService.service";
 import { SessionServiceAgent } from './serviceAgents/sessionServiceAgent.service';
 import { CountryAddressInfoSummary } from '../models/countryAddressInfoSummary';
 import { CountryAddressInfo } from '../models/countryAddressInfo';
@@ -20,8 +21,9 @@ export class CountryService extends SessionServiceAgent<CountryAddressInfo | Cou
         session: SessionMementoService,
         @Inject('ddp.config') configuration: ConfigurationService,
         http: HttpClient,
-        logger: LoggingService) {
-        super(session, configuration, http, logger);
+        logger: LoggingService,
+        _language: LanguageService) {
+        super(session, configuration, http, logger, _language);
         this.initializeAllCountryInfoSummaries();
     }
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/languageService.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/languageService.service.ts
@@ -1,10 +1,16 @@
 import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { isNullOrUndefined } from "util";
+import { Observable, Subject } from "rxjs";
+import { startWith } from "rxjs/operators";
 
 @Injectable()
 export class LanguageService {
-    constructor(private translate: TranslateService) { }
+    private profileLanguageUpdateNotifier: Subject<boolean>;
+    constructor(private translate: TranslateService) {
+      this.profileLanguageUpdateNotifier = new Subject<boolean>();
+      this.profileLanguageUpdateNotifier.next(false);
+    }
 
     public getCurrentLanguage(): string {
         return this.translate.currentLang;
@@ -27,6 +33,14 @@ export class LanguageService {
         return loadedCode;
       }
       return null;
+    }
+
+    public getProfileLanguageUpdateNotifier(): Observable<boolean> {
+      return this.profileLanguageUpdateNotifier.asObservable().pipe(startWith(false));
+    }
+
+    public notifyOfProfileLanguageUpdate(val: boolean): void {
+      this.profileLanguageUpdateNotifier.next(val);
     }
 
     public changeLanguagePromise(languageCode: string): Promise<any> {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/languageService.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/languageService.service.ts
@@ -37,7 +37,7 @@ export class LanguageService {
 
     public getProfileLanguageUpdateNotifier(): Observable<void> {
       return this.profileLanguageUpdateNotifier.asObservable().pipe(
-        startWith()); //Make sure anything that updates when the language updates gets an initial value!
+        startWith(<void>null)); //Make sure anything that updates when the language updates gets an initial value!
     }
 
     public notifyOfProfileLanguageUpdate(): void {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/languageService.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/languageService.service.ts
@@ -6,10 +6,10 @@ import { startWith } from "rxjs/operators";
 
 @Injectable()
 export class LanguageService {
-    private profileLanguageUpdateNotifier: Subject<boolean>;
+    private profileLanguageUpdateNotifier: Subject<void>;
     constructor(private translate: TranslateService) {
-      this.profileLanguageUpdateNotifier = new Subject<boolean>();
-      this.profileLanguageUpdateNotifier.next(false);
+      this.profileLanguageUpdateNotifier = new Subject<void>();
+      this.profileLanguageUpdateNotifier.next();
     }
 
     public getCurrentLanguage(): string {
@@ -35,12 +35,13 @@ export class LanguageService {
       return null;
     }
 
-    public getProfileLanguageUpdateNotifier(): Observable<boolean> {
-      return this.profileLanguageUpdateNotifier.asObservable().pipe(startWith(false));
+    public getProfileLanguageUpdateNotifier(): Observable<void> {
+      return this.profileLanguageUpdateNotifier.asObservable().pipe(
+        startWith()); //Make sure anything that updates when the language updates gets an initial value!
     }
 
-    public notifyOfProfileLanguageUpdate(val: boolean): void {
-      this.profileLanguageUpdateNotifier.next(val);
+    public notifyOfProfileLanguageUpdate(): void {
+      this.profileLanguageUpdateNotifier.next();
     }
 
     public changeLanguagePromise(languageCode: string): Promise<any> {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/activityInstanceStatusServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/activityInstanceStatusServiceAgent.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { SessionServiceAgent } from './sessionServiceAgent.service';
 import { LoggingService } from '../logging.service';
 import { ConfigurationService } from '../configuration.service';
+import { LanguageService } from '../languageService.service';
 import { SessionMementoService } from '../sessionMemento.service';
 import { ActivityInstanceState } from '../../models/activity/activityInstanceState';
 import { Observable } from 'rxjs';
@@ -13,8 +14,9 @@ export class ActivityInstanceStatusServiceAgent extends SessionServiceAgent<any>
         session: SessionMementoService,
         @Inject('ddp.config') configuration: ConfigurationService,
         http: HttpClient,
-        logger: LoggingService) {
-        super(session, configuration, http, logger);
+        logger: LoggingService,
+        _language: LanguageService) {
+        super(session, configuration, http, logger, _language);
     }
 
     public getStatuses(): Observable<Array<ActivityInstanceState>> {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/activityServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/activityServiceAgent.service.ts
@@ -22,13 +22,13 @@ export class ActivityServiceAgent extends UserServiceAgent<any> {
         private converter: ActivityConverter,
         http: HttpClient,
         logger: LoggingService,
-        private _language: LanguageService) {
-        super(session, configuration, http, logger);
+        private __language: LanguageService) {
+        super(session, configuration, http, logger, null);
     }
 
     public getActivity(studyGuid: Observable<string | null>,
         activityGuid: Observable<string | null>): Observable<ActivityForm> {
-        return this._language.getProfileLanguageUpdateNotifier().pipe(
+        return this.__language.getProfileLanguageUpdateNotifier().pipe(
           switchMap(() => studyGuid)).pipe(
           combineLatest(activityGuid, (x, y) => {
             return { study: x, activity: y };

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/activityServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/activityServiceAgent.service.ts
@@ -5,10 +5,11 @@ import { UserServiceAgent } from './userServiceAgent.service';
 import { LoggingService } from '../logging.service';
 import { ConfigurationService } from '../configuration.service';
 import { SessionMementoService } from '../sessionMemento.service';
+import { LanguageService } from '../languageService.service';
 import { AnswerValue } from '../../models/activity/answerValue';
 import { ActivityInstanceGuid } from '../../models/activityInstanceGuid';
 import { Observable, of, throwError } from 'rxjs';
-import { combineLatest, flatMap, catchError, map } from 'rxjs/operators';
+import { combineLatest, flatMap, catchError, map, switchMap } from 'rxjs/operators';
 import { AnswerSubmission } from '../../models/activity/answerSubmission';
 import { PatchAnswerResponse } from '../../models/activity/patchAnswerResponse';
 import { ActivityForm } from '../../models/activity/activityForm';
@@ -20,35 +21,37 @@ export class ActivityServiceAgent extends UserServiceAgent<any> {
         @Inject('ddp.config') configuration: ConfigurationService,
         private converter: ActivityConverter,
         http: HttpClient,
-        logger: LoggingService) {
+        logger: LoggingService,
+        private _language: LanguageService) {
         super(session, configuration, http, logger);
     }
 
     public getActivity(studyGuid: Observable<string | null>,
         activityGuid: Observable<string | null>): Observable<ActivityForm> {
-        return studyGuid.pipe(
-            combineLatest(activityGuid, (x, y) => {
-                return { study: x, activity: y };
-            }),
-            flatMap(x => {
-                if (x.study == null || x.study === '' ||
-                    x.activity == null || x.activity === '') {
-                    return of(null);
-                }
-                return this.getObservable(`/studies/${x.study}/activities/${x.activity}`, {}, [404]);
-            }, (x, y) => y),
-            catchError(e => {
-                if (e.error && e.error.code && e.error.code === 'ACTIVITY_NOT_FOUND') {
-                    return throwError('ACTIVITY_NOT_FOUND');
-                }
-                return throwError(e);
-            }),
-            map(x => {
-                if (x == null) {
-                    return null;
-                }
-                return this.converter.convertActivity(x);
-            })
+        return this._language.getProfileLanguageUpdateNotifier().pipe(
+          switchMap(() => studyGuid)).pipe(
+          combineLatest(activityGuid, (x, y) => {
+            return { study: x, activity: y };
+          }),
+          flatMap(x => {
+            if (x.study == null || x.study === '' ||
+              x.activity == null || x.activity === '') {
+              return of(null);
+            }
+            return this.getObservable(`/studies/${x.study}/activities/${x.activity}`, {}, [404]);
+          }, (x, y) => y),
+          catchError(e => {
+            if (e.error && e.error.code && e.error.code === 'ACTIVITY_NOT_FOUND') {
+              return throwError('ACTIVITY_NOT_FOUND');
+            }
+            return throwError(e);
+          }),
+          map(x => {
+            if (x == null) {
+              return null;
+            }
+            return this.converter.convertActivity(x);
+          })
         );
     }
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/adminServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/adminServiceAgent.service.ts
@@ -4,6 +4,7 @@ import { SessionServiceAgent } from './sessionServiceAgent.service';
 import { LoggingService } from '../logging.service';
 import { ConfigurationService } from '../configuration.service';
 import { SessionMementoService } from '../sessionMemento.service';
+import { LanguageService } from '../languageService.service';
 
 @Injectable()
 export class AdminServiceAgent<TEntity> extends SessionServiceAgent<TEntity> {
@@ -11,8 +12,9 @@ export class AdminServiceAgent<TEntity> extends SessionServiceAgent<TEntity> {
         session: SessionMementoService,
         @Inject('ddp.config') configuration: ConfigurationService,
         http: HttpClient,
-        logger: LoggingService) {
-        super(session, configuration, http, logger);
+        logger: LoggingService,
+        _language: LanguageService) {
+        super(session, configuration, http, logger, _language);
     }
 
     protected getBackendUrl(): string {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/adminServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/adminServiceAgent.service.ts
@@ -4,7 +4,6 @@ import { SessionServiceAgent } from './sessionServiceAgent.service';
 import { LoggingService } from '../logging.service';
 import { ConfigurationService } from '../configuration.service';
 import { SessionMementoService } from '../sessionMemento.service';
-import { LanguageService } from '../languageService.service';
 
 @Injectable()
 export class AdminServiceAgent<TEntity> extends SessionServiceAgent<TEntity> {
@@ -12,9 +11,8 @@ export class AdminServiceAgent<TEntity> extends SessionServiceAgent<TEntity> {
         session: SessionMementoService,
         @Inject('ddp.config') configuration: ConfigurationService,
         http: HttpClient,
-        logger: LoggingService,
-        _language: LanguageService) {
-        super(session, configuration, http, logger, _language);
+        logger: LoggingService) {
+        super(session, configuration, http, logger, null);
     }
 
     protected getBackendUrl(): string {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/announcementsServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/announcementsServiceAgent.service.ts
@@ -5,6 +5,7 @@ import { ConfigurationService } from '../configuration.service';
 import { UserServiceAgent } from './userServiceAgent.service';
 import { SessionMementoService } from '../sessionMemento.service';
 import { AnnouncementMessage } from '../../models/announcementMessage';
+import { LanguageService } from '../languageService.service';
 import { Observable } from 'rxjs';
 
 @Injectable()
@@ -13,8 +14,9 @@ export class AnnouncementsServiceAgent extends UserServiceAgent<Array<Announceme
         session: SessionMementoService,
         @Inject('ddp.config') configuration: ConfigurationService,
         http: HttpClient,
-        logger: LoggingService) {
-        super(session, configuration, http, logger);
+        logger: LoggingService,
+        _language: LanguageService) {
+        super(session, configuration, http, logger, _language);
     }
 
     public getMessages(studyGuid: string): Observable<Array<AnnouncementMessage> | null> {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/consentServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/consentServiceAgent.service.ts
@@ -4,6 +4,7 @@ import { UserServiceAgent } from './userServiceAgent.service';
 import { LoggingService } from '../logging.service';
 import { ConfigurationService } from '../configuration.service';
 import { SessionMementoService } from '../sessionMemento.service';
+import { LanguageService } from '../languageService.service';
 import { Observable } from 'rxjs';
 
 @Injectable()
@@ -12,8 +13,9 @@ export class ConsentServiceAgent extends UserServiceAgent<any> {
         session: SessionMementoService,
         @Inject('ddp.config') configuration: ConfigurationService,
         http: HttpClient,
-        logger: LoggingService) {
-        super(session, configuration, http, logger);
+        logger: LoggingService,
+        _language: LanguageService) {
+        super(session, configuration, http, logger, _language);
     }
 
     public getSummary(studyGuid: string, consentCode: string): Observable<any> {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/fireCloudServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/fireCloudServiceAgent.service.ts
@@ -2,7 +2,6 @@ import { AdminServiceAgent } from './adminServiceAgent.service';
 import { LoggingService } from '../logging.service';
 import { ConfigurationService } from '../configuration.service';
 import { SessionMementoService } from '../sessionMemento.service';
-import { LanguageService } from '../languageService.service';
 import { HttpClient } from '@angular/common/http';
 import { Injectable, Inject } from '@angular/core';
 import { Study } from '../../models/study';
@@ -25,9 +24,8 @@ export class FireCloudServiceAgent extends AdminServiceAgent<any> {
         session: SessionMementoService,
         @Inject('ddp.config') configuration: ConfigurationService,
         http: HttpClient,
-        logger: LoggingService,
-        _language: LanguageService) {
-        super(session, configuration, http, logger, _language);
+        logger: LoggingService) {
+        super(session, configuration, http, logger);
     }
 
     public changeListStudiesMessage(message: string) {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/fireCloudServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/fireCloudServiceAgent.service.ts
@@ -2,6 +2,7 @@ import { AdminServiceAgent } from './adminServiceAgent.service';
 import { LoggingService } from '../logging.service';
 import { ConfigurationService } from '../configuration.service';
 import { SessionMementoService } from '../sessionMemento.service';
+import { LanguageService } from '../languageService.service';
 import { HttpClient } from '@angular/common/http';
 import { Injectable, Inject } from '@angular/core';
 import { Study } from '../../models/study';
@@ -24,8 +25,9 @@ export class FireCloudServiceAgent extends AdminServiceAgent<any> {
         session: SessionMementoService,
         @Inject('ddp.config') configuration: ConfigurationService,
         http: HttpClient,
-        logger: LoggingService) {
-        super(session, configuration, http, logger);
+        logger: LoggingService,
+        _language: LanguageService) {
+        super(session, configuration, http, logger, _language);
     }
 
     public changeListStudiesMessage(message: string) {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/institutionServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/institutionServiceAgent.service.ts
@@ -4,7 +4,6 @@ import { SessionServiceAgent } from './sessionServiceAgent.service';
 import { LoggingService } from '../logging.service';
 import { ConfigurationService } from '../configuration.service';
 import { SessionMementoService } from '../sessionMemento.service';
-import { LanguageService } from '../languageService.service';
 import { Institution } from '../../models/institution';
 import { Observable } from 'rxjs';
 import { flatMap } from 'rxjs/operators';
@@ -15,9 +14,8 @@ export class InstitutionServiceAgent extends SessionServiceAgent<any> {
         session: SessionMementoService,
         @Inject('ddp.config') configuration: ConfigurationService,
         http: HttpClient,
-        logger: LoggingService,
-        _language: LanguageService) {
-        super(session, configuration, http, logger, _language);
+        logger: LoggingService) {
+        super(session, configuration, http, logger, null);
     }
 
     public getSummary(input: Observable<string>): Observable<Institution[]> {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/institutionServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/institutionServiceAgent.service.ts
@@ -4,6 +4,7 @@ import { SessionServiceAgent } from './sessionServiceAgent.service';
 import { LoggingService } from '../logging.service';
 import { ConfigurationService } from '../configuration.service';
 import { SessionMementoService } from '../sessionMemento.service';
+import { LanguageService } from '../languageService.service';
 import { Institution } from '../../models/institution';
 import { Observable } from 'rxjs';
 import { flatMap } from 'rxjs/operators';
@@ -14,8 +15,9 @@ export class InstitutionServiceAgent extends SessionServiceAgent<any> {
         session: SessionMementoService,
         @Inject('ddp.config') configuration: ConfigurationService,
         http: HttpClient,
-        logger: LoggingService) {
-        super(session, configuration, http, logger);
+        logger: LoggingService,
+        _language: LanguageService) {
+        super(session, configuration, http, logger, _language);
     }
 
     public getSummary(input: Observable<string>): Observable<Institution[]> {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/medicalProvidersServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/medicalProvidersServiceAgent.service.ts
@@ -7,6 +7,7 @@ import { SessionMementoService } from '../sessionMemento.service';
 import { ActivityInstitution } from '../../models/activity/activityInstitution';
 import { ActivityInstitutionForm } from '../../models/activity/activityInstitutionForm';
 import { MedicalProviderResponse } from '../../models/medicalProviderResponse';
+import { LanguageService } from '../languageService.service';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -16,8 +17,9 @@ export class MedicalProvidersServiceAgent extends UserServiceAgent<any> {
         session: SessionMementoService,
         @Inject('ddp.config') configuration: ConfigurationService,
         http: HttpClient,
-        logger: LoggingService) {
-        super(session, configuration, http, logger);
+        logger: LoggingService,
+        _language: LanguageService) {
+        super(session, configuration, http, logger, _language);
     }
 
     public createMedicalProvider(studyGuid: string, institutionType: string, form: ActivityInstitutionForm): Observable<MedicalProviderResponse> {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/notAuthenticatedServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/notAuthenticatedServiceAgent.service.ts
@@ -10,7 +10,7 @@ export class NotAuthenticatedServiceAgent<TEntity> extends ServiceAgent<TEntity>
         @Inject('ddp.config') protected _configuration: ConfigurationService,
         private _http: HttpClient,
         private _logger: LoggingService) {
-        super(_configuration, _http, _logger);
+        super(_configuration, _http, _logger, null);
     }
 
     protected getBackendUrl(): string {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/operatorServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/operatorServiceAgent.service.ts
@@ -4,7 +4,6 @@ import { SessionServiceAgent } from './sessionServiceAgent.service';
 import { LoggingService } from '../logging.service';
 import { ConfigurationService } from '../configuration.service';
 import { SessionMementoService } from '../sessionMemento.service';
-import { LanguageService } from '../languageService.service';
 import { Subscription } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 
@@ -17,9 +16,8 @@ export class OperatorServiceAgent<TEntity> extends SessionServiceAgent<TEntity> 
         session: SessionMementoService,
         @Inject('ddp.config') configuration: ConfigurationService,
         http: HttpClient,
-        logger: LoggingService,
-        _language: LanguageService = null) {
-        super(session, configuration, http, logger, _language);
+        logger: LoggingService) {
+        super(session, configuration, http, logger, null);
         this.anchor = session.sessionObservable.pipe(
             filter(x => x !== null),
             map(x => x.userGuid)

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/operatorServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/operatorServiceAgent.service.ts
@@ -4,6 +4,7 @@ import { SessionServiceAgent } from './sessionServiceAgent.service';
 import { LoggingService } from '../logging.service';
 import { ConfigurationService } from '../configuration.service';
 import { SessionMementoService } from '../sessionMemento.service';
+import { LanguageService } from '../languageService.service';
 import { Subscription } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 
@@ -16,8 +17,9 @@ export class OperatorServiceAgent<TEntity> extends SessionServiceAgent<TEntity> 
         session: SessionMementoService,
         @Inject('ddp.config') configuration: ConfigurationService,
         http: HttpClient,
-        logger: LoggingService) {
-        super(session, configuration, http, logger);
+        logger: LoggingService,
+        _language: LanguageService = null) {
+        super(session, configuration, http, logger, _language);
         this.anchor = session.sessionObservable.pipe(
             filter(x => x !== null),
             map(x => x.userGuid)

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/prequalifierServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/prequalifierServiceAgent.service.ts
@@ -2,6 +2,7 @@ import { UserServiceAgent } from './userServiceAgent.service';
 import { LoggingService } from '../logging.service';
 import { ConfigurationService } from '../configuration.service';
 import { SessionMementoService } from '../sessionMemento.service';
+import { LanguageService } from '../languageService.service';
 import { HttpClient } from '@angular/common/http';
 import { Injectable, Inject } from '@angular/core';
 import { Observable } from 'rxjs';
@@ -13,8 +14,9 @@ export class PrequalifierServiceAgent extends UserServiceAgent<any> {
         session: SessionMementoService,
         @Inject('ddp.config') configuration: ConfigurationService,
         http: HttpClient,
-        logger: LoggingService) {
-        super(session, configuration, http, logger);
+        logger: LoggingService,
+        _language: LanguageService) {
+        super(session, configuration, http, logger, _language);
     }
 
     public getPrequalifier(studyGuid: string): Observable<string> {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/sessionServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/sessionServiceAgent.service.ts
@@ -6,7 +6,7 @@ import { ConfigurationService } from '../configuration.service';
 import { SessionMementoService } from '../sessionMemento.service';
 import { LanguageService } from '../languageService.service';
 import { Observable, of } from 'rxjs';
-import { flatMap, switchMap, take } from 'rxjs/operators';
+import { flatMap, take } from 'rxjs/operators';
 
 @Injectable()
 export class SessionServiceAgent<TEntity> extends ServiceAgent<TEntity> {
@@ -15,8 +15,8 @@ export class SessionServiceAgent<TEntity> extends ServiceAgent<TEntity> {
         @Inject('ddp.config') protected _configuration: ConfigurationService,
         private _http: HttpClient,
         private _logger: LoggingService,
-        private language: LanguageService = null) {
-        super(_configuration, _http, _logger);
+        private _language: LanguageService) {
+        super(_configuration, _http, _logger, _language);
     }
 
     protected getHeaders(options: any): Observable<any> {
@@ -45,19 +45,7 @@ export class SessionServiceAgent<TEntity> extends ServiceAgent<TEntity> {
         );
     }
 
-
     protected getBackendUrl(): string {
         return this.configuration.backendUrl + '/pepper/v1';
-    }
-
-    protected getObservable(path: string, options: any = {}, unrecoverableStatuses: Array<number> = []): Observable<TEntity | null> {
-      if (this.language) {
-        return this.language.getProfileLanguageUpdateNotifier()
-          .pipe(switchMap(() =>
-            super.getObservable(path, options, unrecoverableStatuses)));
-      }
-      else {
-        return super.getObservable(path, options, unrecoverableStatuses);
-      }
     }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/subjectInvitationServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/subjectInvitationServiceAgent.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { LoggingService } from '../logging.service';
 import { ConfigurationService } from '../configuration.service';
 import { SessionMementoService } from '../sessionMemento.service';
+import { LanguageService } from '../languageService.service';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { StudySubject } from '../../models/studySubject';
@@ -15,8 +16,9 @@ export class SubjectInvitationServiceAgent extends SessionServiceAgent<any> {
         session: SessionMementoService,
         @Inject('ddp.config') configuration: ConfigurationService,
         http: HttpClient,
-        logger: LoggingService) {
-        super(session, configuration, http, logger);
+        logger: LoggingService,
+        _language: LanguageService) {
+        super(session, configuration, http, logger, _language);
     }
 
     public updateInvitationDetails(invitationId: string, notes: string): Observable<any | null> {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/subjectInvitationServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/subjectInvitationServiceAgent.service.ts
@@ -3,7 +3,6 @@ import { HttpClient } from '@angular/common/http';
 import { LoggingService } from '../logging.service';
 import { ConfigurationService } from '../configuration.service';
 import { SessionMementoService } from '../sessionMemento.service';
-import { LanguageService } from '../languageService.service';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { StudySubject } from '../../models/studySubject';
@@ -16,9 +15,8 @@ export class SubjectInvitationServiceAgent extends SessionServiceAgent<any> {
         session: SessionMementoService,
         @Inject('ddp.config') configuration: ConfigurationService,
         http: HttpClient,
-        logger: LoggingService,
-        _language: LanguageService) {
-        super(session, configuration, http, logger, _language);
+        logger: LoggingService) {
+        super(session, configuration, http, logger, null);
     }
 
     public updateInvitationDetails(invitationId: string, notes: string): Observable<any | null> {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/suggestionsServiceAgent.service.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/suggestionsServiceAgent.service.spec.ts
@@ -36,7 +36,7 @@ describe('SuggestionServiceAgent Test', () => {
         httpClient = TestBed.get(HttpClient);
         httpTestingController = TestBed.get(HttpTestingController);
 
-        service = new SuggestionServiceAgent(sessionSpy, config, httpClient, loggingServiceSpy);
+        service = new SuggestionServiceAgent(sessionSpy, config, httpClient, loggingServiceSpy, null);
     });
 
     afterEach(() => {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/userActivityServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/userActivityServiceAgent.service.ts
@@ -5,6 +5,7 @@ import { LoggingService } from '../logging.service';
 import { ConfigurationService } from '../configuration.service';
 import { SessionMementoService } from '../sessionMemento.service';
 import { ActivityInstance } from '../../models/activityInstance';
+import { LanguageService } from '../languageService.service';
 import { Observable, of } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 
@@ -14,8 +15,9 @@ export class UserActivityServiceAgent extends UserServiceAgent<Array<ActivityIns
         session: SessionMementoService,
         @Inject('ddp.config') configuration: ConfigurationService,
         http: HttpClient,
-        logger: LoggingService) {
-        super(session, configuration, http, logger);
+        logger: LoggingService,
+        _language: LanguageService) {
+        super(session, configuration, http, logger, _language);
     }
 
     public getActivities(studyGuid: Observable<string | null>): Observable<Array<ActivityInstance> | null> {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/userInvitationServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/userInvitationServiceAgent.service.ts
@@ -5,6 +5,7 @@ import { LoggingService } from '../logging.service';
 import { SessionMementoService } from '../sessionMemento.service';
 import { Invitation } from '../../models/invitation';
 import { ConfigurationService } from '../configuration.service';
+import { LanguageService } from '../languageService.service';
 import { Observable } from 'rxjs';
 
 @Injectable()
@@ -13,8 +14,9 @@ export class UserInvitationServiceAgent extends UserServiceAgent<Array<Invitatio
         session: SessionMementoService,
         @Inject('ddp.config') configuration: ConfigurationService,
         http: HttpClient,
-        logger: LoggingService) {
-        super(session, configuration, http, logger);
+        logger: LoggingService,
+        _language: LanguageService) {
+        super(session, configuration, http, logger, _language);
     }
 
     public getInvitations(): Observable<Array<Invitation> | null> {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/userProfileServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/userProfileServiceAgent.service.ts
@@ -8,6 +8,7 @@ import { UserProfile } from '../../models/userProfile';
 import { UserProfileDecorator } from '../../models/userProfileDecorator';
 import { Observable, of, throwError } from 'rxjs';
 import { map, catchError } from 'rxjs/operators';
+import { isNullOrUndefined } from "util";
 
 @Injectable()
 export class UserProfileServiceAgent extends UserServiceAgent<UserProfile> {
@@ -16,7 +17,7 @@ export class UserProfileServiceAgent extends UserServiceAgent<UserProfile> {
         @Inject('ddp.config') configuration: ConfigurationService,
         http: HttpClient,
         logger: LoggingService) {
-        super(session, configuration, http, logger);
+        super(session, configuration, http, logger, null);
     }
 
     public get profile(): Observable<UserProfileDecorator> {
@@ -45,6 +46,17 @@ export class UserProfileServiceAgent extends UserServiceAgent<UserProfile> {
         } else {
             return this.patchObservable('/profile', JSON.stringify(profile));
         }
+    }
+
+    public saveProfileAttributes(profile: UserProfile): Observable<any> {
+      //Save non-null profile attributes
+      let profileChanges: object = {};
+      for (let key in Object.keys(profile)) {
+        if (!isNullOrUndefined(profile[key])) {
+          profileChanges[key] = profile[key];
+        }
+      }
+      return this.patchObservable('/profile', JSON.stringify(profileChanges));
     }
 
     private createProfile(profile: UserProfile): Observable<any> {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/userProfileServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/userProfileServiceAgent.service.ts
@@ -48,7 +48,7 @@ export class UserProfileServiceAgent extends UserServiceAgent<UserProfile> {
         }
     }
 
-    public saveProfileAttributes(profile: UserProfile): Observable<any> {
+    public updateProfile(profile: UserProfile): Observable<any> {
       //Save non-null profile attributes
       let profileChanges: object = {};
       for (let key of Object.keys(profile)) {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/userProfileServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/userProfileServiceAgent.service.ts
@@ -37,7 +37,9 @@ export class UserProfileServiceAgent extends UserServiceAgent<UserProfile> {
     }
 
     public saveProfile(isNew: boolean, profile: UserProfile): Observable<any> {
-        profile.preferredLanguage = 'en';
+        if (!profile.preferredLanguage) {
+          profile.preferredLanguage = 'en';
+        }
         if (isNew) {
             return this.postObservable('/profile', JSON.stringify(profile));
         } else {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/userProfileServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/userProfileServiceAgent.service.ts
@@ -51,7 +51,7 @@ export class UserProfileServiceAgent extends UserServiceAgent<UserProfile> {
     public saveProfileAttributes(profile: UserProfile): Observable<any> {
       //Save non-null profile attributes
       let profileChanges: object = {};
-      for (let key in Object.keys(profile)) {
+      for (let key of Object.keys(profile)) {
         if (!isNullOrUndefined(profile[key])) {
           profileChanges[key] = profile[key];
         }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/userServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/userServiceAgent.service.ts
@@ -18,7 +18,7 @@ export class UserServiceAgent<TEntity> extends SessionServiceAgent<TEntity> impl
         @Inject('ddp.config') configuration: ConfigurationService,
         http: HttpClient,
         logger: LoggingService,
-        _language: LanguageService = null) {
+        _language: LanguageService) {
         super(session, configuration, http, logger, _language);
         this.anchor = session.sessionObservable.pipe(
             filter(x => x !== null),

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/userServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/userServiceAgent.service.ts
@@ -4,6 +4,7 @@ import { SessionServiceAgent } from './sessionServiceAgent.service';
 import { LoggingService } from '../logging.service';
 import { ConfigurationService } from '../configuration.service';
 import { SessionMementoService } from '../sessionMemento.service';
+import { LanguageService } from '../languageService.service';
 import { Subscription } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
 
@@ -16,8 +17,9 @@ export class UserServiceAgent<TEntity> extends SessionServiceAgent<TEntity> impl
         session: SessionMementoService,
         @Inject('ddp.config') configuration: ConfigurationService,
         http: HttpClient,
-        logger: LoggingService) {
-        super(session, configuration, http, logger);
+        logger: LoggingService,
+        _language: LanguageService = null) {
+        super(session, configuration, http, logger, _language);
         this.anchor = session.sessionObservable.pipe(
             filter(x => x !== null),
             map(x => {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/workflowServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/workflowServiceAgent.service.ts
@@ -14,7 +14,7 @@ export class WorkflowServiceAgent extends UserServiceAgent<ActivityResponse> {
         @Inject('ddp.config') configuration: ConfigurationService,
         http: HttpClient,
         logger: LoggingService) {
-        super(session, configuration, http, logger);
+        super(session, configuration, http, logger, null);
     }
 
     public byActivityCode(state: string, activityCode: string): Observable<ActivityResponse | null> {


### PR DESCRIPTION
…or logs in: Porting over changes from DDP-4436

This corresponds to DDP-4806.

This ticket does the following:

- When language is changed using the language selector for an authenticated user, updates the language in the profile and reloads components that get text from the backend so that everything gets translated immediately
- When a user signs in, the language will be retrieved from their profile
- When the language selector loads, it will first check for a profile language if the user authenticated.  Previously, the plan was to first check for a locally stored language, but that caused issues when a user logged into an account that had a different language set.  This way, if an unauthenticated user changes the language and then logs into an account with a different language in the profile, the profile language will be restored.  

This required changing a number of SDK components to allow components to reload text retrieved from the backend when the language was changed.  There are some components that are not used by Prion.  I believe I handled this correctly for those components, but it is possible I missed some.