### PR TITLE
DDP-4936: Add [projecturl].org/MailingList route in CMI sites

### DIFF
--- a/ddp-workspace/projects/ddp-angio/src/app/app-routing.module.ts
+++ b/ddp-workspace/projects/ddp-angio/src/app/app-routing.module.ts
@@ -184,6 +184,11 @@ const routes: Routes = [
         component: PasswordComponent
     },
     {
+        path: 'MailingList',
+        component: WelcomeComponent,
+        canActivate: [IrbGuard]
+    },
+    {
         path: '',
         component: WelcomeComponent,
         pathMatch: 'full',

--- a/ddp-workspace/projects/ddp-angio/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-angio/src/app/app.module.ts
@@ -54,6 +54,7 @@ tkCfg.stayInformedUrl = 'stay-informed';
 tkCfg.lovedOneThankYouUrl = 'loved-one-thank-you';
 tkCfg.internationalPatientsUrl = 'international-patients';
 tkCfg.moreDetailsUrl = 'more-details';
+tkCfg.mailingListDialogUrl = 'MailingList';
 tkCfg.phone = '857-500-6264';
 tkCfg.infoEmail = 'info@ascproject.org';
 tkCfg.dataEmail = 'data@ascproject.org';

--- a/ddp-workspace/projects/ddp-brain-v2/src/app/app-routes.ts
+++ b/ddp-workspace/projects/ddp-brain-v2/src/app/app-routes.ts
@@ -18,5 +18,6 @@ export const AppRoutes = {
     Data: 'data',
     MoreDetails: 'more-details',
     StayInformed: 'stay-informed',
-    JoinList: 'join-list'
+    JoinList: 'join-list',
+    MailingList: 'MailingList'
 };

--- a/ddp-workspace/projects/ddp-brain-v2/src/app/app-routing.module.ts
+++ b/ddp-workspace/projects/ddp-brain-v2/src/app/app-routing.module.ts
@@ -156,6 +156,11 @@ const routes: Routes = [
     }
   },
   {
+    path: AppRoutes.MailingList,
+    component: WelcomeComponent,
+    canActivate: [IrbGuard]
+  },
+  {
     path: '',
     component: WelcomeComponent,
     pathMatch: 'full',

--- a/ddp-workspace/projects/ddp-brain-v2/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-brain-v2/src/app/app.module.ts
@@ -56,6 +56,7 @@ toolkitConfig.dashboardUrl = AppRoutes.Dashboard;
 toolkitConfig.activityUrl = AppRoutes.Activity;
 toolkitConfig.errorUrl = AppRoutes.Error;
 toolkitConfig.stayInformedUrl = AppRoutes.StayInformed;
+toolkitConfig.mailingListDialogUrl = AppRoutes.MailingList;
 toolkitConfig.phone = '651-229-3480';
 toolkitConfig.infoEmail = 'info@braincancerproject.org';
 toolkitConfig.dataEmail = 'data@braincancerproject.org';

--- a/ddp-workspace/projects/ddp-brain-v2/src/app/components/app/app.component.ts
+++ b/ddp-workspace/projects/ddp-brain-v2/src/app/components/app/app.component.ts
@@ -1,52 +1,21 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, Inject } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-import { NoopScrollStrategy } from '@angular/cdk/overlay';
-import { CompositeDisposable, RenewSessionNotifier } from 'ddp-sdk';
-import { CommunicationService, JoinMailingListComponent, SessionWillExpireComponent } from 'toolkit';
+import { RenewSessionNotifier } from 'ddp-sdk';
+import { AppRedesignedBaseComponent, CommunicationService, ToolkitConfigurationService } from 'toolkit';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
-export class AppComponent implements OnInit, OnDestroy {
-  private anchor = new CompositeDisposable();
-  private readonly DIALOG_BASE_SETTINGS = {
-    width: '740px',
-    position: { top: '30px' },
-    data: {},
-    autoFocus: false,
-    scrollStrategy: new NoopScrollStrategy()
-  };
-
+export class AppComponent extends AppRedesignedBaseComponent {
   constructor(
-    private communicationService: CommunicationService,
-    private dialog: MatDialog,
-    private renewNotifier: RenewSessionNotifier) { }
-
-  public ngOnInit(): void {
-    this.initMailingListDialogListener();
-    this.initSessionExpiredDialogListener();
-  }
-
-  public ngOnDestroy(): void {
-    this.anchor.removeAll();
-  }
-
-  private initMailingListDialogListener(): void {
-    const modalOpen = this.communicationService.openJoinDialog$.subscribe(() => {
-      this.dialog.open(JoinMailingListComponent, this.DIALOG_BASE_SETTINGS);
-    });
-    this.anchor.addNew(modalOpen);
-  }
-
-  private initSessionExpiredDialogListener(): void {
-    const modalOpen = this.renewNotifier.openDialogEvents.subscribe(() => {
-      this.dialog.open(SessionWillExpireComponent, { ...this.DIALOG_BASE_SETTINGS, disableClose: true });
-    });
-    const modalClose = this.renewNotifier.closeDialogEvents.subscribe(() => {
-      this.dialog.closeAll();
-    });
-    this.anchor.addNew(modalOpen).addNew(modalClose);
+    private _communicationService: CommunicationService,
+    private _dialog: MatDialog,
+    private _renewNotifier: RenewSessionNotifier,
+    private _router: Router,
+    @Inject('toolkit.toolkitConfig') private _config: ToolkitConfigurationService) {
+    super(_communicationService, _dialog, _renewNotifier, _router, _config);
   }
 }

--- a/ddp-workspace/projects/ddp-brain/src/app/app-routing.module.ts
+++ b/ddp-workspace/projects/ddp-brain/src/app/app-routing.module.ts
@@ -160,6 +160,11 @@ const routes: Routes = [
         canActivate: [IrbGuard]
     },
     {
+        path: 'MailingList',
+        component: WelcomeComponent,
+        canActivate: [IrbGuard]
+    },
+    {
         path: '',
         component: WelcomeComponent,
         pathMatch: 'full',

--- a/ddp-workspace/projects/ddp-brain/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-brain/src/app/app.module.ts
@@ -50,6 +50,7 @@ tkCfg.errorUrl = 'error';
 tkCfg.stayInformedUrl = 'stay-informed';
 tkCfg.moreDetailsUrl = 'more-details';
 tkCfg.internationalPatientsUrl = 'international-patients';
+tkCfg.mailingListDialogUrl = 'MailingList';
 tkCfg.phone = '651-229-3480';
 tkCfg.infoEmail = 'info@braincancerproject.org';
 tkCfg.dataEmail = 'data@braincancerproject.org';

--- a/ddp-workspace/projects/ddp-mbc/src/app/app-routing.module.ts
+++ b/ddp-workspace/projects/ddp-mbc/src/app/app-routing.module.ts
@@ -224,6 +224,11 @@ const routes: Routes = [
         component: PasswordComponent
     },
     {
+        path: 'MailingList',
+        component: WelcomeComponent,
+        canActivate: [IrbGuard]
+    },
+    {
         path: '',
         component: WelcomeComponent,
         pathMatch: 'full',

--- a/ddp-workspace/projects/ddp-mbc/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-mbc/src/app/app.module.ts
@@ -61,6 +61,7 @@ tkCfg.bloodConsentUrl = 'blood-consent';
 tkCfg.bloodReleaseUrl = 'blood-release-survey';
 tkCfg.followupUrl = 'followup';
 tkCfg.internationalPatientsUrl = 'international-patients';
+tkCfg.mailingListDialogUrl = 'MailingList';
 tkCfg.phone = '617-800-1622';
 tkCfg.infoEmail = 'info@mbcproject.org';
 tkCfg.dataEmail = 'data@mbcproject.org';

--- a/ddp-workspace/projects/ddp-mpc/src/app/app-routing.module.ts
+++ b/ddp-workspace/projects/ddp-mpc/src/app/app-routing.module.ts
@@ -175,6 +175,11 @@ const routes: Routes = [
     component: PasswordComponent
   },
   {
+    path: 'MailingList',
+    component: WelcomeComponent,
+    canActivate: [IrbGuard]
+  },
+  {
     path: '',
     component: WelcomeComponent,
     pathMatch: 'full',

--- a/ddp-workspace/projects/ddp-mpc/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-mpc/src/app/app.module.ts
@@ -51,6 +51,7 @@ toolkitConfig.activityUrl = 'activity';
 toolkitConfig.errorUrl = 'error';
 toolkitConfig.stayInformedUrl = 'stay-informed';
 toolkitConfig.internationalPatientsUrl = 'international-patients';
+toolkitConfig.mailingListDialogUrl = 'MailingList';
 toolkitConfig.phone = '651-293-5029';
 toolkitConfig.infoEmail = 'info@mpcproject.org';
 toolkitConfig.dataEmail = 'data@mpcproject.org'

--- a/ddp-workspace/projects/ddp-osteo/src/app/app-routing.module.ts
+++ b/ddp-workspace/projects/ddp-osteo/src/app/app-routing.module.ts
@@ -249,6 +249,11 @@ const routes: Routes = [
         data: { openJoinDialog: true }
     },
     {
+        path: 'MailingList',
+        component: WelcomeComponent,
+        canActivate: [IrbGuard]
+    },
+    {
         path: '',
         component: WelcomeComponent,
         pathMatch: 'full',

--- a/ddp-workspace/projects/ddp-osteo/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-osteo/src/app/app.module.ts
@@ -69,6 +69,7 @@ tkCfg.activityUrl = 'activity';
 tkCfg.errorUrl = 'error';
 tkCfg.stayInformedUrl = 'stay-informed';
 tkCfg.lovedOneThankYouUrl = 'loved-one-thank-you';
+tkCfg.mailingListDialogUrl = 'MailingList';
 tkCfg.phone = '651-602-2020';
 tkCfg.infoEmail = 'info@osproject.org';
 tkCfg.twitterAccountId = 'the_osproject';

--- a/ddp-workspace/projects/ddp-osteo/src/app/components/app/app.component.ts
+++ b/ddp-workspace/projects/ddp-osteo/src/app/components/app/app.component.ts
@@ -1,54 +1,21 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, Inject } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-import { NoopScrollStrategy } from '@angular/cdk/overlay';
-import { CompositeDisposable, RenewSessionNotifier } from 'ddp-sdk';
-import { CommunicationService, JoinMailingListComponent, SessionWillExpireComponent } from 'toolkit';
-
-declare const ga: Function;
+import { RenewSessionNotifier } from 'ddp-sdk';
+import { AppRedesignedBaseComponent, CommunicationService, ToolkitConfigurationService } from 'toolkit';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
-export class AppComponent implements OnInit, OnDestroy {
-  private anchor = new CompositeDisposable();
-  private readonly DIALOG_BASE_SETTINGS = {
-    width: '740px',
-    position: { top: '30px' },
-    data: {},
-    autoFocus: false,
-    scrollStrategy: new NoopScrollStrategy()
-  };
-
+export class AppComponent extends AppRedesignedBaseComponent {
   constructor(
-    private communicationService: CommunicationService,
-    private dialog: MatDialog,
-    private renewNotifier: RenewSessionNotifier) { }
-
-  public ngOnInit(): void {
-    this.initMailingListDialogListener();
-    this.initSessionExpiredDialogListener();
-  }
-
-  public ngOnDestroy(): void {
-    this.anchor.removeAll();
-  }
-
-  private initMailingListDialogListener(): void {
-    const modalOpen = this.communicationService.openJoinDialog$.subscribe(() => {
-      this.dialog.open(JoinMailingListComponent, this.DIALOG_BASE_SETTINGS);
-    });
-    this.anchor.addNew(modalOpen);
-  }
-
-  private initSessionExpiredDialogListener(): void {
-    const modalOpen = this.renewNotifier.openDialogEvents.subscribe(() => {
-      this.dialog.open(SessionWillExpireComponent, { ...this.DIALOG_BASE_SETTINGS, disableClose: true });
-    });
-    const modalClose = this.renewNotifier.closeDialogEvents.subscribe(() => {
-      this.dialog.closeAll();
-    });
-    this.anchor.addNew(modalOpen).addNew(modalClose);
+    private _communicationService: CommunicationService,
+    private _dialog: MatDialog,
+    private _renewNotifier: RenewSessionNotifier,
+    private _router: Router,
+    @Inject('toolkit.toolkitConfig') private _config: ToolkitConfigurationService) {
+    super(_communicationService, _dialog, _renewNotifier, _router, _config);
   }
 }

--- a/ddp-workspace/projects/toolkit/src/lib/components/app/app-redesigned-base.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/app/app-redesigned-base.component.ts
@@ -1,0 +1,62 @@
+import { OnInit, OnDestroy, Inject } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { NoopScrollStrategy } from '@angular/cdk/overlay';
+import { NavigationEnd, Router } from '@angular/router';
+import { CommunicationService } from '../../services/communication.service';
+import { ToolkitConfigurationService } from '../../services/toolkitConfiguration.service';
+import { JoinMailingListComponent } from '../dialogs/joinMailingList.component';
+import { SessionWillExpireComponent } from '../dialogs/sessionWillExpire.component';
+import { CompositeDisposable, RenewSessionNotifier } from 'ddp-sdk';
+
+export class AppRedesignedBaseComponent implements OnInit, OnDestroy {
+    private anchor = new CompositeDisposable();
+    private readonly DIALOG_BASE_SETTINGS = {
+        width: '740px',
+        position: { top: '30px' },
+        data: {},
+        autoFocus: false,
+        scrollStrategy: new NoopScrollStrategy()
+    };
+
+    constructor(
+        private communicationService: CommunicationService,
+        private dialog: MatDialog,
+        private renewNotifier: RenewSessionNotifier,
+        private router: Router,
+        @Inject('toolkit.toolkitConfig') private config: ToolkitConfigurationService) { }
+
+    public ngOnInit(): void {
+        this.initMailingListDialogListener();
+        this.initSessionExpiredDialogListener();
+        this.initRouterListener();
+    }
+
+    public ngOnDestroy(): void {
+        this.anchor.removeAll();
+    }
+
+    private initMailingListDialogListener(): void {
+        const modalOpen = this.communicationService.openJoinDialog$.subscribe(() => {
+            this.dialog.open(JoinMailingListComponent, this.DIALOG_BASE_SETTINGS);
+        });
+        this.anchor.addNew(modalOpen);
+    }
+
+    private initSessionExpiredDialogListener(): void {
+        const modalOpen = this.renewNotifier.openDialogEvents.subscribe(() => {
+            this.dialog.open(SessionWillExpireComponent, { ...this.DIALOG_BASE_SETTINGS, disableClose: true });
+        });
+        const modalClose = this.renewNotifier.closeDialogEvents.subscribe(() => {
+            this.dialog.closeAll();
+        });
+        this.anchor.addNew(modalOpen).addNew(modalClose);
+    }
+
+    private initRouterListener(): void {
+        this.router.events.subscribe(event => {
+            if (event instanceof NavigationEnd && event.url.includes(this.config.mailingListDialogUrl)) {
+                this.communicationService.openJoinDialog();
+            }
+        });
+    }
+}

--- a/ddp-workspace/projects/toolkit/src/lib/components/app/app.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/app/app.component.ts
@@ -178,7 +178,7 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
                 of({ joinDialogOpen: false }) :
                 merge(
                     dialog.afterClosed().pipe(map(() => ({ joinDialogOpen: false }))),
-                    dialog.afterOpen().pipe(map(() => ({ joinDialogOpen: true })))
+                    dialog.afterOpened().pipe(map(() => ({ joinDialogOpen: true })))
                 )),
             distinctUntilChanged()
         );
@@ -245,6 +245,9 @@ export class AppComponent implements OnInit, AfterViewInit, OnDestroy {
         this.router.events.subscribe(event => {
             if (event instanceof NavigationEnd) {
                 this.closeNav();
+                if (event.url.includes(this.toolkitConfiguration.mailingListDialogUrl)) {
+                    this.communicationService.openJoinDialog();
+                }
             }
         });
     }

--- a/ddp-workspace/projects/toolkit/src/lib/components/dialogs/joinMailingList.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/dialogs/joinMailingList.component.ts
@@ -101,6 +101,8 @@ export class JoinMailingListComponent implements OnInit, OnDestroy {
             if (isSubmitted) {
                 this.communicationService.closeSidePanel();
                 this.router.navigateByUrl(this.stayInformedUrl);
+            } else if (this.router.url.includes(this.toolkitConfiguration.mailingListDialogUrl)) {
+                this.router.navigateByUrl('/');
             }
         });
     }

--- a/ddp-workspace/projects/toolkit/src/lib/services/toolkitConfiguration.service.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/services/toolkitConfiguration.service.ts
@@ -51,6 +51,7 @@ export class ToolkitConfigurationService {
     symptomSurveyUrl: string;
     addressUrl: string;
     adminDashboardUrl: string | null = null;
+    mailingListDialogUrl: string;
 
     // Social media and contacts
     phone: string;

--- a/ddp-workspace/projects/toolkit/src/public-api.ts
+++ b/ddp-workspace/projects/toolkit/src/public-api.ts
@@ -53,5 +53,6 @@ export * from './lib/components/age-up/verifyAgeUpPage.component';
 export * from './lib/components/age-up/acceptAgeUpPage.component';
 export * from './lib/components/thank-you/age-up-thank-you.component';
 export * from './lib/components/twitter-widget/twitter-timeline-widget.component';
+export * from './lib/components/app/app-redesigned-base.component';
 
 export * from './lib/guards/headerAction.guard';


### PR DESCRIPTION
For all existing cmi sites on pepper, add a /MailingList route to angular that opens the mailing list modal so that the CMI team can send users directly to the mailing list without them having to click on anything.