### PR TITLE
ATX-275: print not parseable auth error

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/authentication/auth0Adapter.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/authentication/auth0Adapter.service.ts
@@ -180,6 +180,7 @@ export class Auth0AdapterService implements OnDestroy {
                     error = JSON.parse(decodeURIComponent(err.errorDescription));
                 } catch (e) {
                     console.error('Problem decoding authentication error', e);
+                    console.error(err.errorDescription);
                 }
                 if (onErrorCallback && error) {
                     // We might encounter errors from Auth0 that is not in expected


### PR DESCRIPTION
Sometimes Auth0 returns not parseable error, so this commit fixes output of such error to console.