### PR TITLE
DDP-5018: Fixed issue where Analytics cookies that get prefixe…

### DIFF
--- a/ddp-workspace/projects/toolkit/src/lib/services/analyticsManagement.service.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/services/analyticsManagement.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { CookieService } from 'ngx-cookie';
+import { CookieOptions, CookieService } from 'ngx-cookie';
 
 declare const DDP_ENV: any;
 declare const ga: (...args: any[]) => {};
@@ -62,5 +62,12 @@ export class AnalyticsManagementService {
     this.cookie.remove('_gid');
     this.cookie.remove('_gat');
     this.cookie.remove('_gat_platform');
+
+    // Sometimes Google Analytics adds a '.' prefix to the domain
+    const prefixedOptions: CookieOptions = {domain: '.' + document.location.hostname};
+    this.cookie.remove('_ga', prefixedOptions);
+    this.cookie.remove('_gid', prefixedOptions);
+    this.cookie.remove('_gat', prefixedOptions);
+    this.cookie.remove('_gat_platform', prefixedOptions);
   }
 }


### PR DESCRIPTION
…d with a '.' weren't getting removed correctly after cookie rejection

See DDP-5018.  I noticed this issue happening in Prion dev (https://prion-dot-broad-ddp-dev.appspot.com/) but not locally.