### PR TITLE
DDP-4564: Manage cookie preferences

### DIFF
--- a/ddp-workspace/projects/ddp-prion/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-prion/src/app/app.module.ts
@@ -87,18 +87,83 @@ config.cookies = {
       list: [
         {
           name: 'auth0',
+          description: null,
+          duration: null
+        },
+        {
+          name: 'auth0_com.auth0.auth',
           description: 'authorization',
-          expiration: 'various'
+          duration: '30minutes'
+        },
+        {
+          name: 'auth0_auth0',
+          description: 'session',
+          duration: '3days'
+        },
+        {
+          name: 'auth0_auth0_compat',
+          description: 'session',
+          duration: '3days'
+        },
+        {
+          name: 'auth0_did',
+          description: 'ua_identifier',
+          duration: '1year'
+        },
+        {
+          name: 'auth0_did_compat',
+          description: 'ua_identifier',
+          duration: '1year'
         },
         {
           name: 'pepper',
-          description: 'authorization',
-          expiration: 'session'
+          description: null,
+          duration: null
+        },
+        {
+          name: 'pepper_session_key',
+          description: 'authentication',
+          duration: 'persistent'
+        },
+        {
+          name: 'pepper_token',
+          description: 'authentication',
+          duration: 'persistent'
+        },
+        {
+          name: 'pepper_cookie',
+          description: 'cookie',
+          duration: 'persistent'
+        },
+        {
+          name: 'pepper_studyLanguage',
+          description: 'language',
+          duration: 'persistent'
+        },
+        {
+          name: 'pepper_nextUrl',
+          description: 'navigation',
+          duration: 'session'
+        },
+        {
+          name: 'pepper_auth',
+          description: 'authentication',
+          duration: 'session'
         },
         {
           name: 'tcell',
-          description: 'authorization',
-          expiration: 'various'
+          description: null,
+          duration: null
+        },
+        {
+          name: 'tcell_agent_session_id',
+          description: 'security',
+          duration: 'persistent'
+        },
+        {
+          name: 'tcell_agent_policy_cache',
+          description: 'security',
+          duration: 'persistent'
         }
       ]
     },
@@ -107,19 +172,29 @@ config.cookies = {
       actions: ['Accept', 'Reject'],
       list: [
         {
+          name: 'google_analytics',
+          description: null,
+          duration: null
+        },
+        {
           name: 'ga',
           description: 'identification',
-          expiration: '2years'
+          duration: '2years'
         },
         {
           name: 'gid',
           description: 'grouping_behavior',
-          expiration: '24hours'
+          duration: '24hours'
         },
         {
           name: 'gat',
           description: 'throttling',
-          expiration: '10minutes'
+          duration: '10minutes'
+        },
+        {
+          name: 'gat_platform',
+          description: 'throttling',
+          duration: '10minutes'
         }
       ]
     }

--- a/ddp-workspace/projects/ddp-prion/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-prion/src/assets/i18n/en.json
@@ -476,29 +476,54 @@
       "Details": "Cookie Details",
       "Name": "Name",
       "Description": "Description",
-      "Expiration": "Expiration",
+      "Duration": "Duration",
       "Policy": "Privacy policy",
       "Submit": "Submit Preferences",
       "CookieName": {
-        "auth0": "auth0",
-        "pepper": "pepper platform",
-        "tcell": "tcell",
+        "auth0": "Auth0:",
+        "auth0_com.auth0.auth": "com.auth0.auth.#",
+        "auth0_auth0": "auth0",
+        "auth0_auth0_compat": "auth0_compat",
+        "auth0_did": "did",
+        "auth0_did_compat": "did_compat",
+        "pepper": "Pepper:",
+        "pepper_cookie": "prion_cookies_consent",
+        "pepper_session_key": "session_key",
+        "pepper_token": "token",
+        "pepper_studyLanguage": "studyLanguage",
+        "pepper_nextUrl": "nextUrl",
+        "pepper_auth": "localAuthParams",
+        "tcell": "Tcell:",
+        "tcell_agent_session_id": "tcell_agent_session_id",
+        "tcell_agent_policy_cache": "tcell_agent_policy_cache",
+        "google_analytics": "Google Analytics:",
         "ga": "_ga",
         "gid": "_gid",
-        "gat": "_gat"
+        "gat": "_gat",
+        "gat_platform": "_gat_platform"
       },
       "CookieDescription": {
-        "authorization": "user authorization",
-        "identification": "user identification",
+        "authentication": "authentication",
+        "authorization": "authorization",
+        "identification": "identification",
+        "navigation": "navigation helper",
         "grouping_behavior": "grouping user behavior",
-        "throttling": "throttling requests to increase the efficiency of network calls"
+        "throttling": "throttling to increase the efficiency of analytics collection",
+        "security": "security",
+        "cookie": "cookie preferences",
+        "language": "language preferences",
+        "session": "handles user sessions",
+        "ua_identifier": "the identifier for a device/user agent"
       },
