### PR TITLE
DDP-4923: [Osteo] [Brain] [Test Boston] Replace "+" with "x" when accordion panel was opened

### DIFF
--- a/ddp-workspace/projects/ddp-brain-v2/src/app/components/faq/faq.component.html
+++ b/ddp-workspace/projects/ddp-brain-v2/src/app/components/faq/faq.component.html
@@ -23,9 +23,10 @@
                 <h2 class="faq-block__title">{{section.Title}}</h2>
                 <mat-accordion hideToggle="true" multi="true" displayMode="flat">
                     <ng-container *ngFor="let item of section.Items">
-                        <mat-expansion-panel>
+                        <mat-expansion-panel #panel>
                             <mat-expansion-panel-header collapsedHeight="100%" expandedHeight="100%">
-                                <mat-icon class="faq-block__icon">add</mat-icon>
+                                <mat-icon *ngIf="!panel.expanded" class="faq-block__icon">add</mat-icon>
+                                <mat-icon *ngIf="panel.expanded" class="faq-block__icon">clear</mat-icon>
                                 <p class="faq-block__question no-margin">{{item.Question}}</p>
                             </mat-expansion-panel-header>
                             <ng-template matExpansionPanelContent>

--- a/ddp-workspace/projects/ddp-osteo/src/app/components/faq/faq.component.html
+++ b/ddp-workspace/projects/ddp-osteo/src/app/components/faq/faq.component.html
@@ -23,9 +23,10 @@
                 <h3 class="no-margin">{{faqSection.Title}}</h3>
                 <mat-accordion hideToggle="true" multi="true" displayMode="flat">
                     <ng-container *ngFor="let item of faqSection.Items">
-                        <mat-expansion-panel>
+                        <mat-expansion-panel #panel>
                             <mat-expansion-panel-header collapsedHeight="100%" expandedHeight="100%">
-                                <mat-icon class="faq-block__icon">add</mat-icon>
+                                <mat-icon *ngIf="!panel.expanded" class="faq-block__icon">add</mat-icon>
+                                <mat-icon *ngIf="panel.expanded" class="faq-block__icon">clear</mat-icon>
                                 <p class="faq-block__question no-margin">{{item.Question}}</p>
                             </mat-expansion-panel-header>
                             <ng-template matExpansionPanelContent>

--- a/ddp-workspace/projects/ddp-osteo/src/app/components/faq/faq.component.scss
+++ b/ddp-workspace/projects/ddp-osteo/src/app/components/faq/faq.component.scss
@@ -44,6 +44,7 @@
 
 .mat-expansion-panel-header {
     padding: 1rem !important;
+    transition: 0.3s;
 }
 
 .mat-content {

--- a/ddp-workspace/projects/ddp-testboston/src/app/components/welcome/welcome.component.html
+++ b/ddp-workspace/projects/ddp-testboston/src/app/components/welcome/welcome.component.html
@@ -31,9 +31,10 @@
             <h2 class="center semi-bold" translate>HomePage.FaqSection.Title</h2>
             <mat-accordion hideToggle="true" multi="true" displayMode="flat">
                 <ng-container *ngFor="let item of 'HomePage.FaqSection.Items' | translate">
-                    <mat-expansion-panel>
+                    <mat-expansion-panel #panel>
                         <mat-expansion-panel-header collapsedHeight="100%" expandedHeight="100%">
-                            <mat-icon class="question-block__icon">add</mat-icon>
+                            <mat-icon *ngIf="!panel.expanded" class="question-block__icon">add</mat-icon>
+                            <mat-icon *ngIf="panel.expanded" class="question-block__icon">clear</mat-icon>
                             <p class="question-block__question no-margin">{{item.Question}}</p>
                         </mat-expansion-panel-header>
                         <ng-template matExpansionPanelContent>


### PR DESCRIPTION
Inspired by this comment - https://github.com/broadinstitute/ddp-angular/pull/221#pullrequestreview-477830225
Erin suggested using "x" instead of  "-"