### PR TITLE
DDP-4834: [TestBoston] Allow CRC to create login account for participant post-enrollment

### DIFF
--- a/ddp-workspace/projects/ddp-testboston/src/app/app-routing.module.ts
+++ b/ddp-workspace/projects/ddp-testboston/src/app/app-routing.module.ts
@@ -7,7 +7,7 @@ import { ActivityGuids } from './aсtivity-guids';
 import { WelcomeComponent } from './components/welcome/welcome.component';
 import { UserRegistrationPrequalComponent } from './components/user-registration-prequal/user-registration-prequal.component';
 import { PrismComponent } from './components/prism/prism.component';
-import { EnrollmentComponent } from './components/enrollment/enrollment.component'
+import { EnrollmentComponent } from './components/enrollment/enrollment.component';
 
 import {
   Auth0CodeCallbackComponent,

--- a/ddp-workspace/projects/ddp-testboston/src/app/components/enrollment/enrollment.component.ts
+++ b/ddp-workspace/projects/ddp-testboston/src/app/components/enrollment/enrollment.component.ts
@@ -5,12 +5,13 @@ import {
   SessionMementoService,
   SubjectInvitationServiceAgent,
   UserProfile,
+  UserProfileDecorator,
   UserProfileServiceAgent,
   WorkflowServiceAgent
 } from 'ddp-sdk';
 import { WorkflowBuilderService } from 'toolkit';
 import { AppRoutes } from '../../app-routes';
-import { of } from 'rxjs';
+import { of, throwError, Observable } from 'rxjs';
 import { take, tap, mergeMap } from 'rxjs/operators';
 
 @Component({
@@ -23,6 +24,7 @@ export class EnrollmentComponent implements OnInit {
   public accountForm: FormGroup;
   public isLoading = false;
   public showError = false;
+  private profile: UserProfile;
 
   constructor(
     private router: Router,
@@ -35,8 +37,7 @@ export class EnrollmentComponent implements OnInit {
 
   public ngOnInit(): void {
     this.initAccountForm();
-    this.showError = (this.session.session.participantGuid === null && this.session.session.invitationId === null) ||
-      (this.session.session.participantGuid !== null);
+    this.setupInitialState();
   }
 
   public onSubmit(): void {
@@ -47,15 +48,16 @@ export class EnrollmentComponent implements OnInit {
     const profile = this.createProfile();
     const email = this.accountForm.controls.email.value;
     const invitationId = this.session.session.invitationId;
+    const participantGuid = this.session.session.participantGuid;
+    const participantGuid$ = participantGuid ? of(participantGuid) : this.createStudyParticipant(invitationId);
 
     this.isLoading = true;
     this.accountForm.disable();
 
-    this.subjectInvitation.createStudyParticipant(invitationId).pipe(
+    participantGuid$.pipe(
       take(1),
-      tap(userGuid => this.session.setParticipant(userGuid)),
       mergeMap(userGuid => email ? this.subjectInvitation.createUserLoginAccount(userGuid, email) : of(null)),
-      mergeMap(() => this.userProfile.saveProfile(false, profile)),
+      mergeMap(() => this.isProfileChanged(profile) ? this.userProfile.updateProfile(profile) : of(null)),
       mergeMap(() => this.workflow.getStart())
     ).subscribe(response => {
       if (response) {
@@ -84,5 +86,51 @@ export class EnrollmentComponent implements OnInit {
     profile.firstName = this.accountForm.controls.firstName.value;
     profile.lastName = this.accountForm.controls.lastName.value;
     return profile;
+  }
+
+  private createStudyParticipant(invitationId: string): Observable<string> {
+    return this.subjectInvitation.createStudyParticipant(invitationId).pipe(
+      tap(userGuid => this.session.setParticipant(userGuid))
+    );
+  }
+
+  private isProfileChanged(profile: UserProfile): boolean {
+    return this.profile.firstName !== profile.firstName || this.profile.lastName !== profile.lastName;
+  }
+
+  private setupInitialState(): void {
+    const invitationId$ = of(this.session.session.invitationId);
+
+    invitationId$.pipe(
+      take(1),
+      mergeMap(invitationId => {
+        if (invitationId) {
+          return this.subjectInvitation.lookupInvitation(invitationId);
+        } else {
+          return throwError('There is no invitationId!');
+        }
+      }),
+      mergeMap(studySubject => {
+        if (studySubject.userLoginEmail) {
+          return throwError('The subject already has email-associated account!');
+        } else {
+          const participantGuid = this.session.session.participantGuid;
+          return participantGuid ? this.userProfile.profile : of(new UserProfileDecorator());
+        }
+      })
+    ).subscribe(
+      response => {
+        if (response) {
+          this.accountForm.controls.firstName.patchValue(response.profile.firstName);
+          this.accountForm.controls.lastName.patchValue(response.profile.lastName);
+          this.profile = response.profile;
+        } else {
+          this.router.navigateByUrl(this.appRoutes.Error);
+        }
+      },
+      error => {
+        this.showError = true;
+      }
+    );
   }
 }

--- a/ddp-workspace/projects/ddp-testboston/src/app/components/header/header.component.html
+++ b/ddp-workspace/projects/ddp-testboston/src/app/components/header/header.component.html
@@ -32,7 +32,8 @@
             </ul>
         </nav>
         <div class="static-menu">
-            <a class="header-link static-menu__item" [href]="language + '/kit-instructions.pdf'" target="_blank" translate>
+            <a class="header-link static-menu__item" [href]="language + '/kit-instructions.pdf'" target="_blank"
+                translate>
                 <img src="assets/images/instructions.svg" alt="Download" class="header-link__icon">
                 Navigation.KitInstructions
             </a>
@@ -59,7 +60,7 @@
     </div>
 </header>
 
-<div #overlay class="overlay">
+<div *ngIf="!isAdmin" #overlay class="overlay">
     <nav class="overlay-content">
         <ul #menu class="menu">
             <ng-container>

--- a/ddp-workspace/projects/ddp-testboston/src/app/components/prism/prism.component.html
+++ b/ddp-workspace/projects/ddp-testboston/src/app/components/prism/prism.component.html
@@ -78,9 +78,19 @@
                     <ng-container *ngIf="studySubject && studySubject.userGuid">
                         <div class="info-block">
                             <p class="info-block__title" translate>Prism.Email</p>
-                            <p class="info-block__text">
-                                {{studySubject.userLoginEmail ? studySubject.userLoginEmail : 'Prism.NoEmail' | translate}}
+                            <p class="info-block__text" *ngIf="studySubject.userLoginEmail; else none">
+                                {{studySubject.userLoginEmail}}
                             </p>
+                            <ng-template #none>
+                                <div class="none-listed">
+                                    <h2 class="none-listed__title" translate>Prism.NoneListed.Title</h2>
+                                    <p class="none-listed__text">
+                                        <span translate>Prism.NoneListed.Text</span>
+                                        <a class="Link none-listed__link" [routerLink]="'/' + appRoutes.EnrollSubject"
+                                            translate>Prism.NoneListed.Link</a>.
+                                    </p>
+                                </div>
+                            </ng-template>
                         </div>
                         <div class="navigate">
                             <a class="button button_primary" [routerLink]="'/' + appRoutes.Dashboard" translate>

--- a/ddp-workspace/projects/ddp-testboston/src/app/components/prism/prism.component.scss
+++ b/ddp-workspace/projects/ddp-testboston/src/app/components/prism/prism.component.scss
@@ -7,6 +7,13 @@
     color: mat-color($app-theme, 1000);
 }
 
+@mixin text {
+    color: mat-color($app-theme, 400);
+    font-size: 1.125rem;
+    line-height: 1.5rem;
+    margin: 0;
+}
+
 .content-prism {
     max-width: 1050px;
 }
@@ -42,10 +49,7 @@
 }
 
 .subtitle {
-    color: mat-color($app-theme, 400);
-    font-size: 1.125rem;
-    line-height: 1.5rem;
-    margin: 0;
+    @include text;
 
     &_field {
         margin-bottom: -0.5rem;
@@ -139,6 +143,24 @@
         font-weight: 300;
         margin: 0;
         color: mat-color($app-theme, 400);
+    }
+}
+
+.none-listed {
+    &__title {
+        margin: 0;
+        font-weight: 200;
+        font-size: 2rem;
+        line-height: 3rem;
+    }
+
+    &__text {
+        @include text;
+    }
+
+    &__link {
+        font-weight: 600;
+        text-decoration: underline;
     }
 }
 

--- a/ddp-workspace/projects/ddp-testboston/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-testboston/src/assets/i18n/en.json
@@ -182,32 +182,32 @@
           ]
         }
       ]
-  },
-  "TeamSection": {
-    "Title": "Our Team",
-    "Text": "We are a team of infectious disease doctors and researchers who want to better understand how COVID-19 is affecting individuals and communities so we can better serve all patients. ",
-    "List": [
-      {
-        "Name": "Ann E. Woolley, MD",
-        "Affiliations": "Instructor in Medicine",
-        "Info": "Dr. Ann Woolley is an Instructor in Medicine and an Infectious disease physician at Brigham & Women’s Hospital and Harvard Medical School. Dr. Woolley received a B.S. in mechanical and aerospace engineering from Princeton University in 2001 and a postbaccalaureate certificate in premedical studies from Columbia University before training in both public health and medicine at the Mount Sinai School of Medicine in New York. With a focus on transplant, hepatitis, and cardiac infections, Dr. Woolley’s research has demonstrated novel methods to safely use organs from individuals previously thought to be unsuitable donors. Her work has resulted in shorter wait times for individuals in need of organ donation, and in more individuals being able to choose to become lifesaving organ donors."
-      },
-      {
-        "Name": "Lisa A. Cosimi, MD",
-        "Affiliations": "Assistant Professor, Harvard Medical School Infectious Disease, Global Health Equity",
-        "Info": "Dr. Cosimi is an Associate Physician in the Divisions of Global Health Equity & Infectious Diseases at Brigham & Women’s Hospital, and Assistant Professor of Medicine at Harvard Medical School. Dr. Cosimi received a B.A. in Economics from Cornell University in 1992 and M.D. from the Weill Cornell Medical College in 1996.  She completed her residency in Internal Medicine and Primary Care at the Massachusetts General Hospital and Infectious Disease training at the Partners combined fellowship program.  Dr. Cosimi’s research has focused on ways to strengthen health systems and the quality of healthcare in resource-limited settings. Her group, The Partnership for Health Advancement in Vietnam (HAIVN), has partnered with Vietnam’s Ministry of Health, Medical Universities and hospitals to reform and modernize health care worker education, and improve quality and access to health care for HIV, tuberculosis and other emerging infections throughout the country."
-      },
-      {
-        "Name": "Deborah T. Hung, MD, PhD",
-        "Affiliations": "Associate Professor, Harvard Medical School Infectious Disease, Pulmonary and Critical Care",
-        "Info": "Dr. Deborah Hung is Professor of Genetics at Massachusetts General Hospital and Harvard Medical School, a Core Faculty Member and Co-Director of the Infectious Disease and Microbiome Program at the Broad Institute of MIT and Harvard, and an attending physician in infectious diseases and pulmonary & critical care medicine at Brigham and Women’s Hospital. She works at the interface of chemical biology, genomics, and bacterial pathogenesis to establish new paradigms for an antibiotic based on the essential biology required for a pathogen to cause disease within the host. Using her training as a synthetic chemist, bacterial geneticist, and clinical physician, she explores approaches to disrupting the pathogen-host interaction."
-      }
-    ]
-  },
-  "MailingSection": {
-    "Title": "TestBoston is currently enrolling invited patients of Brigham and Women’s Hospital. ",
-    "Text": "If you did not receive an invitation to join the study but are interested in staying up to date about general TestBoston information, please join our newsletter list:"
-  }
+    },
+    "TeamSection": {
+      "Title": "Our Team",
+      "Text": "We are a team of infectious disease doctors and researchers who want to better understand how COVID-19 is affecting individuals and communities so we can better serve all patients. ",
+      "List": [
+        {
+          "Name": "Ann E. Woolley, MD",
+          "Affiliations": "Instructor in Medicine",
+          "Info": "Dr. Ann Woolley is an Instructor in Medicine and an Infectious disease physician at Brigham & Women’s Hospital and Harvard Medical School. Dr. Woolley received a B.S. in mechanical and aerospace engineering from Princeton University in 2001 and a postbaccalaureate certificate in premedical studies from Columbia University before training in both public health and medicine at the Mount Sinai School of Medicine in New York. With a focus on transplant, hepatitis, and cardiac infections, Dr. Woolley’s research has demonstrated novel methods to safely use organs from individuals previously thought to be unsuitable donors. Her work has resulted in shorter wait times for individuals in need of organ donation, and in more individuals being able to choose to become lifesaving organ donors."
+        },
+        {
+          "Name": "Lisa A. Cosimi, MD",
+          "Affiliations": "Assistant Professor, Harvard Medical School Infectious Disease, Global Health Equity",
+          "Info": "Dr. Cosimi is an Associate Physician in the Divisions of Global Health Equity & Infectious Diseases at Brigham & Women’s Hospital, and Assistant Professor of Medicine at Harvard Medical School. Dr. Cosimi received a B.A. in Economics from Cornell University in 1992 and M.D. from the Weill Cornell Medical College in 1996.  She completed her residency in Internal Medicine and Primary Care at the Massachusetts General Hospital and Infectious Disease training at the Partners combined fellowship program.  Dr. Cosimi’s research has focused on ways to strengthen health systems and the quality of healthcare in resource-limited settings. Her group, The Partnership for Health Advancement in Vietnam (HAIVN), has partnered with Vietnam’s Ministry of Health, Medical Universities and hospitals to reform and modernize health care worker education, and improve quality and access to health care for HIV, tuberculosis and other emerging infections throughout the country."
+        },
+        {
+          "Name": "Deborah T. Hung, MD, PhD",
+          "Affiliations": "Associate Professor, Harvard Medical School Infectious Disease, Pulmonary and Critical Care",
+          "Info": "Dr. Deborah Hung is Professor of Genetics at Massachusetts General Hospital and Harvard Medical School, a Core Faculty Member and Co-Director of the Infectious Disease and Microbiome Program at the Broad Institute of MIT and Harvard, and an attending physician in infectious diseases and pulmonary & critical care medicine at Brigham and Women’s Hospital. She works at the interface of chemical biology, genomics, and bacterial pathogenesis to establish new paradigms for an antibiotic based on the essential biology required for a pathogen to cause disease within the host. Using her training as a synthetic chemist, bacterial geneticist, and clinical physician, she explores approaches to disrupting the pathogen-host interaction."
+        }
+      ]
+    },
+    "MailingSection": {
+      "Title": "TestBoston is currently enrolling invited patients of Brigham and Women’s Hospital. ",
+      "Text": "If you did not receive an invitation to join the study but are interested in staying up to date about general TestBoston information, please join our newsletter list:"
+    }
   },
   "PrequalPage": {
     "Title": "First, confirm your eligibility",
@@ -241,7 +241,11 @@
   "Prism": {
     "ClearSearch": "Clear",
     "Email": "SUBJECT EMAIL ADDRESS",
-    "NoEmail": "N/A",
+    "NoneListed": {
+      "Title": "None listed",
+      "Text": "If the participant wants to bo able to login to the TestBoston site, please enable their TestBoston account",
+      "Link": "here"
+    },
     "Buttons": {
       "Enrollment": "Begin Enrollment",
       "Dashboard": "View Dashboard"

--- a/ddp-workspace/projects/ddp-testboston/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-testboston/src/assets/i18n/en.json
@@ -272,7 +272,7 @@
     }
   },
   "Enrollment": {
-    "Title": "Account setup",
+    "Title": "Account set-up",
     "FirstName": {
       "Text": "Subject's First Name",
       "Placeholder": "Enter first name",

--- a/ddp-workspace/projects/ddp-testboston/src/assets/i18n/es.json
+++ b/ddp-workspace/projects/ddp-testboston/src/assets/i18n/es.json
@@ -182,32 +182,32 @@
           ]
         }
       ]
-  },
-  "TeamSection": {
-    "Title": "Nuestro equipo",
-    "Text": "Somos un equipo de infectólogas e investigadoras que deseamos tener una noción más clara de cómo COVID-19 afecta a cada persona y a las comunidades, de modo que podamos atender mejor a todos los pacientes. ",
-    "List": [
-      {
-        "Name": "Dra. Ann E. Woolley",
-        "Affiliations": "Profesora de Medicina",
-        "Info": "La Dra. Ann Woolley es profesora de Medicina e infectóloga de Brigham & Women’s Hospital y la Facultad de Medicina de Harvard. La Dra. Woolley obtuvo una licenciatura en Ingeniería Mecánica y Aeroespacial de la Universidad de Princeton en 2001 y un título de posgrado de estudios preparatorios de Medicina en la Universidad de Columbia. Más tarde, se formó en Salud Pública y en Medicina en la Facultad de Medicina de Mount Sinai en Nueva York. Con sus investigaciones centradas en los trasplantes, la hepatitis y las infecciones cardíacas, la Dra. Woolley ha demostrado métodos novedosos para utilizar sin riesgos los órganos de personas que antes no se consideraban donantes aptos. Gracias a su labor, ha sido posible reducir los plazos de espera para quienes necesitan trasplantes de órganos y lograr que más personas puedan optar por donar órganos y salvar vidas."
-      },
-      {
-        "Name": "Dra. Lisa A. Cosimi",
-        "Affiliations": "Profesora adjunta de Infectología de la Facultad de Medicina de Harvard, Global Health Equity (Equidad Mundial en Salud)",
-        "Info": "La Dra. Cosimi es médica adjunta de las divisiones de Equidad Mundial en Salud e Infectología de Brigham & Women’s Hospital. Además, se desempeña como profesora adjunta de Medicina en la Facultad de Medicina de Harvard. La Dra. Cosimi obtuvo una licenciatura en Economía de la Universidad Cornell en 1992 y una licenciatura en Medicina de la Facultad de Medicina Weill Cornell en 1996.  Finalizó su residencia de Medicina Interna y Atención Primaria en Massachusetts General Hospital y, posteriormente, se especializó en Infectología en el programa combinado de Partners.  Las investigaciones de la Dra. Cosimi se han centrado en formas de fortalecer los sistemas de salud y la calidad de la asistencia sanitaria en contextos donde los recursos son limitados. Su grupo, The Partnership for Health Advancement in Vietnam (HAIVN, Sociedad para la Promoción de la Salud en Vietnam), se ha asociado con el Ministerio de Salud, las universidades de medicina y los hospitales de Vietnam. Su objetivo es reformar y modernizar la educación de los trabajadores de la salud, así como mejorar la calidad de la atención sanitaria y el acceso a ella para los pacientes con VIH, tuberculosis y otras infecciones de reciente aparición en todo el país."
-      },
-      {
-        "Name": "Dra. Deborah T. Hung, PhD",
-        "Affiliations": "Profesora titular de Infectología, Neumología y Medicina Intensiva de la Facultad de Medicina de Harvard",
-        "Info": "La Dra. Deborah Hung es profesora de Genética en Massachusetts General Hospital y en la Facultad de Medicina de Harvard. Además, integra el cuerpo docente principal y es codirectora del programa de Infectología y Microbioma de Broad Institute of MIT and Harvard. Asimismo, se desempeña como especialista en Infectología, Neumología y Medicina Intensiva en Brigham and Women’s Hospital. Trabaja en la relación entre la bioquímica, la genómica y la patogenia bacteriana con el fin de definir nuevos paradigmas para los antibióticos, a partir de la biología esencial necesaria para que un microrganismo patógeno cause una enfermedad en un anfitrión. Aplicando su formación en los campos de la síntesis química, la genética bacteriana y la medicina clínica, la Dra. Hung estudia métodos para alterar la interacción entre los microrganismos patógenos y sus anfitriones."
-      }
-    ]
-  },
-  "MailingSection": {
-    "Title": "En la actualidad, TestBoston inscribe a los pacientes invitados de Brigham and Women’s Hospital. ",
-    "Text": "Si no recibió una invitación para participar en el estudio, pero le interesa estar al tanto de las novedades generales de TestBoston, inscríbase en nuestra lista para recibir un boletín:"
-  }
+    },
+    "TeamSection": {
+      "Title": "Nuestro equipo",
+      "Text": "Somos un equipo de infectólogas e investigadoras que deseamos tener una noción más clara de cómo COVID-19 afecta a cada persona y a las comunidades, de modo que podamos atender mejor a todos los pacientes. ",
+      "List": [
+        {
+          "Name": "Dra. Ann E. Woolley",
+          "Affiliations": "Profesora de Medicina",
+          "Info": "La Dra. Ann Woolley es profesora de Medicina e infectóloga de Brigham & Women’s Hospital y la Facultad de Medicina de Harvard. La Dra. Woolley obtuvo una licenciatura en Ingeniería Mecánica y Aeroespacial de la Universidad de Princeton en 2001 y un título de posgrado de estudios preparatorios de Medicina en la Universidad de Columbia. Más tarde, se formó en Salud Pública y en Medicina en la Facultad de Medicina de Mount Sinai en Nueva York. Con sus investigaciones centradas en los trasplantes, la hepatitis y las infecciones cardíacas, la Dra. Woolley ha demostrado métodos novedosos para utilizar sin riesgos los órganos de personas que antes no se consideraban donantes aptos. Gracias a su labor, ha sido posible reducir los plazos de espera para quienes necesitan trasplantes de órganos y lograr que más personas puedan optar por donar órganos y salvar vidas."
+        },
+        {
+          "Name": "Dra. Lisa A. Cosimi",
+          "Affiliations": "Profesora adjunta de Infectología de la Facultad de Medicina de Harvard, Global Health Equity (Equidad Mundial en Salud)",
+          "Info": "La Dra. Cosimi es médica adjunta de las divisiones de Equidad Mundial en Salud e Infectología de Brigham & Women’s Hospital. Además, se desempeña como profesora adjunta de Medicina en la Facultad de Medicina de Harvard. La Dra. Cosimi obtuvo una licenciatura en Economía de la Universidad Cornell en 1992 y una licenciatura en Medicina de la Facultad de Medicina Weill Cornell en 1996.  Finalizó su residencia de Medicina Interna y Atención Primaria en Massachusetts General Hospital y, posteriormente, se especializó en Infectología en el programa combinado de Partners.  Las investigaciones de la Dra. Cosimi se han centrado en formas de fortalecer los sistemas de salud y la calidad de la asistencia sanitaria en contextos donde los recursos son limitados. Su grupo, The Partnership for Health Advancement in Vietnam (HAIVN, Sociedad para la Promoción de la Salud en Vietnam), se ha asociado con el Ministerio de Salud, las universidades de medicina y los hospitales de Vietnam. Su objetivo es reformar y modernizar la educación de los trabajadores de la salud, así como mejorar la calidad de la atención sanitaria y el acceso a ella para los pacientes con VIH, tuberculosis y otras infecciones de reciente aparición en todo el país."
+        },
+        {
+          "Name": "Dra. Deborah T. Hung, PhD",
+          "Affiliations": "Profesora titular de Infectología, Neumología y Medicina Intensiva de la Facultad de Medicina de Harvard",
+          "Info": "La Dra. Deborah Hung es profesora de Genética en Massachusetts General Hospital y en la Facultad de Medicina de Harvard. Además, integra el cuerpo docente principal y es codirectora del programa de Infectología y Microbioma de Broad Institute of MIT and Harvard. Asimismo, se desempeña como especialista en Infectología, Neumología y Medicina Intensiva en Brigham and Women’s Hospital. Trabaja en la relación entre la bioquímica, la genómica y la patogenia bacteriana con el fin de definir nuevos paradigmas para los antibióticos, a partir de la biología esencial necesaria para que un microrganismo patógeno cause una enfermedad en un anfitrión. Aplicando su formación en los campos de la síntesis química, la genética bacteriana y la medicina clínica, la Dra. Hung estudia métodos para alterar la interacción entre los microrganismos patógenos y sus anfitriones."
+        }
+      ]
+    },
+    "MailingSection": {
+      "Title": "En la actualidad, TestBoston inscribe a los pacientes invitados de Brigham and Women’s Hospital. ",
+      "Text": "Si no recibió una invitación para participar en el estudio, pero le interesa estar al tanto de las novedades generales de TestBoston, inscríbase en nuestra lista para recibir un boletín:"
+    }
   },
   "PrequalPage": {
     "Title": "Primero, confirme si reúne los requisitos.",
@@ -241,7 +241,11 @@
   "Prism": {
     "ClearSearch": "Borrar",
     "Email": "DIRECCIÓN DE CORREO ELECTRÓNICO DEL PARTICIPANTE VOLUNTARIO",
-    "NoEmail": "NO APLICA",
+    "NoneListed": {
+      "Title": "None listed",
+      "Text": "If the participant wants to bo able to login to the TestBoston site, please enable their TestBoston account",
+      "Link": "here"
+    },
     "Buttons": {
       "Enrollment": "Iniciar la inscripción",
       "Dashboard": "Ver el panel"

--- a/ddp-workspace/projects/ddp-testboston/src/assets/i18n/ht.json
+++ b/ddp-workspace/projects/ddp-testboston/src/assets/i18n/ht.json
@@ -182,32 +182,32 @@
           ]
         }
       ]
