### PR TITLE
DDP-4921 added /ddp for GP kit receipt in BSP

### DIFF
--- a/config/deployment/dev/dispatch.yaml
+++ b/config/deployment/dev/dispatch.yaml
@@ -19,6 +19,8 @@ dispatch:
     service: pepper-api-spec
   - url: "pepper-dev.datadonationplatform.org/*"
     service: pepper-backend
+  - url: "dsm-dev.datadonationplatform.org/ddp/*"
+    service: study-manager-backend
   - url: "dsm-dev.datadonationplatform.org/api/*"
     service: study-manager-backend
   - url: "dsm-dev.datadonationplatform.org/app/*"

--- a/config/deployment/prod/dispatch.yaml
+++ b/config/deployment/prod/dispatch.yaml
@@ -17,6 +17,8 @@ dispatch:
     service: pepper-api-spec
   - url: "pepper.datadonationplatform.org/*"
     service: pepper-backend
+  - url: "dsm-dev.datadonationplatform.org/ddp/*"
+    service: study-manager-backend
   - url: "dsm.datadonationplatform.org/api/*"
     service: study-manager-backend
   - url: "dsm.datadonationplatform.org/app/*"

--- a/config/deployment/prod/dispatch.yaml
+++ b/config/deployment/prod/dispatch.yaml
@@ -17,7 +17,7 @@ dispatch:
     service: pepper-api-spec
   - url: "pepper.datadonationplatform.org/*"
     service: pepper-backend
-  - url: "dsm-dev.datadonationplatform.org/ddp/*"
+  - url: "dsm.datadonationplatform.org/ddp/*"
     service: study-manager-backend
   - url: "dsm.datadonationplatform.org/api/*"
     service: study-manager-backend

--- a/config/deployment/staging/dispatch.yaml
+++ b/config/deployment/staging/dispatch.yaml
@@ -19,7 +19,7 @@ dispatch:
     service: pepper-api-spec
   - url: "pepper-staging.datadonationplatform.org/*"
     service: pepper-backend
-  - url: "dsm-dev.datadonationplatform.org/ddp/*"
+  - url: "dsm-staging.datadonationplatform.org/ddp/*"
     service: study-manager-backend
   - url: "dsm-staging.datadonationplatform.org/api/*"
     service: study-manager-backend

--- a/config/deployment/staging/dispatch.yaml
+++ b/config/deployment/staging/dispatch.yaml
@@ -19,6 +19,8 @@ dispatch:
     service: pepper-api-spec
   - url: "pepper-staging.datadonationplatform.org/*"
     service: pepper-backend
+  - url: "dsm-dev.datadonationplatform.org/ddp/*"
+    service: study-manager-backend
   - url: "dsm-staging.datadonationplatform.org/api/*"
     service: study-manager-backend
   - url: "dsm-staging.datadonationplatform.org/app/*"

--- a/config/deployment/test/dispatch.yaml
+++ b/config/deployment/test/dispatch.yaml
@@ -19,7 +19,7 @@ dispatch:
     service: pepper-api-spec
   - url: "pepper-test.datadonationplatform.org/*"
     service: pepper-backend
-  - url: "dsm-dev.datadonationplatform.org/ddp/*"
+  - url: "dsm-test.datadonationplatform.org/ddp/*"
     service: study-manager-backend
   - url: "dsm-test.datadonationplatform.org/api/*"
     service: study-manager-backend

--- a/config/deployment/test/dispatch.yaml
+++ b/config/deployment/test/dispatch.yaml
@@ -19,6 +19,8 @@ dispatch:
     service: pepper-api-spec
   - url: "pepper-test.datadonationplatform.org/*"
     service: pepper-backend
+  - url: "dsm-dev.datadonationplatform.org/ddp/*"
+    service: study-manager-backend
   - url: "dsm-test.datadonationplatform.org/api/*"
     service: study-manager-backend
   - url: "dsm-test.datadonationplatform.org/app/*"


### PR DESCRIPTION
DDP-4921 restores the `/ddp` route so that GP can receive kits.

Will put up a separate hotfix PR for prod.