### PR TITLE
[TestBoston] Wide dashboard

### DIFF
--- a/ddp-workspace/projects/ddp-testboston/src/style/dashboard.scss
+++ b/ddp-workspace/projects/ddp-testboston/src/style/dashboard.scss
@@ -19,6 +19,12 @@
 
 .dashboard-section {
     margin: 5rem 0 15rem 0;
+
+    .content {
+        &_medium {
+            max-width: 800px !important;
+        }
+    }
 }
 
 .dashboard-content {
@@ -142,7 +148,7 @@
 
 .dashboard-activity-button {
     font-size: 1.125rem;
-    line-height: 1.75rem;
+    line-height: 1.5625rem;
     font-family: inherit;
     background: none;
     border: none;


### PR DESCRIPTION
TestBoston's Dashobord should be a bit wider than now per as Slack discussion.