### PR TITLE
DDP-4919 address states list not shown for testboston

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.ts
@@ -72,7 +72,7 @@ interface AddressSuggestion {
                 [address]="inputAddress$ | async"
                 [addressErrors]="verifyFieldErrors$ | async"
                 [readonly]="isReadOnly$ | async"
-                [country]="staticCountry$ | async"
+                [country]="country"
                 [phoneRequired]="block.requirePhone"
                 (componentBusy)="isInputComponentBusy$.next($event)"></ddp-address-input>
         <ddp-validation-message
@@ -193,7 +193,6 @@ export class AddressEmbeddedComponent implements OnDestroy, OnInit {
   public isReadOnly$: Observable<boolean>;
   public inputComponentAddress$: Subject<Address | null> = new BehaviorSubject(null);
   public generateTaggedAddress = generateTaggedAddress;
-  public staticCountry$: Observable<string | null>;
 
 
   private ngUnsubscribe = new Subject();
@@ -282,19 +281,6 @@ export class AddressEmbeddedComponent implements OnDestroy, OnInit {
               busyCounter$.next(-1);
           }),
       );
-
-    this.staticCountry$ = this.inputAddress$.pipe(
-        map(address => {
-          // ok to look at country at ngOnInit. We don't want to do this more than once
-          if ((this.country && (!(address) || (address.country === this.country)))) {
-            return this.country;
-          } else {
-            return null;
-          }
-        }),
-        distinctUntilChanged(),
-        shareReplay()
-    );
 
     // derived observables
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.component.ts
@@ -172,7 +172,12 @@ export class AddressInputComponent implements OnInit, OnDestroy {
     this.ais.inputIsReadOnly$.next(val);
   }
   @Input()
-  country: string | null;
+  set country(countryCode: string | null) {
+    this.ais.defaultCountryCode$.next(countryCode);
+  }
+  get country(): string | null {
+    return this.ais.defaultCountryCode$.getValue();
+  }
   @Input()
   phoneRequired = false;
 
@@ -244,6 +249,7 @@ export class AddressInputComponent implements OnInit, OnDestroy {
 
     this.valueChanged.subscribe((address) => console.debug('the address we got was:' + JSON.stringify(address)));
     this.componentBusy.subscribe((isBusy) => console.debug('is busy?:' + isBusy));
+
     this.setupBlockChromeStreet1Autofill();
 
   }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.service.ts
@@ -56,6 +56,8 @@ export class AddressInputService implements OnDestroy {
    * Incoming addresses
    */
   readonly inputAddress$ = new BehaviorSubject<Address | null>(null);
+
+  readonly defaultCountryCode$ = new BehaviorSubject<string | null>(null);
   /**
    * Set component to readonly mode
    */
@@ -92,6 +94,7 @@ export class AddressInputService implements OnDestroy {
 
   constructor(private countryService: CountryService, private addressService: AddressService,
               private cdr: ChangeDetectorRef, phoneRequired: boolean) {
+
     this.addressForm = this.createForm(phoneRequired);
 
     const countryCache = new BehaviorSubject<CountryCache>({});
@@ -144,6 +147,13 @@ export class AddressInputService implements OnDestroy {
       this.inputIsReadOnly$.pipe(
         distinctUntilChanged(),
         map(val => ({ isReadOnly: val }))),
+
+      this.defaultCountryCode$.pipe(
+          cachingCountryInfoOp,
+          map(countryInfo => ({ country: (countryInfo ? countryInfo.code : ''), countryInfo })),
+          map(countryInfoState => ({formData: new Address({country: countryInfoState.country}),
+            ...countryInfoState, formDataSource: 'INPUT' }))
+      ),
 
       this.inputAddress$.pipe(
         filter(address => !!address),

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/addressCountry.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/addressCountry.service.ts
@@ -56,7 +56,6 @@ export class CountryService extends SessionServiceAgent<CountryAddressInfo | Cou
     }
 
     private initializeAllCountryInfoSummaries(): void {
-      console.log('initializeAllCountryINfosums');
         this.anchor = this.getObservable('/addresscountries').pipe(
             map((data: any) => {
                 if (data) {
@@ -65,7 +64,6 @@ export class CountryService extends SessionServiceAgent<CountryAddressInfo | Cou
                     return [];
                 }
             }),
-          tap((data) => console.log('initializeAllCountryInfosums got allcedss' + data.length))
         ).subscribe(this.allCountryInfoSummariesSubject$);
     }
 }


### PR DESCRIPTION
There was a bug when we tried to set a default country for mailing address. The dependent state list was not updated properly.
This problem was only showing up on testboston; the only study where we confine country to be US.