-  },
-  "TeamSection": {
-    "Title": "Ekip nou an",
-    "Text": "Nou se yon ekip doktè ak chèchè nan domèn maladi enfektyez ki vle konprann pi byen fason COVID-19 afekte moun ak kominote yo pou nou kapab sèvi tout pasyan yo pi byen. ",
-    "List": [
-      {
-        "Name": "Doktè Ann E. Woolley, MD",
-        "Affiliations": "Enstriktè nan medsin",
-        "Info": "Doktè Ann Woolley se yon enstriktè nan medsin ak yon doktè nan domèn maladi enfektyez nan Brigham & Women’s Hospital ak Harvard Medical School. Doktè Woolley te resevwa yon BS nan jeni mekanik ak ayewospasyal nan Princeton University nan ane 2001 ak yon sètifika pòs-bakaloreya nan etid premedikal nan Columbia University anvan fòmasyon nan sante piblik ak nan medsin nan Mount Sinai School of medicine nan New York. Avèk yon konsantrasyon sou transplantasyon, epatit, ak enfeksyon kadyak, rechèch Doktè Woolley te demontre nouvo metòd pou itilize an tout sekirite ògàn moun ki konsidere kòm donatè men ki pa t apwopriye oparavan. Travay li te pèmèt rakousi tan datant pou moun ki bezwen don ògàn, epi pèmèt plis moun kapab chwazi pou yo vin donatè ògàn pou sove lavi."
-      },
-      {
-        "Name": "Doktè Lisa A. Cosimi, MD",
-        "Affiliations": "Asistan pwofesè, maladi enfektyèz nan Harvard Medical School, Global Health Equity",
-        "Info": "Doktè Cosimi se yon medsen asosye nan Global Health Equity & Incetuous Disease nan Brigham & Women’s Hospital, ak pwofesè adjwen nan medsin nan Harvard Medical School. Doktè Cosimi te resevwa yon BA nan ekonomi nan Cornell University an 1992 ak doktora an medsin nan Weill Cornell Medical College an 1996.  Li te fè rezidans li nan medsin entèn ak swen primè nan Massachusetts General Hospital epi fòmasyon nan maladi enfektyez nan pwogram bous konbine Partners.  Rechèch Doktè Cosimi te konsantre sou fason pou ranfòse sistèm sante yo ak kalite swen sante yo nan anviwònman ki gen resous limite. Gwoup li a, Partnership for Health Advancement in Vietnam (HAIVN), te asosye avèk Ministè Sante Vyetnam, Inivèsite Medikal ak lopital yo pou refòme ak modènize edikasyon travayè swen sante, ak amelyore kalite ak aksè nan swen sante pou VIH, tibèkiloz ak lòt enfeksyon k ap parèt nan tout peyi a."
-      },
-      {
-        "Name": "Doktè Deborah T. Hung, MD, PhD",
-        "Affiliations": "Pwofesè agreje, maladi enfektyez, swen pilmonè, ak swen entansif nan Harvard Medical School",
-        "Info": "Doktè Deborah Hung se pwofesè nan jenetik nan Massachusetts General Hospital Harvard Medical School, yon manm prensipal fakilte a ak ko-direktris pwogram maladi enfektyez ak mikwobyòm nan Broad Institute of MIT and Harvard, epi yon medsen tretan nan maladi enfektyez ak medsin swen pilmonè ak swen entansif nan Brigham and Women’s Hospital. Li travay nan entèfas byoloji chimik, jenomik, ak patojenèz bakteryèn pou etabli nouvo paradigm pou yon antibyotik baze sou biyoloji esansyèl ki nesesè pou yon patojèn lakòz maladi kay moun li antre sou li an. Avèk itilizasyon fòmasyon li kòm chimis sentetik, jenetisyen bakteryèn, ak medsen klinik, li eksplore apwòch pou deranje entèraksyon an patojèn-ot."
-      }
-    ]
-  },
-  "MailingSection": {
-    "Title": "TestBoston enskri aktyèlman pasyan Brigham and Women’s Hospital ki resevwa envitasyon. ",
-    "Text": "Si w pa te resevwa yon envitasyon pou antre nan etid la, men ou enterese rete okouran enfòmasyon jeneral TestBoston, tanpri antre nan lis bilten nouvèl nou an:"
-  }
+    },
+    "TeamSection": {
+      "Title": "Ekip nou an",
+      "Text": "Nou se yon ekip doktè ak chèchè nan domèn maladi enfektyez ki vle konprann pi byen fason COVID-19 afekte moun ak kominote yo pou nou kapab sèvi tout pasyan yo pi byen. ",
+      "List": [
+        {
+          "Name": "Doktè Ann E. Woolley, MD",
+          "Affiliations": "Enstriktè nan medsin",
+          "Info": "Doktè Ann Woolley se yon enstriktè nan medsin ak yon doktè nan domèn maladi enfektyez nan Brigham & Women’s Hospital ak Harvard Medical School. Doktè Woolley te resevwa yon BS nan jeni mekanik ak ayewospasyal nan Princeton University nan ane 2001 ak yon sètifika pòs-bakaloreya nan etid premedikal nan Columbia University anvan fòmasyon nan sante piblik ak nan medsin nan Mount Sinai School of medicine nan New York. Avèk yon konsantrasyon sou transplantasyon, epatit, ak enfeksyon kadyak, rechèch Doktè Woolley te demontre nouvo metòd pou itilize an tout sekirite ògàn moun ki konsidere kòm donatè men ki pa t apwopriye oparavan. Travay li te pèmèt rakousi tan datant pou moun ki bezwen don ògàn, epi pèmèt plis moun kapab chwazi pou yo vin donatè ògàn pou sove lavi."
+        },
+        {
+          "Name": "Doktè Lisa A. Cosimi, MD",
+          "Affiliations": "Asistan pwofesè, maladi enfektyèz nan Harvard Medical School, Global Health Equity",
+          "Info": "Doktè Cosimi se yon medsen asosye nan Global Health Equity & Incetuous Disease nan Brigham & Women’s Hospital, ak pwofesè adjwen nan medsin nan Harvard Medical School. Doktè Cosimi te resevwa yon BA nan ekonomi nan Cornell University an 1992 ak doktora an medsin nan Weill Cornell Medical College an 1996.  Li te fè rezidans li nan medsin entèn ak swen primè nan Massachusetts General Hospital epi fòmasyon nan maladi enfektyez nan pwogram bous konbine Partners.  Rechèch Doktè Cosimi te konsantre sou fason pou ranfòse sistèm sante yo ak kalite swen sante yo nan anviwònman ki gen resous limite. Gwoup li a, Partnership for Health Advancement in Vietnam (HAIVN), te asosye avèk Ministè Sante Vyetnam, Inivèsite Medikal ak lopital yo pou refòme ak modènize edikasyon travayè swen sante, ak amelyore kalite ak aksè nan swen sante pou VIH, tibèkiloz ak lòt enfeksyon k ap parèt nan tout peyi a."
+        },
+        {
+          "Name": "Doktè Deborah T. Hung, MD, PhD",
+          "Affiliations": "Pwofesè agreje, maladi enfektyez, swen pilmonè, ak swen entansif nan Harvard Medical School",
+          "Info": "Doktè Deborah Hung se pwofesè nan jenetik nan Massachusetts General Hospital Harvard Medical School, yon manm prensipal fakilte a ak ko-direktris pwogram maladi enfektyez ak mikwobyòm nan Broad Institute of MIT and Harvard, epi yon medsen tretan nan maladi enfektyez ak medsin swen pilmonè ak swen entansif nan Brigham and Women’s Hospital. Li travay nan entèfas byoloji chimik, jenomik, ak patojenèz bakteryèn pou etabli nouvo paradigm pou yon antibyotik baze sou biyoloji esansyèl ki nesesè pou yon patojèn lakòz maladi kay moun li antre sou li an. Avèk itilizasyon fòmasyon li kòm chimis sentetik, jenetisyen bakteryèn, ak medsen klinik, li eksplore apwòch pou deranje entèraksyon an patojèn-ot."
+        }
+      ]
+    },
+    "MailingSection": {
+      "Title": "TestBoston enskri aktyèlman pasyan Brigham and Women’s Hospital ki resevwa envitasyon. ",
+      "Text": "Si w pa te resevwa yon envitasyon pou antre nan etid la, men ou enterese rete okouran enfòmasyon jeneral TestBoston, tanpri antre nan lis bilten nouvèl nou an:"
+    }
   },
   "PrequalPage": {
     "Title": "Premyèman, konfime kalifikasyon ou",
@@ -241,7 +241,11 @@
   "Prism": {
     "ClearSearch": "Efase",
     "Email": "ADRÈS IMÈL SIJÈ A",
-    "NoEmail": "PA APLIKAB",
+    "NoneListed": {
+      "Title": "None listed",
+      "Text": "If the participant wants to bo able to login to the TestBoston site, please enable their TestBoston account",
+      "Link": "here"
+    },
     "Buttons": {
       "Enrollment": "Kòmanse enskripsyon an",
       "Dashboard": "Gade dach la"


### PR DESCRIPTION
Description - https://broadinstitute.atlassian.net/browse/DDP-4834