-      "CookieExpiration": {
-        "various": "various",
+      "CookieDuration": {
         "session": "session",
+        "1year": "1 year",
         "2years": "2 years",
         "24hours": "24 hours",
-        "10minutes": "10 minutes"
+        "3days": "3 days",
+        "10minutes": "10 minutes",
+        "30minutes": "30 minutes",
+        "persistent": "persistent"
       }
     },
     "PrivacyPolicy": {

--- a/ddp-workspace/projects/ddp-prion/src/assets/i18n/es.json
+++ b/ddp-workspace/projects/ddp-prion/src/assets/i18n/es.json
@@ -476,29 +476,54 @@
       "Details": "es: Cookie Details",
       "Name": "es: Name",
       "Description": "es: Description",
-      "Expiration": "es: Expiration",
+      "Duration": "es: Duration",
       "Policy": "es: Privacy policy",
       "Submit": "es: Submit Preferences",
       "CookieName": {
-        "auth0": "es: auth0",
-        "pepper": "es: pepper platform",
-        "tcell": "es: tcell",
+        "auth0": "es: Auth0:",
+        "auth0_com.auth0.auth": "es: com.auth0.auth.#",
+        "auth0_auth0": "es: auth0",
+        "auth0_auth0_compat": "es: auth0_compat",
+        "auth0_did": "es: did",
+        "auth0_did_compat": "es: did_compat",
+        "pepper": "es: Pepper:",
+        "pepper_cookie": "es: prion_cookies_consent",
+        "pepper_session_key": "es: session_key",
+        "pepper_token": "es: token",
+        "pepper_studyLanguage": "es: studyLanguage",
+        "pepper_nextUrl": "es: nextUrl",
+        "pepper_auth": "es: localAuthParams",
+        "tcell": "es: Tcell:",
+        "tcell_agent_session_id": "es: tcell_agent_session_id",
+        "tcell_agent_policy_cache": "es: tcell_agent_policy_cache",
+        "google_analytics": "es: Google Analytics:",
         "ga": "es: _ga",
         "gid": "es: _gid",
-        "gat": "es: _gat"
+        "gat": "es: _gat",
+        "gat_platform": "es: _gat_platform"
       },
       "CookieDescription": {
-        "authorization": "es: user authorization",
-        "identification": "es: user identification",
+        "authentication": "es: authentication",
+        "authorization": "es: authorization",
+        "identification": "es: identification",
+        "navigation": "es: navigation helper",
         "grouping_behavior": "es: grouping user behavior",
-        "throttling": "es: throttling requests to increase the efficiency of network calls"
+        "throttling": "es: throttling to increase the efficiency of analytics collection",
+        "security": "es: security",
+        "cookie": "es: cookie preferences",
+        "language": "es: language preferences",
+        "session": "es: handles user sessions",
+        "ua_identifier": "es: the identifier for a device/user agent"
       },
-      "CookieExpiration": {
-        "various": "es: various",
+      "CookieDuration": {
         "session": "es: session",
+        "1year": "es: 1 year",
         "2years": "es: 2 years",
         "24hours": "es: 24 hours",
-        "10minutes": "es: 10 minutes"
+        "3days": "es: 3 days",
+        "10minutes": "es: 10 minutes",
+        "30minutes": "es: 30 minutes",
+        "persistent": "es: persistent"
       }
     },
     "PrivacyPolicy": {

--- a/ddp-workspace/projects/ddp-prion/src/assets/i18n/he.json
+++ b/ddp-workspace/projects/ddp-prion/src/assets/i18n/he.json
@@ -477,29 +477,54 @@
       "Details": "he: Cookie Details",
       "Name": "he: Name",
       "Description": "he: Description",
-      "Expiration": "he: Expiration",
+      "Duration": "he:  Duration",
       "Policy": "he: Privacy policy",
       "Submit": "he: Submit Preferences",
       "CookieName": {
-        "auth0": "he: auth0",
-        "pepper": "he: pepper platform",
-        "tcell": "he: tcell",
+        "auth0": "he: Auth0:",
+        "auth0_com.auth0.auth": "he: com.auth0.auth.#",
+        "auth0_auth0": "he: auth0",
+        "auth0_auth0_compat": "he: auth0_compat",
+        "auth0_did": "he: did",
+        "auth0_did_compat": "he: did_compat",
+        "pepper": "he: Pepper:",
+        "pepper_cookie": "he: prion_cookies_consent",
+        "pepper_session_key": "he: session_key",
+        "pepper_token": "he: token",
+        "pepper_studyLanguage": "he: studyLanguage",
+        "pepper_nextUrl": "he: nextUrl",
+        "pepper_auth": "he: localAuthParams",
+        "tcell": "he: Tcell:",
+        "tcell_agent_session_id": "he: tcell_agent_session_id",
+        "tcell_agent_policy_cache": "he: tcell_agent_policy_cache",
+        "google_analytics": "he: Google Analytics:",
         "ga": "he: _ga",
         "gid": "he: _gid",
-        "gat": "he: _gat"
+        "gat": "he: _gat",
+        "gat_platform": "he: _gat_platform"
       },
       "CookieDescription": {
-        "authorization": "he: user authorization",
-        "identification": "he: user identification",
+        "authentication": "he: authentication",
+        "authorization": "he: authorization",
+        "identification": "he: identification",
+        "navigation": "he: navigation helper",
         "grouping_behavior": "he: grouping user behavior",
-        "throttling": "he: throttling requests to increase the efficiency of network calls"
+        "throttling": "he: throttling to increase the efficiency of analytics collection",
+        "security": "he: security",
+        "cookie": "he: cookie preferences",
+        "language": "he: language preferences",
+        "session": "he: handles user sessions",
+        "ua_identifier": "he: the identifier for a device/user agent"
       },
-      "CookieExpiration": {
-        "various": "he: various",
+      "CookieDuration": {
         "session": "he: session",
+        "1year": "he: 1 year",
         "2years": "he: 2 years",
         "24hours": "he: 24 hours",
-        "10minutes": "he: 10 minutes"
+        "3days": "he: 3 days",
+        "10minutes": "he: 10 minutes",
+        "30minutes": "he: 30 minutes",
+        "persistent": "he: persistent"
       }
     },
     "PrivacyPolicy": {

--- a/ddp-workspace/projects/ddp-prion/src/assets/i18n/zh.json
+++ b/ddp-workspace/projects/ddp-prion/src/assets/i18n/zh.json
@@ -476,29 +476,54 @@
       "Details": "zh: Cookie Details",
       "Name": "zh: Name",
       "Description": "zh: Description",
-      "Expiration": "zh: Expiration",
+      "Duration": "zh:  Duration",
       "Policy": "zh: Privacy policy",
       "Submit": "zh: Submit Preferences",
       "CookieName": {
-        "auth0": "zh: auth0",
-        "pepper": "zh: pepper platform",
-        "tcell": "zh: tcell",
+        "auth0": "zh: Auth0:",
+        "auth0_com.auth0.auth": "zh: com.auth0.auth.#",
+        "auth0_auth0": "zh: auth0",
+        "auth0_auth0_compat": "zh: auth0_compat",
+        "auth0_did": "zh: did",
+        "auth0_did_compat": "zh: did_compat",
+        "pepper": "zh: Pepper:",
+        "pepper_cookie": "zh: prion_cookies_consent",
+        "pepper_session_key": "zh: session_key",
+        "pepper_token": "zh: token",
+        "pepper_studyLanguage": "zh: studyLanguage",
+        "pepper_nextUrl": "zh: nextUrl",
+        "pepper_auth": "zh: localAuthParams",
+        "tcell": "zh: Tcell:",
+        "tcell_agent_session_id": "zh: tcell_agent_session_id",
+        "tcell_agent_policy_cache": "zh: tcell_agent_policy_cache",
+        "google_analytics": "zh: Google Analytics:",
         "ga": "zh: _ga",
         "gid": "zh: _gid",
-        "gat": "zh: _gat"
+        "gat": "zh: _gat",
+        "gat_platform": "zh: _gat_platform"
       },
       "CookieDescription": {
-        "authorization": "zh: user authorization",
-        "identification": "zh: user identification",
+        "authentication": "zh: authentication",
+        "authorization": "zh: authorization",
+        "identification": "zh: identification",
+        "navigation": "zh: navigation helper",
         "grouping_behavior": "zh: grouping user behavior",
-        "throttling": "zh: throttling requests to increase the efficiency of network calls"
+        "throttling": "zh: throttling to increase the efficiency of analytics collection",
+        "security": "zh: security",
+        "cookie": "zh: cookie preferences",
+        "language": "zh: language preferences",
+        "session": "zh: handles user sessions",
+        "ua_identifier": "zh: the identifier for a device/user agent"
       },
-      "CookieExpiration": {
-        "various": "zh: various",
+      "CookieDuration": {
         "session": "zh: session",
+        "1year": "zh: 1 year",
         "2years": "zh: 2 years",
         "24hours": "zh: 24 hours",
-        "10minutes": "zh: 10 minutes"
+        "3days": "zh: 3 days",
+        "10minutes": "zh: 10 minutes",
+        "30minutes": "zh: 30 minutes",
+        "persistent": "zh: persistent"
       }
     },
     "PrivacyPolicy": {

--- a/ddp-workspace/projects/ddp-prion/src/styles.scss
+++ b/ddp-workspace/projects/ddp-prion/src/styles.scss
@@ -118,10 +118,7 @@ a:focus {
 
 .Button--primaryYellow,
 .Button--primaryYellow:active,
-.Button--primaryYellow:focus,
-.CookieButton--Accept,
-.CookieButton--Accept:active,
-.CookieButton--Accept:focus {
+.Button--primaryYellow:focus {
     border: 1px solid #F2B816 !important;
     background-color: #F2B816 !important;
     color: #ffffff !important;
@@ -133,6 +130,32 @@ a:focus {
   border: 1px solid #F2B816 !important;
   background-color: transparent !important;
   color: #F2B816 !important;
+}
+
+.CookieButton--Accept,
+.CookieButton--Accept:active,
+.CookieButton--Accept:focus {
+  border: 1px solid #F2B816 !important;
+  background-color: #F2B816 !important;
+  color: #000000;
+}
+
+.CookieButton--Preferences,
+.CookieButton--Preferences:active,
+.CookieButton--Preferences:focus {
+  width: 200px;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: bold;
+  color: #FFFFFF;
+  cursor: pointer;
+  border: none;
+  background-color: transparent;
+
+  &:hover,
+  &:active {
+    color: #a88838;
+  }
 }
 
 .Button--primaryNeutral,
@@ -3253,6 +3276,10 @@ p.Medium {
     display: flex;
     flex-direction: row;
     justify-content: space-between;
+
+    .Button--primary {
+      margin-left: auto;
+    }
   }
 
   &--link {
@@ -3286,6 +3313,17 @@ p.Medium {
   &--tabHeader h4,
   &--tabTable h4 {
     font-weight: bold;
+  }
+
+  &--cookieSource:not(:first-of-type) {
+    border-top: 1px solid #e0e0e0;
+  }
+
+  &--cookieSource {
+    .mat-cell {
+      font-weight: bold;
+      font-size: 1rem;
+    }
   }
 
   &--tabActions {
@@ -3361,16 +3399,35 @@ ddp-cookies-preferences-modal {
 
   .mat-tab-body-content {
     padding: 10px 0 10px 20px;
+    height: 450px;
   }
 
   .mat-table {
+    max-height: 250px;
+    overflow: auto;
     background-color: #fafafa;
 
     .mat-cell {
-      padding-right: 24px;
+      padding-right: 10px;
+      font-size: 0.8rem;
+      min-width: 100px;
+    }
+
+    .mat-header-cell {
+      padding-right: 10px;
+      min-width: 100px;
+    }
+
+    .mat-cell:first-of-type,
+    .mat-header-cell:first-of-type {
+      padding-left: 10px;
+      min-width: 190px;
+    }
+
+    .mat-row {
+      border-bottom: none;
     }
   }
-
 }
 
 @media only screen and (max-width: 1026px) {
@@ -3392,6 +3449,14 @@ ddp-cookies-preferences-modal {
         position: absolute;
         top: 0;
         right: 0;
+      }
+    }
+
+    &--actions {
+      flex-direction: column;
+
+      ddp-privacy-policy-button {
+        margin: 20px 0;
       }
     }
   }
@@ -3416,6 +3481,15 @@ ddp-cookies-preferences-modal {
     .mat-header-row {
       display: flex !important;
     }
+    .mat-table {
+      .mat-header-cell {
+        min-width: 100px;
+      }
+      .mat-cell {
+        font-size: 0.9rem;
+        min-width: 100px;
+      }
+    }
 
     .mat-row {
       flex-direction: row !important;
@@ -3424,6 +3498,7 @@ ddp-cookies-preferences-modal {
 
   .cdk-overlay-pane {
     max-width: 100vw !important;
+    height: 100vh !important;
   }
 }
 
@@ -3440,6 +3515,10 @@ ddp-cookies-preferences-modal {
   }
 
   ddp-cookies-preferences-modal {
+    .PageContent-title {
+      font-size: 1.35rem;
+    }
+
     .mat-tab-body-content {
       padding: 10px 0;
     }
@@ -3461,5 +3540,22 @@ ddp-cookies-preferences-modal {
 ddp-privacy-policy-modal {
   .Container, .PageContent {
     background: transparent;
+  }
+
+  .Container {
+    margin: 0 !important;
+    padding: 0;
+
+    .col-lg-8, .col-md-10, .col-sm-12, .col-xs-12 {
+      width: 100%;
+    }
+  }
+}
+
+@media only screen and (max-width: 767px) {
+  ddp-privacy-policy-modal {
+    .mat-dialog-content {
+      max-height: 100%;
+    }
   }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/cookies/cookiesBanner/cookiesBanner.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/cookies/cookiesBanner/cookiesBanner.component.ts
@@ -1,11 +1,6 @@
-import { Component, Inject } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { CookiesManagementService } from '../../../services/cookiesManagement.service';
-import { MatDialog } from '@angular/material/dialog';
-import { ConfigurationService } from '../../../services/configuration.service';
-import { NoopScrollStrategy } from '@angular/cdk/overlay';
-import { CookiesPreferencesModalComponent } from '../cookiesPreferencesModal/cookiesPreferencesModal.component';
-import { PrivacyPolicyModalComponent } from '../../privacy-policy/privacyPolicyModal.component';
-import { PrivacyModalData } from "../../../models/privacyModalData";
+import { ConsentStatuses } from '../../../models/cookies';
 
 @Component({
   selector: 'ddp-cookies-banner',
@@ -13,55 +8,25 @@ import { PrivacyModalData } from "../../../models/privacyModalData";
   <div class="cookiesBanner">
     <div class="cookiesBanner--text">
       <span translate>SDK.CookiesBanner.Text_Before_Policy_Link</span>
-      <button class="cookiesBanner--link policy"
-              (click)="openPolicy()"
-              [innerText]="'SDK.CookiesBanner.Policy' | translate"></button>
+      <ddp-privacy-policy-button [className]="'cookiesBanner--link policy'"></ddp-privacy-policy-button>
       <span translate>SDK.CookiesBanner.Text_After_Policy_Link</span>
     </div>
-    <button class="cookiesBanner--link"
-            (click)="openPreferences()"
-            [innerText]="'SDK.CookiesBanner.Preferences' | translate"></button>
+    <ddp-cookies-preferences-button [className]="'CookieButton--Preferences col-lg-4 col-md-4 col-sm-8 col-xs-8'"
+                                    [privacyPolicyLink]="true">
+    </ddp-cookies-preferences-button>
     <button class="Button CookieButton--Reject col-lg-4 col-md-4 col-sm-8 col-xs-8"
-            (click)="reject()"
+            (click)="cookiesService.updatePreferences(statuses.defaultReject)"
             [innerText]="'SDK.CookiesBanner.Reject' | translate">
     </button>
     <button class="Button CookieButton--Accept col-lg-4 col-md-4 col-sm-8 col-xs-8"
-            (click)="accept()"
+            (click)="cookiesService.updatePreferences(statuses.defaultAccept)"
             [innerText]="'SDK.CookiesBanner.Accept' | translate">
     </button>
   </div>`
 })
 export class CookiesBannerComponent {
-  constructor(private cookiesService: CookiesManagementService,
-              public dialog: MatDialog,
-              @Inject('ddp.config') private configuration: ConfigurationService) {
-  }
+  public statuses = ConsentStatuses;
 
-  accept(): void {
-    this.cookiesService.acceptCookies();
-  }
-
-  reject(): void {
-    this.cookiesService.rejectNotFunctionalCookies();
-  }
-
-  openPreferences(): void {
-    this.dialog.open(CookiesPreferencesModalComponent, {
-      width: '740px',
-      data: this.configuration.cookies,
-      autoFocus: false,
-      disableClose: true,
-      scrollStrategy: new NoopScrollStrategy()
-    });
-  }
-
-  openPolicy(): void {
-    this.dialog.open(PrivacyPolicyModalComponent, {
-      width: '740px',
-      data: new PrivacyModalData(this.configuration.usePrionPrivacyPolicyTemplate),
-      autoFocus: false,
-      disableClose: false,
-      scrollStrategy: new NoopScrollStrategy()
-    });
+  constructor(public cookiesService: CookiesManagementService) {
   }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/cookies/cookiesPreferencesModal/cookiesPreferencesButton.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/cookies/cookiesPreferencesModal/cookiesPreferencesButton.component.ts
@@ -1,0 +1,31 @@
+import { Component, Inject, Input } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { NoopScrollStrategy } from '@angular/cdk/overlay';
+import { ConfigurationService } from '../../../services/configuration.service';
+import { CookiesPreferencesModalComponent } from '../cookiesPreferencesModal/cookiesPreferencesModal.component';
+
+@Component({
+  selector: 'ddp-cookies-preferences-button',
+  template: `
+    <button (click)="openPreferences()"
+            [innerText]="'SDK.CookiesBanner.Preferences' | translate"
+            [class]="this.className"></button>`
+})
+export class CookiesPreferencesButtonComponent {
+  @Input() className: string;
+  @Input() privacyPolicyLink: boolean;
+
+  constructor(public dialog: MatDialog,
+              @Inject('ddp.config') private configuration: ConfigurationService) {
+  }
+
+  openPreferences(): void {
+    this.dialog.open(CookiesPreferencesModalComponent, {
+      width: '740px',
+      data: { cookies: this.configuration.cookies, privacyPolicyLink: this.privacyPolicyLink },
+      autoFocus: false,
+      disableClose: true,
+      scrollStrategy: new NoopScrollStrategy()
+    });
+  }
+}

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/cookies/cookiesPreferencesModal/cookiesPreferencesModal.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/cookies/cookiesPreferencesModal/cookiesPreferencesModal.component.ts
@@ -1,21 +1,19 @@
-import { Component, Inject } from '@angular/core';
+import { Component, Inject, OnInit } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA, MatDialog } from '@angular/material/dialog';
-import { Cookies } from '../../../models/cookies';
-import { PrivacyPolicyModalComponent } from '../../privacy-policy/privacyPolicyModal.component';
-import { NoopScrollStrategy } from '@angular/cdk/overlay';
-import { PrivacyModalData } from "../../../models/privacyModalData";
-import { ConfigurationService } from "../../../services/configuration.service";
+import { CookiesManagementService } from '../../../services/cookiesManagement.service';
+import { ConsentStatuses } from '../../../models/cookies';
 
 @Component({
   selector: 'ddp-cookies-preferences-modal',
   template: `
     <div class="cookiesModal cookiesModal--header">
-      <img class="cookiesModal--logo" lazy-resource src="/assets/images/project-logo-dark.svg"
+      <img class="cookiesModal--logo" lazy-resource
+           src="/assets/images/project-logo-dark.svg"
            [attr.alt]="'SDK.Common.LogoAlt' | translate">
       <h1 class="PageContent-title" translate>SDK.CookiesModal.Title</h1>
       <button mat-icon-button (click)="close()"><mat-icon>close</mat-icon></button>
     </div>
-    <div mat-dialog-content>
+    <div>
       <mat-tab-group>
         <mat-tab [label]="'SDK.CookiesModal.Privacy' | translate">
           <div class="cookiesModal--tabHeader">
@@ -23,17 +21,20 @@ import { ConfigurationService } from "../../../services/configuration.service";
           </div>
           <p translate>SDK.CookiesModal.Privacy_Text</p>
         </mat-tab>
-
         <!-- Create tabs for all cookie types -->
-
-        <mat-tab *ngFor="let cookie of data.cookies" [label]="'SDK.CookiesModal.' + cookie.type | translate">
+        <mat-tab *ngFor="let cookie of data.cookies.cookies" [label]="'SDK.CookiesModal.' + cookie.type | translate">
           <section>
             <div class="cookiesModal--tabHeader">
               <h4 translate>{{ 'SDK.CookiesModal.' + cookie.type }}</h4>
               <div  class="cookiesModal--tabActions">
-                <mat-radio-group *ngIf="cookie.actions" aria-label="Select an option">
-                  <mat-radio-button value="Accept"><span translate>SDK.CookiesModal.Accept</span></mat-radio-button>
-                  <mat-radio-button value="Reject"><span translate>SDK.CookiesModal.Reject</span></mat-radio-button>
+                <mat-radio-group *ngIf="cookie.actions" aria-label="Select an option"
+                                 (change)="this.onChange(cookie.type, $event.value)">
+                  <mat-radio-button value="Accept" [checked]="this.cookies[cookie.type]">
+                    <span translate>SDK.CookiesModal.Accept</span>
+                  </mat-radio-button>
+                  <mat-radio-button value="Reject" [checked]="!this.cookies[cookie.type]">
+                    <span translate>SDK.CookiesModal.Reject</span>
+                  </mat-radio-button>
                 </mat-radio-group>
                 <p *ngIf="!cookie.actions" translate>SDK.CookiesModal.AlwaysOn</p>
               </div>
@@ -43,67 +44,77 @@ import { ConfigurationService } from "../../../services/configuration.service";
           <section *ngIf="cookie.list" class="cookiesModal--tabTable">
             <h4 class="cookiesModal--tableHeader" translate>SDK.CookiesModal.Details</h4>
             <mat-table [dataSource]="cookie.list" class="mat-elevation-z0">
-
               <!-- Name Column -->
               <ng-container matColumnDef="name">
                 <mat-header-cell *matHeaderCellDef translate>SDK.CookiesModal.Name</mat-header-cell>
-                <mat-cell *matCellDef="let element" translate> {{'SDK.CookiesModal.CookieName.' + element.name}} </mat-cell>
+                <mat-cell *matCellDef="let element" translate>
+                  {{'SDK.CookiesModal.CookieName.' + element.name}}
+                </mat-cell>
               </ng-container>
-
               <!-- Description Column -->
               <ng-container matColumnDef="description">
                 <mat-header-cell *matHeaderCellDef translate>SDK.CookiesModal.Description</mat-header-cell>
-                <mat-cell *matCellDef="let element" translate> {{'SDK.CookiesModal.CookieDescription.' + element.description}} </mat-cell>
+                <mat-cell *matCellDef="let element" translate>
+                  {{element.description ? 'SDK.CookiesModal.CookieDescription.' + element.description : null}}
+                </mat-cell>
               </ng-container>
-
-              <!-- Expiration Column -->
-              <ng-container matColumnDef="expiration">
-                <mat-header-cell *matHeaderCellDef translate>SDK.CookiesModal.Expiration </mat-header-cell>
-                <mat-cell *matCellDef="let element" translate> {{'SDK.CookiesModal.CookieExpiration.' + element.expiration}} </mat-cell>
+              <!-- Duration Column -->
+              <ng-container matColumnDef="duration">
+                <mat-header-cell *matHeaderCellDef translate>SDK.CookiesModal.Duration </mat-header-cell>
+                <mat-cell *matCellDef="let element" translate>
+                  {{element.duration ? 'SDK.CookiesModal.CookieDuration.' + element.duration : null}}
+                </mat-cell>
               </ng-container>
-
-              <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-              <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+              <mat-header-row *matHeaderRowDef="displayedColumns; sticky: true"></mat-header-row>
+              <mat-row *matRowDef="let row; columns: displayedColumns; let element"
+                       [ngClass]="{'cookiesModal--cookieSource' : !element.description}"></mat-row>
             </mat-table>
           </section>
         </mat-tab>
-
       </mat-tab-group>
     </div>
     <div mat-dialog-actions class="cookiesModal--actions">
-      <button class="cookiesModal--link"
-              (click)="openPolicy()"
-              [innerText]="'SDK.CookiesBanner.Policy' | translate"></button>
-      <button class="Button Button--primary col-lg-4 col-md-4 col-sm-8 col-xs-8"
+      <ddp-privacy-policy-button *ngIf="this.data.privacyPolicyLink" [className]="'cookiesModal--link'"></ddp-privacy-policy-button>
+      <button class="Button Button--primary col-lg-4 col-md-4 col-sm-8 col-xs-12"
               (click)="submit()"
               [innerText]="'SDK.CookiesModal.Submit' | translate">
       </button>
     </div>`,
 })
-export class CookiesPreferencesModalComponent {
-  public displayedColumns: string[] = ['name', 'description', 'expiration'];
+export class CookiesPreferencesModalComponent implements OnInit {
+  public displayedColumns: string[] = ['name', 'description', 'duration'];
+  public cookies;
 
   constructor(public dialogRef: MatDialogRef<CookiesPreferencesModalComponent>,
+              private cookiesService: CookiesManagementService,
               public dialog: MatDialog,
-              @Inject('ddp.config') private configuration: ConfigurationService,
-              @Inject(MAT_DIALOG_DATA) public data: Cookies) {
+              @Inject(MAT_DIALOG_DATA) public data) {
   }
 
-  close(): void {
-    this.dialogRef.close();
+  ngOnInit(): void {
+    const initialCookiesAcceptance = this.cookiesService.getCurrentCookiesAcceptance();
+    this.setDefaultAcceptance(initialCookiesAcceptance);
   }
 
-  submit(): void {
-    this.dialogRef.close();
-  }
-
-  openPolicy(): void {
-    this.dialog.open(PrivacyPolicyModalComponent, {
-      width: '740px',
-      data: new PrivacyModalData(this.configuration.usePrionPrivacyPolicyTemplate),
-      autoFocus: false,
-      disableClose: false,
-      scrollStrategy: new NoopScrollStrategy()
+  private setDefaultAcceptance(initialCookies): void {
+    this.cookies = {...initialCookies};
+    Object.keys(initialCookies).forEach(x => {
+      if (initialCookies[x] === null) {
+        this.cookies[x] = true;
+      }
     });
+  }
+
+  public onChange(cookieType, value): void {
+    this.cookies[cookieType] = value === 'Accept';
+  }
+
+  public close(): void {
+    this.dialogRef.close();
+  }
+
+  public submit(): void {
+    this.cookiesService.updatePreferences(ConsentStatuses.managed, this.cookies);
+    this.dialogRef.close();
   }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/privacy-policy/prionPrivacyPolicy.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/privacy-policy/prionPrivacyPolicy.component.ts
@@ -92,7 +92,7 @@ import {
               </p>
               <p translate>SDK.PrivacyPolicy.Cookies.Text.P8</p>
               <div class="CenterDiv SpacedButtonDiv">
-                <button translate>SDK.PrivacyPolicy.CookiePreferences</button>
+                <ddp-cookies-preferences-button [privacyPolicyLink]="false" [className]="'Button Button--primary'"></ddp-cookies-preferences-button>
               </div>
               <p><span class="Accent" translate>SDK.PrivacyPolicy.Cookies.Text.P9Bold</span><span translate>SDK.PrivacyPolicy.Cookies.Text.P10</span>
               </p>

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/privacy-policy/privacyPolicyButton.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/privacy-policy/privacyPolicyButton.component.ts
@@ -1,0 +1,31 @@
+import { Component, Inject, Input } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { NoopScrollStrategy } from '@angular/cdk/overlay';
+import { PrivacyPolicyModalComponent } from './privacyPolicyModal.component';
+import { PrivacyModalData } from '../../models/privacyModalData';
+import { ConfigurationService } from '../../services/configuration.service';
+
+@Component({
+  selector: 'ddp-privacy-policy-button',
+  template: `
+    <button (click)="openPolicy()"
+            [innerText]="'SDK.CookiesBanner.Policy' | translate"
+            [class]="this.className"></button>`
+})
+export class PrivacyPolicyButtonComponent {
+  @Input() className: string;
+
+  constructor(public dialog: MatDialog,
+              @Inject('ddp.config') private configuration: ConfigurationService) {
+  }
+
+  openPolicy(): void {
+    this.dialog.open(PrivacyPolicyModalComponent, {
+      width: '740px',
+      data: new PrivacyModalData(this.configuration.usePrionPrivacyPolicyTemplate),
+      autoFocus: false,
+      disableClose: false,
+      scrollStrategy: new NoopScrollStrategy()
+    });
+  }
+}

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/privacy-policy/privacyPolicyModal.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/privacy-policy/privacyPolicyModal.component.ts
@@ -3,13 +3,13 @@ import {
   Inject
 } from '@angular/core';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
-import { PrivacyModalData } from "../../models/privacyModalData";
+import { PrivacyModalData } from '../../models/privacyModalData';
 
 @Component({
   selector: 'ddp-privacy-policy-modal',
   template: `
-    <div class="cookiesModal cookiesModal__header">
-      <img class="cookiesModal__logo" lazy-resource src="/assets/images/project-logo-dark.svg"
+    <div class="cookiesModal cookiesModal--header">
+      <img class="cookiesModal--logo" lazy-resource src="/assets/images/project-logo-dark.svg"
            [attr.alt]="'Toolkit.Common.LogoAlt' | translate">
       <button mat-icon-button (click)="close()"><mat-icon>close</mat-icon></button>
     </div>

--- a/ddp-workspace/projects/ddp-sdk/src/lib/ddp.module.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/ddp.module.ts
@@ -16,8 +16,10 @@ import { CookieModule } from 'ngx-cookie';
 import { CookiesBannerComponent } from './components/cookies/cookiesBanner/cookiesBanner.component';
 import { CookiesManagementService } from './services/cookiesManagement.service';
 import { CookiesPreferencesModalComponent } from './components/cookies/cookiesPreferencesModal/cookiesPreferencesModal.component';
+import { CookiesPreferencesButtonComponent } from './components/cookies/cookiesPreferencesModal/cookiesPreferencesButton.component';
+import { PrivacyPolicyButtonComponent } from './components/privacy-policy/privacyPolicyButton.component';
 import { PrivacyPolicyModalComponent } from './components/privacy-policy/privacyPolicyModal.component';
-import { PrionPrivacyPolicyComponent} from "./components/privacy-policy/prionPrivacyPolicy.component";
+import { PrionPrivacyPolicyComponent } from './components/privacy-policy/prionPrivacyPolicy.component';
 import { AnalyticsManagementService } from './services/analyticsManagement.service';
 
 // Angular JWT
@@ -368,6 +370,8 @@ export function createTranslateLoader(http: HttpClient): TranslateHttpLoader {
 
     CookiesBannerComponent,
     CookiesPreferencesModalComponent,
+    CookiesPreferencesButtonComponent,
+    PrivacyPolicyButtonComponent,
     PrivacyPolicyModalComponent,
     PrionPrivacyPolicyComponent
   ],
@@ -436,6 +440,8 @@ export function createTranslateLoader(http: HttpClient): TranslateHttpLoader {
 
     CookiesBannerComponent,
     CookiesPreferencesModalComponent,
+    CookiesPreferencesButtonComponent,
+    PrivacyPolicyButtonComponent,
     PrivacyPolicyModalComponent,
     PrionPrivacyPolicyComponent
   ],

--- a/ddp-workspace/projects/ddp-sdk/src/lib/guards/irb.guard.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/guards/irb.guard.ts
@@ -17,7 +17,7 @@ export class IrbGuard implements CanActivate {
 
     public canActivate(next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
         if (this.session.isAuthenticatedSession() || this.irbPassword.isIrbAuthenticated()) {
-            this.cookiesManagementService.checkCookiesPolicy();
+          this.cookiesManagementService.checkCookiesConsent();
             return of(true);
         } else {
             return this.irbPassword.requiresIrbAuthentication().pipe(

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/cookies.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/cookies.ts
@@ -1,7 +1,7 @@
 export interface Cookie {
   name: string;
   description: string;
-  expiration: string;
+  duration: string;
 }
 
 export type CookiesTypes = 'Functional' | 'Analytical';
@@ -12,4 +12,18 @@ export interface Cookies {
     actions: ['Accept', 'Reject'] | null;
     list: Array<Cookie>;
   }>;
+}
+
+export type CookiesConsentStatuses = 'default_accept' | 'default_reject' | 'managed';
+
+export enum ConsentStatuses {
+  defaultAccept= 'default_accept',
+  defaultReject = 'default_reject',
+  managed = 'managed'
+}
+
+export interface CookiesPreferences {
+  decision: boolean;
+  status: CookiesConsentStatuses;
+  cookies: {};
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/analyticsManagement.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/analyticsManagement.service.ts
@@ -1,10 +1,15 @@
 import { Injectable } from '@angular/core';
+import { CookieService } from 'ngx-cookie';
 
 declare const DDP_ENV: any;
 declare const ga: Function;
 
 @Injectable()
 export class AnalyticsManagementService {
+
+  constructor(private cookie: CookieService) {
+  }
+
   public trackAnalytics(): void {
     this.startGATracking();
   }
@@ -15,16 +20,47 @@ export class AnalyticsManagementService {
 
   private doNotTrackGA(): void {
     window['ga-disable-' + DDP_ENV.platformGAToken] = true;
+    window['ga-disable-' + DDP_ENV.projectGAToken] = true;
+    this.removeTrackers();
+    this.removeStoredCookies();
   }
 
   private startGATracking(): void {
     window['ga-disable-' + DDP_ENV.platformGAToken] = false;
+    window['ga-disable-' + DDP_ENV.projectGAToken] = false;
+
     ga(() => {
       // @ts-ignore, create trackers if non created
       if (!ga.getAll().length) {
         ga('create', DDP_ENV.projectGAToken, 'auto');
         ga('create', DDP_ENV.platformGAToken, 'auto', 'platform');
       }
+
+      // @ts-ignore,
+      const trackers = ga.getAll();
+      trackers.forEach(x => {
+        x.set('page');
+        x.send('pageview');
+      });
     });
+  }
+
+  private removeTrackers(): void {
+    ga(() => {
+      // @ts-ignore
+      if (ga.getAll().length) {
+        // @ts-ignore
+        const trackers = ga.getAll();
+        // @ts-ignore
+        trackers.forEach(x => ga.remove(x.get('name')));
+      }
+    });
+  }
+
+  private removeStoredCookies(): void {
+    this.cookie.remove('_ga');
+    this.cookie.remove('_gid');
+    this.cookie.remove('_gat');
+    this.cookie.remove('_gat_platform');
   }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/public-api.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/public-api.ts
@@ -81,6 +81,8 @@ export * from './lib/components/address/addressEmbedded.component';
 export * from './lib/components/activityForm/activity.component';
 export * from './lib/components/changeLanguageRedirect.component';
 export * from './lib/components/cookies/cookiesBanner/cookiesBanner.component';
+export * from './lib/components/privacy-policy/privacyPolicyButton.component';
+export * from './lib/components/cookies/cookiesPreferencesModal/cookiesPreferencesButton.component';
 export * from './lib/components/privacy-policy/privacyPolicyModal.component';
 export * from './lib/components/privacy-policy/prionPrivacyPolicy.component';
 

--- a/ddp-workspace/projects/toolkit-prion/src/lib/components/app/prionApp.component.ts
+++ b/ddp-workspace/projects/toolkit-prion/src/lib/components/app/prionApp.component.ts
@@ -49,7 +49,7 @@ export class PrionAppComponent implements OnInit, OnDestroy {
   public ngOnInit(): void {
     this.initBrowserWarningListener();
     this.initSessionWillExpireListener();
-    this.initHasToSetCookiesPolicyListener();
+    this.initHasToSetCookiesPreferencesListener();
     this.initTranslate();
     this.unsupportedBrowser = this.browserContent.unsupportedBrowser();
   }
@@ -87,13 +87,12 @@ export class PrionAppComponent implements OnInit, OnDestroy {
     this.anchor.add(modalOpen).add(modalClose);
   }
 
-  private initHasToSetCookiesPolicyListener(): void {
-    const hasToSetCookiesPolicy =  this.cookiesManagementService.getHasToSetCookiesPolicy().subscribe(x => {
+  private initHasToSetCookiesPreferencesListener(): void {
+    const hasToSetCookiesPreferences =  this.cookiesManagementService.getHasToSetCookiesPreferences().subscribe(x => {
       this.showCookiesBanner = x;
     });
-    this.anchor.add(hasToSetCookiesPolicy);
+    this.anchor.add(hasToSetCookiesPreferences);
   }
-
 
   private initTranslate(): void {
     const session = localStorage.getItem('session_key');


### PR DESCRIPTION
Current PR adds ability to manage cookies preferences.

**AC1, AC2**
When participant clicks on “Manage Preferences” in the cookie banner
![image](https://user-images.githubusercontent.com/54633385/90216879-8ed78f00-de21-11ea-9431-88b66d67ddaa.png)

the modal “Manage Cookie Preferences” is displayed
![image](https://user-images.githubusercontent.com/54633385/90216899-9a2aba80-de21-11ea-8864-0766eb0e5f6c.png)


**AC3**
There are 3 tabs: “Your Privacy”, “Functional Cookies”, “Analytical Cookies”
For example:
![image](https://user-images.githubusercontent.com/54633385/90216921-ab73c700-de21-11ea-998d-6f2ac2795182.png)

But any additional categories of cookies can be added to the type CookiesTypes and listed in the project configuration.

**AC4**
Click on the “Submit Preferences” button -> submits the accepted/rejected cookies -> user preferences set in the Local Storage under `prion_cookies_consent` cookie + dismisses the modal and the underlying cookie banner
![image](https://user-images.githubusercontent.com/54633385/90217164-5edcbb80-de22-11ea-9503-20d91cf090cd.png)


**AC5**
Click on the “X” -> dismiss the modal, not changes apply

**AC6**
Click on the “Privacy Policy” link -> launch the Privacy Policy page in the modal
![image](https://user-images.githubusercontent.com/54633385/90216972-ccd4b300-de21-11ea-82fb-0456e81f170b.png)

**AC7**
The cookie preferences selected persist across sessions since set in the Local Storage

**AC8**
On mobile view the modal takes up the whole view port
![image](https://user-images.githubusercontent.com/54633385/90217125-3ce33900-de22-11ea-8830-69c69f384d25.png)


**AC9**
Added a button to launch cookie preference panel in the Privacy Policy page
![image](https://user-images.githubusercontent.com/54633385/90217218-93e90e00-de22-11ea-9369-b009ac828bfe.png)

**AC10**
Added logger to the cookies consent update event