### PR TITLE
DDP-4894 use different redirect item for admin login

### DIFF
--- a/ddp-workspace/.gitignore
+++ b/ddp-workspace/.gitignore
@@ -44,3 +44,6 @@ testem.log
 # System Files
 .DS_Store
 Thumbs.db
+
+# Karma test report
+TESTS.xml

--- a/ddp-workspace/projects/ddp-sdk/src/lib/guards/adminAuth.guard.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/guards/adminAuth.guard.ts
@@ -13,7 +13,7 @@ export class AdminAuthGuard implements CanActivate {
   public canActivate(next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean {
     const isLoggedIn = this.session.isAuthenticatedAdminSession();
     if (!isLoggedIn) {
-      sessionStorage.setItem('nextUrl', state.url);
+      sessionStorage.setItem('adminNextUrl', state.url);
       this.auth0.adminLogin();
     }
     return isLoggedIn;

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/authentication/auth0Adapter.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/authentication/auth0Adapter.service.ts
@@ -114,6 +114,7 @@ export class Auth0AdapterService implements OnDestroy {
             ...(additionalAuth0QueryParams && additionalAuth0QueryParams)
         };
         if (this.configuration.doLocalRegistration) {
+            sessionStorage.setItem('localAdminAuth', 'false');
             sessionStorage.setItem('localAuthParams', JSON.stringify(auth0Params));
         }
         this.webAuth.authorize(

--- a/ddp-workspace/projects/toolkit/src/lib/components/login-landing/admin-login-landing.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/login-landing/admin-login-landing.component.ts
@@ -57,13 +57,13 @@ export class AdminLoginLandingComponent implements OnInit, OnDestroy {
   }
 
   private redirect(): void {
-    const nextUrlFromStorage = sessionStorage.getItem('nextUrl');
+    const nextUrlFromStorage = sessionStorage.getItem('adminNextUrl');
     if (nextUrlFromStorage) {
-      // `nextUrl` is set before redirecting to auth0. If it exists, then pick up where we left off.
-      sessionStorage.removeItem('nextUrl');
+      // `adminNextUrl` is set before redirecting to auth0. If it exists, then pick up where we left off.
+      sessionStorage.removeItem('adminNextUrl');
       this.router.navigateByUrl(nextUrlFromStorage);
     } else {
-      // No `nextUrl` set before going to auth0, go to admin dashboard next.
+      // No `adminNextUrl` set before going to auth0, go to admin dashboard next.
       this.router.navigateByUrl(this.toolkitConfiguration.adminDashboardUrl);
     }
   }


### PR DESCRIPTION
Fixes DDP-4894.

### Issue
Issue is that both regular login and admin login is using the `nextUrl` session storage item. So after navigating to `/prism` the session storage item is populated, then when you back out and do a regular login, `login-landing` component will pick up on `nextUrl` and redirect to `/prism`.

### Solution
We'll use a different session item call `adminNextUrl`, so admin login flow is more isolated.