### PR TITLE
DDP-5249 Reduce label size to fit very long placeholder and label text in brain tribe question

### DIFF
--- a/ddp-workspace/projects/ddp-brain/src/styles/activities.scss
+++ b/ddp-workspace/projects/ddp-brain/src/styles/activities.scss
@@ -351,6 +351,9 @@ select:disabled {
     color: mat-color($app-theme, 700) !important;
 }
 
+.mat-form-field-label {
+    font-size: 1.0rem !important;
+}
 // input
 .mat-form-field-infix {
     font-size: 1.2rem;


### PR DESCRIPTION
Was able to fit in the whole placeholder by reducing font size in desktop screens.

<img width="745" alt="Screen Shot 2020-11-05 at 11 57 52 AM" src="https://user-images.githubusercontent.com/29984380/98271946-7ed1d600-1f5e-11eb-9c0d-76cf60822448.png">


But in mobile, it still does not fit. And if I try to reduce it enough to fit, it gets ridiculously small. This is what it looks like with change in this PR:
<img width="450" alt="Screen Shot 2020-11-05 at 11 58 35 AM" src="https://user-images.githubusercontent.com/29984380/98271906-6eb9f680-1f5e-11eb-9e17-f3b55421b0e3.png">


Wrapping of labels does not seem to be an option as far as I can see.

If we are able to, best solution is to come of with a shorter text for this label. It is super-long.
If not an option, then we might have to tolerate truncation.

