### PR TITLE
[TestBoston] Dashboard Report activity 

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/configuration.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/configuration.service.ts
@@ -35,8 +35,12 @@ export class ConfigurationService {
     dashboardShowQuestionCountExceptions: string[] = [];
     // if activity status added here, buttons text will be changed on custom
     dashboardActivitiesCompletedStatuses: string[] = [];
+    // if activity status added here, buttons text will be changed on custom
+    dashboardActivitiesStartedStatuses: string[] = [];
     // if activity added here, the status column will show activitySummary message and will be shown a custom button
     dashboardSummaryInsteadOfStatus: string[] = [];
+    // if activity added here, for this activity will be shown another button
+    dashboardReportActivities: string[] = [];
     tooltipIconUrl: string = '';
     // must be a 24x24 svg icon.  To make sure colors match, do not specify a stroke color
     languageSelectorIconURL: string | null = null;

--- a/ddp-workspace/projects/ddp-testboston/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-testboston/src/app/app.module.ts
@@ -96,14 +96,18 @@ sdkConfig.auth0Audience = DDP_ENV.auth0Audience;
 sdkConfig.projectGAToken = DDP_ENV.projectGAToken;
 sdkConfig.supportedCountry = 'US';
 sdkConfig.dashboardShowQuestionCount = true;
-sdkConfig.dashboardShowQuestionCountExceptions = ['CONSENT', 'ADHOC_SYMPTOM'];
+sdkConfig.dashboardShowQuestionCountExceptions = ['CONSENT', 'ADHOC_SYMPTOM', 'RESULT_REPORT'];
 sdkConfig.dashboardActivitiesCompletedStatuses = ['COMPLETE'];
-sdkConfig.dashboardSummaryInsteadOfStatus = ['ADHOC_SYMPTOM'];
+sdkConfig.dashboardActivitiesStartedStatuses = ['CREATED'];
+sdkConfig.dashboardSummaryInsteadOfStatus = ['ADHOC_SYMPTOM', 'RESULT_REPORT'];
+sdkConfig.dashboardReportActivities = ['RESULT_REPORT'];
 sdkConfig.tooltipIconUrl = 'assets/images/info.png';
 sdkConfig.lookupPageUrl = AppRoutes.Prism;
 sdkConfig.compositeRequiredFieldExceptions = [QuestionType.Numeric];
 sdkConfig.scrollToErrorOffset = 130;
+
 const initialLanguageCode = localStorage.getItem('studyLanguage') || 'en';
+
 export function translateFactory(translate: TranslateService, injector: Injector): any {
     return () => new Promise<any>((resolve: any) => {
         const locationInitialized = injector.get(LOCATION_INITIALIZED, Promise.resolve(null));

--- a/ddp-workspace/projects/ddp-testboston/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-testboston/src/assets/i18n/en.json
@@ -382,6 +382,8 @@
     "EditButton": "Continue",
     "CompleteButton": "Edit",
     "ReviewButton": "View",
+    "OpenButton": "Open",
+    "StartButton": "Start",
     "AgreeButton": "I agree",
     "ReportButton": "Report",
     "NotAgreeButton": "I'm not ready to agree",

--- a/ddp-workspace/projects/ddp-testboston/src/assets/i18n/es.json
+++ b/ddp-workspace/projects/ddp-testboston/src/assets/i18n/es.json
@@ -382,6 +382,8 @@
     "EditButton": "Continuar",
     "CompleteButton": "Editar",
     "ReviewButton": "Ver",
+    "OpenButton": "[ES] Open",
+    "StartButton": "[ES] Start",
     "AgreeButton": "Acepto",
     "ReportButton": "[ES] Report",
     "NotAgreeButton": "Todavía no quiero aceptar",

--- a/ddp-workspace/projects/ddp-testboston/src/assets/i18n/ht.json
+++ b/ddp-workspace/projects/ddp-testboston/src/assets/i18n/ht.json
@@ -382,6 +382,8 @@
     "EditButton": "Kontinye",
     "CompleteButton": "Modifye",
     "ReviewButton": "Gade",
+    "OpenButton": "[HT] Open",
+    "StartButton": "[HT] Start",
     "AgreeButton": "Mwen aksepte",
     "ReportButton": "[HT] Report",
     "NotAgreeButton": "Mwen pa pare pou aksepte",


### PR DESCRIPTION
When the test result activity was created, a user should see:
![image](https://user-images.githubusercontent.com/30126907/92746994-698c6100-f38c-11ea-8756-b7934c4736e1.png)
When a user clicked 'Open' activity should be marked as 'COMPLETED' and show 'view' button:
![image](https://user-images.githubusercontent.com/30126907/92747120-904a9780-f38c-11ea-9334-55e4b9f8524a.png)

