### PR TITLE
testboston: use custom domain

### DIFF
--- a/config/pepperConfig.js.ctmpl
+++ b/config/pepperConfig.js.ctmpl
@@ -113,7 +113,7 @@ var DDP_ENV = {
 
 {{if eq $study_guid "testboston"}}
     {{if eq $environment "dev"}}
-        DDP_ENV['auth0Domain'] = "testboston-dev.auth0.com";
+        DDP_ENV['auth0Domain'] = "login-dev.testboston.org";
         DDP_ENV['auth0Audience'] = "testboston-dev.auth0.com";
         DDP_ENV['auth0ClientId'] = "m4lhHnq2WvRm3lloUHbQzwCte7s03o3S";
         DDP_ENV['adminClientId'] = "OC3gFZD8vIBiKlJ3tPUJJ2cUI5EwVFSz";


### PR DESCRIPTION
We have just added a custom domain for testboston: `login-dev.testboston.org`. This needs to be used by the frontend, otherwise it looks like Okta SAML integration won't work properly when using `login-dev.testboston.org`.