### PR TITLE
testboston: enable idp-initiated sso

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/authentication/auth0Adapter.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/authentication/auth0Adapter.service.ts
@@ -206,7 +206,10 @@ export class Auth0AdapterService implements OnDestroy {
     }
 
     public handleAdminAuthentication(onErrorCallback?: (e: any | null) => void): void {
-        this.adminWebAuth.parseHash((err, authResult) => {
+        const options = {
+            __enableIdPInitiatedLogin: true
+        };
+        this.adminWebAuth.parseHash(options, (err, authResult) => {
             if (authResult && authResult.accessToken && authResult.idToken) {
                 this.windowRef.nativeWindow.location.hash = '';
                 this.setSession(authResult, true);


### PR DESCRIPTION
It appears that TestBoston PIs are logging in to CRC UI using IdP-Initiated SSO. The `__enableIdPInitiatedLogin` option is required to support IdP-Initiated SSO. See docs [here](https://auth0.com/docs/protocols/saml/idp-initiated-sso#lock-auth0-js). As the docs indicate, there is _potential_ security risk with IdP-Initiated SSO (which is why I originally did not enable it), but we're probably fine since we're only allowing a restricted set of PI email accounts.