### PR TITLE
DDP-5251 Setting a max height on text area appears to fix sudden scroll problem

### DIFF
--- a/ddp-workspace/projects/ddp-brain/src/styles/activities.scss
+++ b/ddp-workspace/projects/ddp-brain/src/styles/activities.scss
@@ -463,6 +463,10 @@ select:disabled {
     }
 }
 
+.ddp-textarea {
+    max-height: 10rem !important;
+}
+
 // nested picklist
 .ddp-nested-picklist {
     margin-left: 3rem;


### PR DESCRIPTION
Change sets a maximum height on textarea entry. Any text beyond that height will trigger a scrollbar showing up for field.
The sudden jumping observed does not appear to occur no matter how large entry is.