### PR TITLE
DDP-4439: Language pref pop up

### DIFF
--- a/ddp-workspace/projects/ddp-prion/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-prion/src/assets/i18n/en.json
@@ -228,6 +228,11 @@
         "SignOut": "Sign Out",
         "Continue": "Continue",
         "RenewalFailed": "Session renewal failed. Please log out and log back in again."
+      },
+      "LanguagePreferences": {
+        "Text": "Changing the language preference will also change the language used for e-mail communications.",
+        "CheckboxText": "Don't show this again",
+        "ButtonText": "OK"
       }
     },
     "Warning": {

--- a/ddp-workspace/projects/ddp-prion/src/assets/i18n/es.json
+++ b/ddp-workspace/projects/ddp-prion/src/assets/i18n/es.json
@@ -228,6 +228,11 @@
         "SignOut": "es: Sign Out",
         "Continue": "es: Continue",
         "RenewalFailed": "es: Session renewal failed. Please log out and log back in again."
+      },
+      "LanguagePreferences": {
+        "Text": "es: Changing the language preference will also change the language used for e-mail communications.",
+        "CheckboxText": "es: Don't show this again",
+        "ButtonText": "es: OK"
       }
     },
     "Warning": {

--- a/ddp-workspace/projects/ddp-prion/src/assets/i18n/he.json
+++ b/ddp-workspace/projects/ddp-prion/src/assets/i18n/he.json
@@ -229,6 +229,11 @@
         "SignOut": "he: Sign Out",
         "Continue": "he: Continue",
         "RenewalFailed": "he: Session renewal failed. Please log out and log back in again."
+      },
+      "LanguagePreferences": {
+        "Text": "he: Changing the language preference will also change the language used for e-mail communications.",
+        "CheckboxText": "he: Don't show this again",
+        "ButtonText": "he: OK"
       }
     },
     "Warning": {

--- a/ddp-workspace/projects/ddp-prion/src/assets/i18n/zh.json
+++ b/ddp-workspace/projects/ddp-prion/src/assets/i18n/zh.json
@@ -228,6 +228,11 @@
         "SignOut": "zh: Sign Out",
         "Continue": "zh: Continue",
         "RenewalFailed": "zh: Session renewal failed. Please log out and log back in again."
+      },
+      "LanguagePreferences": {
+        "Text": "zh: Changing the language preference will also change the language used for e-mail communications.",
+        "CheckboxText": "zh: Don't show this again",
+        "ButtonText": "zh: OK"
       }
     },
     "Warning": {

--- a/ddp-workspace/projects/ddp-prion/src/styles.scss
+++ b/ddp-workspace/projects/ddp-prion/src/styles.scss
@@ -3783,7 +3783,7 @@ toolkit-popup-with-checkbox {
 @media only screen and (max-width: 767px) {
   .cdk-overlay-pane.toolkit-popup-with-checkbox {
     width: 300px !important;
-    max-height: 200px !important;
+    max-height: 170px !important;
     margin-top: 50% !important;
     margin-left: calc(50% - 150px) !important;
   }

--- a/ddp-workspace/projects/ddp-prion/src/styles.scss
+++ b/ddp-workspace/projects/ddp-prion/src/styles.scss
@@ -3774,11 +3774,17 @@ toolkit-popup-with-checkbox {
   }
 }
 
+@media only screen and (max-width: 824px) {
+  .cdk-overlay-pane.toolkit-popup-with-checkbox {
+    margin-top: 150px !important;
+  }
+}
+
 @media only screen and (max-width: 767px) {
   .cdk-overlay-pane.toolkit-popup-with-checkbox {
     width: 300px !important;
     max-height: 200px !important;
     margin-top: 50% !important;
-    margin-right: calc(50% - 150px) !important;
+    margin-left: calc(50% - 150px) !important;
   }
 }

--- a/ddp-workspace/projects/ddp-prion/src/styles.scss
+++ b/ddp-workspace/projects/ddp-prion/src/styles.scss
@@ -171,6 +171,17 @@ a:focus {
     color: #ffffff !important;
 }
 
+.Button--primaryNeutralWithFocus,
+.Button--primaryNeutralWithFocus:active {
+  border: 2px solid #9E9E9E !important;
+  background-color: #9E9E9E !important;
+  color: #ffffff !important;
+}
+
+.Button--primaryNeutralWithFocus:focus {
+  border: 2px solid #F2B816 !important;
+}
+
 .Button--primaryGoogle {
     border: 1px solid #db4437 !important;
     background-color: #db4437 !important;
@@ -3725,4 +3736,49 @@ app-third-party {
   justify-content: center;
   align-items: center;
   padding: 100px 0;
+}
+
+toolkit-popup-with-checkbox {
+  .SimpleButton {
+    margin-top: 0;
+  }
+}
+
+.toolkit-popup-with-checkbox {
+  .SimpleButton {
+    margin-top: 0;
+  }
+
+  .cdk-overlay-backdrop.cdk-overlay-backdrop-showing {
+    opacity: 0.1;
+  }
+
+  .popup {
+    &--text {
+      font-size: 0.8rem;
+    }
+
+    &--checkboxText {
+      font-size: 0.8rem;
+      margin: 0;
+    }
+
+    &--actions {
+      display: flex;
+      justify-content: space-between;
+
+      button {
+        padding: 5px 30px;
+      }
+    }
+  }
+}
+
+@media only screen and (max-width: 767px) {
+  .cdk-overlay-pane.toolkit-popup-with-checkbox {
+    width: 300px !important;
+    max-height: 200px !important;
+    margin-top: 50% !important;
+    margin-right: calc(50% - 150px) !important;
+  }
 }

--- a/ddp-workspace/projects/toolkit-prion/src/lib/components/header/prionHeader.component.ts
+++ b/ddp-workspace/projects/toolkit-prion/src/lib/components/header/prionHeader.component.ts
@@ -32,6 +32,14 @@ import { CommunicationService, HeaderComponent, ToolkitConfigurationService } fr
             <li class="Nav-item">
               <ddp-language-selector></ddp-language-selector>
             </li>
+            <li class="Nav-item">
+              <span class="Nav-itemLink">
+                <toolkit-popup-with-checkbox text="Toolkit.Dialogs.LanguagePreferences.Text"
+                                             checkboxText="Toolkit.Dialogs.LanguagePreferences.CheckboxText"
+                                             buttonText="Toolkit.Dialogs.LanguagePreferences.ButtonText"
+                ></toolkit-popup-with-checkbox>
+              </span>
+            </li>
             <li *ngIf="isLoggedIn()" class="Nav-item">
                         <span (click)="clickDashboard()" id="Dashboard" class="Nav-itemLink" [ngClass]="{'Nav-itemLink--active': currentRoute == '/dashboard'}" translate>
                             Toolkit.Common.Dashboard

--- a/ddp-workspace/projects/toolkit/src/lib/components/dialogs/popupWithCheckbox.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/dialogs/popupWithCheckbox.component.ts
@@ -10,7 +10,7 @@ import { ToolkitConfigurationService } from '../../services/toolkitConfiguration
     <button (click)="openModal()"
             class="SimpleButton"
             [disabled]="!isAuthenticated">
-      Language Preferences
+      Pref
     </button>
     <ng-template #modal>
       <div mat-dialog-content class="popup">
@@ -49,7 +49,7 @@ export class PopupWithCheckboxComponent {
       disableClose: true,
       panelClass: 'toolkit-popup-with-checkbox',
       backdropClass: 'toolkit-popup-with-checkbox',
-      position: {top: '100px', right: '70px'},
+      position: {top: '100px', left: 'calc(50% - 150px)'},
       scrollStrategy: new NoopScrollStrategy()
     });
   }

--- a/ddp-workspace/projects/toolkit/src/lib/components/dialogs/popupWithCheckbox.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/dialogs/popupWithCheckbox.component.ts
@@ -1,0 +1,61 @@
+import { Component, Inject, Input, TemplateRef, ViewChild } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { NoopScrollStrategy } from '@angular/cdk/overlay';
+import { SessionMementoService } from 'ddp-sdk';
+import { ToolkitConfigurationService } from '../../services/toolkitConfiguration.service';
+
+@Component({
+  selector: 'toolkit-popup-with-checkbox',
+  template: `
+    <button (click)="openModal()"
+            class="SimpleButton"
+            [disabled]="!isAuthenticated">
+      Language Preferences
+    </button>
+    <ng-template #modal>
+      <div mat-dialog-content class="popup">
+        <p class="popup--text" [innerHTML]="text | translate"></p>
+      </div>
+      <div mat-dialog-actions class="popup--actions">
+        <mat-checkbox #checkbox autofocus>
+          <p class="popup--checkboxText"
+             [innerHTML]="checkboxText | translate"></p>
+        </mat-checkbox>
+        <button class="Button Button--primaryNeutralWithFocus"
+                (click)="close(checkbox.checked)"
+                [innerHTML]="buttonText | translate"></button>
+      </div>
+    </ng-template>
+  `
+})
+export class PopupWithCheckboxComponent {
+  @Input() text: string;
+  @Input() checkboxText: string;
+  @Input() buttonText: string;
+
+  public isAuthenticated: boolean;
+  @ViewChild('modal', {static: true}) private modalRef: TemplateRef<any>;
+
+  constructor(public dialog: MatDialog,
+              private session: SessionMementoService,
+              @Inject('toolkit.toolkitConfig') public config: ToolkitConfigurationService) {
+    this.isAuthenticated = this.session.isAuthenticatedSession();
+  }
+
+  openModal(): void {
+    this.dialog.open(this.modalRef, {
+      maxWidth: '400px',
+      autoFocus: false,
+      disableClose: true,
+      panelClass: 'toolkit-popup-with-checkbox',
+      backdropClass: 'toolkit-popup-with-checkbox',
+      position: {top: '100px', right: '70px'},
+      scrollStrategy: new NoopScrollStrategy()
+    });
+  }
+
+  public close(languageConfirmed: boolean): void  {
+    console.log(languageConfirmed);
+    this.dialog.closeAll();
+  }
+}

--- a/ddp-workspace/projects/toolkit/src/lib/toolkit.module.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/toolkit.module.ts
@@ -69,6 +69,7 @@ import { PrivacyPolicyModalComponent } from './components/privacy-policy/privacy
 import { PrionPrivacyPolicyComponent } from './components/privacy-policy/prionPrivacyPolicy.component';
 import { ModalActivityButtonComponent } from './components/activity/modal-activity-button.component';
 import { ModalActivityComponent } from './components/activity/modal-activity.component';
+import { PopupWithCheckboxComponent } from './components/dialogs/popupWithCheckbox.component';
 
 // Guards
 import { HeaderActionGuard } from './guards/headerAction.guard';
@@ -88,6 +89,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatTableModule } from '@angular/material/table';
 import { MatRadioModule } from '@angular/material/radio';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 
 @NgModule({
   imports: [
@@ -110,7 +112,8 @@ import { MatRadioModule } from '@angular/material/radio';
     TranslateModule,
     MatTabsModule,
     MatTableModule,
-    MatRadioModule
+    MatRadioModule,
+    MatCheckboxModule
   ],
   providers: [
     CommunicationService,
@@ -174,7 +177,8 @@ import { MatRadioModule } from '@angular/material/radio';
     PrivacyPolicyModalComponent,
     PrionPrivacyPolicyComponent,
     ModalActivityButtonComponent,
-    ModalActivityComponent
+    ModalActivityComponent,
+    PopupWithCheckboxComponent
   ],
   exports: [
     FooterComponent,
@@ -214,7 +218,8 @@ import { MatRadioModule } from '@angular/material/radio';
     InstagramFeedLightwidgetPluginComponent,
     TwitterTimelineWidgetComponent,
     CookiesBannerComponent,
-    PrionPrivacyPolicyComponent
+    PrionPrivacyPolicyComponent,
+    PopupWithCheckboxComponent
   ],
   entryComponents: [
     DisclaimerComponent,
@@ -224,7 +229,8 @@ import { MatRadioModule } from '@angular/material/radio';
     SessionWillExpireComponent,
     CookiesPreferencesModalComponent,
     PrivacyPolicyModalComponent,
-    ModalActivityComponent
+    ModalActivityComponent,
+    PopupWithCheckboxComponent
   ]
 })
 export class ToolkitModule {

--- a/ddp-workspace/projects/toolkit/src/public-api.ts
+++ b/ddp-workspace/projects/toolkit/src/public-api.ts
@@ -27,6 +27,7 @@ export * from './lib/components/dialogs/joinMailingList.component';
 export * from './lib/components/dialogs/resendEmail.component';
 export * from './lib/components/dialogs/sessionWillExpire.component';
 export * from './lib/components/dialogs/warning.component';
+export * from './lib/components/dialogs/popupWithCheckbox.component';
 export * from './lib/components/error/error.component';
 export * from './lib/components/error/error-redesigned.component';
 export * from './lib/components/footer/footer.component';


### PR DESCRIPTION
Current commit is for a part of language pop-up component feature:

AC1, AC2

As was agreed temp button was created to show the popup
I placed it into the header as "Pref"
It is enabled only for logged in users

AC2
Placed text into the JSONs
![image](https://user-images.githubusercontent.com/54633385/92246582-c77dfc00-eee7-11ea-88e7-7141c335d516.png)

AC3
Popup is places bellow the language selector
![image](https://user-images.githubusercontent.com/54633385/92244920-6bb27380-eee5-11ea-8b65-893fa81fe3ef.png)

centered on mobile
![image](https://user-images.githubusercontent.com/54633385/92293589-8832c800-ef46-11ea-8358-ed7d90ec7857.png)

AC4
The pop-up is dismissed on the "OK" button  click

AC8

Tab goes from checkbox to OK button (added border on focus for it)
![image](https://user-images.githubusercontent.com/54633385/92245842-bbde0580-eee6-11ea-80dc-35ffbd52ef9f.png)

![image](https://user-images.githubusercontent.com/54633385/92245874-c4364080-eee6-11ea-8a2f-4023b127f440.png)
