### PR TITLE
DDP-4849 IGNORE ME

### DIFF
--- a/config/deployment/prod/dispatch.yaml
+++ b/config/deployment/prod/dispatch.yaml
@@ -17,5 +17,11 @@ dispatch:
     service: pepper-backend
   - url: "dsm.datadonationplatform.org/api/*"
     service: study-manager-backend
+  - url: "dsm.datadonationplatform.org/app/*"
+    service: study-manager-backend
+  - url: "dsm.datadonationplatform.org/info/*"
+    service: study-manager-backend
+  - url: "dsm.datadonationplatform.org/ui/*"
+    service: study-manager-backend
   - url: "dsm.datadonationplatform.org/*"
     service: study-manager-ui

--- a/config/deployment/staging/dispatch.yaml
+++ b/config/deployment/staging/dispatch.yaml
@@ -17,7 +17,13 @@ dispatch:
     service: pepper-backend
   - url: "pepper-staging.datadonationplatform.org/*"
     service: pepper-backend
-  - url: "dsm.staging.datadonationplatform.org/api/*"
+  - url: "dsm-staging.datadonationplatform.org/api/*"
     service: study-manager-backend
-  - url: "dsm.staging.datadonationplatform.org/*"
+  - url: "dsm-staging.datadonationplatform.org/app/*"
+    service: study-manager-backend
+  - url: "dsm-staging.datadonationplatform.org/info/*"
+    service: study-manager-backend
+  - url: "dsm-staging.datadonationplatform.org/ui/*"
+    service: study-manager-backend
+  - url: "dsm-staging.datadonationplatform.org/*"
     service: study-manager-ui

--- a/config/deployment/test/dispatch.yaml
+++ b/config/deployment/test/dispatch.yaml
@@ -17,7 +17,13 @@ dispatch:
     service: pepper-backend
   - url: "pepper-test.datadonationplatform.org/*"
     service: pepper-backend
-  - url: "dsm.test.datadonationplatform.org/api/*"
+  - url: "dsm-test.datadonationplatform.org/api/*"
     service: study-manager-backend
-  - url: "dsm.test.datadonationplatform.org/*"
+  - url: "dsm-test.datadonationplatform.org/app/*"
+    service: study-manager-backend
+  - url: "dsm-test.datadonationplatform.org/info/*"
+    service: study-manager-backend
+  - url: "dsm-test.datadonationplatform.org/ui/*"
+    service: study-manager-backend
+  - url: "dsm-test.datadonationplatform.org/*"
     service: study-manager-ui


### PR DESCRIPTION
DDP-4849 Added routes for DSM GAE on test, staging, and prod.   Since these changes  require DNS updates as well, there is no harm in pushing  them  out now, as they  will not impact  prod.