### PR TITLE
DDP-4853 support marking phone required in address component

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.spec.ts
@@ -31,6 +31,7 @@ class FakeAddressInputComponent {
   @Output()valueChanged = new EventEmitter();
   @Input()addressErrors;
   @Input()country;
+  @Input()phoneRequired;
   @Input()
   set address(val: Address | null) {
     console.log('set address called with: %o', val);

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.ts
@@ -73,6 +73,7 @@ interface AddressSuggestion {
             [addressErrors]="addressErrors$ | async"
             [readonly]="isReadOnly$ | async"
             [country]="staticCountry$ | async"
+            [phoneRequired]="block.requirePhone"
             (componentBusy)="isInputComponentBusy$.next($event)"></ddp-address-input>
     <ddp-validation-message
             *ngIf="(errorMessagesToDisplay$ | async).length > 0"

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.component.ts
@@ -1,4 +1,5 @@
 import {
+  ChangeDetectorRef,
   ChangeDetectionStrategy,
   Component,
   ElementRef,
@@ -20,6 +21,7 @@ import * as _ from 'underscore';
 import { mergeMap, take, takeUntil, tap } from 'rxjs/operators';
 import { AddressInputService } from '../address/addressInput.service';
 import { NGXTranslateService } from '../../services/internationalization/ngxTranslate.service';
+import { AddressService } from '../../services/address.service';
 
 @Component({
   selector: 'ddp-address-input',
@@ -147,7 +149,7 @@ import { NGXTranslateService } from '../../services/internationalization/ngxTran
       padding: 0;
       margin:0;
     }`],
-  providers: [AddressInputService],
+  providers: [],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 
@@ -182,7 +184,7 @@ export class AddressInputComponent implements OnInit, OnDestroy {
   }
 
   @Input()
-  phoneRequired: boolean = false;
+  phoneRequired = false;
 
   /**
    * Will emit event with address as it changes in form
@@ -204,13 +206,17 @@ export class AddressInputComponent implements OnInit, OnDestroy {
   @ViewChild('street1', {static: true})
   street1Input: ElementRef;
 
+  public ais: AddressInputService;
+
   private ngUnsubscribe = new Subject();
 
   // See if we can continue making stuff in form observable as much as possible
   constructor(
     private countryService: CountryService,
-    public ais: AddressInputService,
+    private addressService: AddressService,
+    private cdr: ChangeDetectorRef,
     private ngxTranslate: NGXTranslateService) {
+    this.ais = new AddressInputService(this.countryService, this.addressService, this.cdr, this.phoneRequired);
   }
 
   ngOnInit(): void {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.component.ts
@@ -173,6 +173,8 @@ export class AddressInputComponent implements OnInit, OnDestroy {
   }
   @Input()
   country: string | null;
+  @Input()
+  phoneRequired = false;
 
   /**
    * Set the errors in the input component. If list is empty, errors will be cleared.
@@ -181,9 +183,6 @@ export class AddressInputComponent implements OnInit, OnDestroy {
   set addressErrors(addressErrors: AddressError[]) {
     this.displayVerificationErrors(addressErrors);
   }
-
-  @Input()
-  phoneRequired = false;
 
   /**
    * Will emit event with address as it changes in form

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.component.ts
@@ -131,7 +131,8 @@ import { NGXTranslateService } from '../../services/internationalization/ngxTran
                  [name]="disableAutofill"
                  [attr.autocomplete]="autocompleteAttributeValue()"
                  formControlName="phone"
-                 uppercase>
+                 uppercase
+                 [required]="phoneRequired">
           <mat-error>{{getFieldErrorMessage('phone') | async}}</mat-error>
         </mat-form-field>
 
@@ -179,6 +180,10 @@ export class AddressInputComponent implements OnInit, OnDestroy {
   set addressErrors(addressErrors: AddressError[]) {
     this.displayVerificationErrors(addressErrors);
   }
+
+  @Input()
+  phoneRequired: boolean = false;
+
   /**
    * Will emit event with address as it changes in form
    * If contents of form elements are modified we will emit null

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.component.ts
@@ -149,7 +149,6 @@ import { AddressService } from '../../services/address.service';
       padding: 0;
       margin:0;
     }`],
-  providers: [],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.service.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.service.spec.ts
@@ -30,7 +30,7 @@ describe('AddressInputService', () => {
     addressServiceSpy = jasmine.createSpyObj('AddressService', ['verifyAddress']);
     cdrSpy = jasmine.createSpyObj('ChangeDetectorRef', ['detectChanges']);
     TestBed.configureTestingModule({});
-    ais = new AddressInputService(countryServiceSpy, addressServiceSpy, cdrSpy);
+    ais = new AddressInputService(countryServiceSpy, addressServiceSpy, cdrSpy, false);
   });
 
   it('should be created', () => {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.service.ts
@@ -335,8 +335,8 @@ export class AddressInputService implements OnDestroy {
       zip: new FormControl(''),
       state: new FormControl(''),
       city: new FormControl('', Validators.required),
-      phone: new FormControl(''),
-      guid: phoneRequired ? new FormControl('', Validators.required) : new FormControl(''),
+      phone: phoneRequired ? new FormControl('', Validators.required) : new FormControl(''),
+      guid: new FormControl('')
     }, { updateOn: 'blur' });
   }
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.service.ts
@@ -51,7 +51,7 @@ export class AddressInputService implements OnDestroy {
   /**
    * The formgroup used by the input form
    */
-  readonly addressForm: FormGroup = this.createForm();
+  readonly addressForm: FormGroup;
   /**
    * Incoming addresses
    */
@@ -91,7 +91,9 @@ export class AddressInputService implements OnDestroy {
   ngUnsubscribe = new Subject<void>();
 
   constructor(private countryService: CountryService, private addressService: AddressService,
-              private cdr: ChangeDetectorRef) {
+              private cdr: ChangeDetectorRef, phoneRequired: boolean) {
+    this.addressForm = this.createForm(phoneRequired);
+
     const countryCache = new BehaviorSubject<CountryCache>({});
     const countryCacheUpdates$ = new Subject<CountryAddressInfo>();
     // todo: can we factor this out as generic cache?
@@ -324,7 +326,7 @@ export class AddressInputService implements OnDestroy {
 
   }
 
-  createForm(): FormGroup {
+  createForm(phoneRequired: boolean): FormGroup {
     return new FormGroup({
       name: new FormControl('', Validators.required),
       country: new FormControl('', Validators.required),
@@ -334,7 +336,7 @@ export class AddressInputService implements OnDestroy {
       state: new FormControl(''),
       city: new FormControl('', Validators.required),
       phone: new FormControl(''),
-      guid: new FormControl('')
+      guid: phoneRequired ? new FormControl('', Validators.required) : new FormControl(''),
     }, { updateOn: 'blur' });
   }
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/MailAddressBlock.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/MailAddressBlock.ts
@@ -5,6 +5,8 @@ export class MailAddressBlock extends ActivityBlock {
     public displayNumber: number | null;
     public titleText: string | null;
     public subtitleText: string | null;
+    public requireVerified: boolean;
+    public requirePhone: boolean;
 
     constructor(displayNumber: number) {
         super();

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityComponentConverter.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityComponentConverter.service.ts
@@ -26,6 +26,8 @@ export class ActivityComponentConverter {
         const block = new MailAddressBlock(inputBlock.displayNumber);
         block.titleText = inputBlock.component.parameters.titleText;
         block.subtitleText = inputBlock.component.parameters.subtitleText;
+        block.requireVerified = !!inputBlock.component.parameters.requireVerified;
+        block.requirePhone = !!inputBlock.component.parameters.requirePhone;
         return block;
     }
 


### PR DESCRIPTION
We added new `requirePhone` flag, so this change is to support reading that flag and marking phone field as required. This ONLY marks it as required, but doesn't seem to check it is indeed filled in. I think it will be checked by backend once Marco makes his change related to that. Please let me know if I missed something here.