### PR TITLE
Uppercase UPS route appears to break when running in AOT

### DIFF
--- a/ddp-workspace/projects/ddp-testboston/src/app/app-routes.ts
+++ b/ddp-workspace/projects/ddp-testboston/src/app/app-routes.ts
@@ -20,5 +20,6 @@ export const AppRoutes = {
     Address: 'mailing-address',
     PasswordResetDone: 'password-reset-done',
     EnrollSubject: 'enrollment',
-    UPS: 'ups'
+    UPS: 'ups',
+    UPS_UPPER: 'UPS'
 };

--- a/ddp-workspace/projects/ddp-testboston/src/app/app-routing.module.ts
+++ b/ddp-workspace/projects/ddp-testboston/src/app/app-routing.module.ts
@@ -207,7 +207,7 @@ const routes: Routes = [
     ]
   },
   {
-    path: AppRoutes.UPS.toUpperCase(),
+    path: AppRoutes.UPS_UPPER,
     redirectTo: AppRoutes.UPS
   },
   {


### PR DESCRIPTION
testboston.dev.datadonatioplatform.org was coming up with a blank page.
This is a screenshot of the console:
<img width="906" alt="Screen Shot 2020-09-23 at 2 57 05 PM" src="https://user-images.githubusercontent.com/29984380/94058448-04cefe80-fdaf-11ea-936e-2069669b664a.png">

My interpretation of problem is that the AOT compiled app did not like including the toUppercase() function in the route definitions.

I deployed to dev environment the fix. It appears to deal with problem.