### PR TITLE
[TestBoston] Stepper for single section consent 

### DIFF
--- a/ddp-workspace/projects/ddp-testboston/src/app/components/app/app.component.html
+++ b/ddp-workspace/projects/ddp-testboston/src/app/components/app/app.component.html
@@ -1,4 +1,4 @@
-<div class="wrapper">
+<div class="wrapper" (click)="scrollToStep($event)">
     <app-header></app-header>
     <router-outlet></router-outlet>
     <app-footer></app-footer>

--- a/ddp-workspace/projects/ddp-testboston/src/app/components/app/app.component.ts
+++ b/ddp-workspace/projects/ddp-testboston/src/app/components/app/app.component.ts
@@ -31,6 +31,20 @@ export class AppComponent implements OnInit, OnDestroy {
     this.anchor.removeAll();
   }
 
+  public scrollToStep(event: MouseEvent): void {
+    const element = event.target as HTMLElement;
+    if (element.className.includes('scrollable')) {
+      const id = element.classList[element.classList.length - 1];
+      const step = document.getElementById(id);
+      const headerHeight = 7.5 * parseFloat(getComputedStyle(document.documentElement).fontSize);
+      const top = step.getBoundingClientRect().top + window.scrollY - headerHeight;
+      window.scrollTo({
+        top,
+        behavior: 'smooth'
+      });
+    }
+  }
+
   private initSessionExpiredDialogListener(): void {
     const modalOpen = this.renewNotifier.openDialogEvents.subscribe(() => {
       this.dialog.open(SessionWillExpireComponent, { ...this.DIALOG_BASE_SETTINGS, disableClose: true });

--- a/ddp-workspace/projects/ddp-testboston/src/app/components/app/app.component.ts
+++ b/ddp-workspace/projects/ddp-testboston/src/app/components/app/app.component.ts
@@ -36,12 +36,15 @@ export class AppComponent implements OnInit, OnDestroy {
     if (element.className.includes('scrollable')) {
       const id = element.classList[element.classList.length - 1];
       const step = document.getElementById(id);
-      const headerHeight = 7.5 * parseFloat(getComputedStyle(document.documentElement).fontSize);
-      const top = step.getBoundingClientRect().top + window.scrollY - headerHeight;
-      window.scrollTo({
-        top,
-        behavior: 'smooth'
-      });
+      if (step) {
+        const HEADER_HEIGHT_REM = 7.5;
+        const headerHeightPx = HEADER_HEIGHT_REM * parseFloat(getComputedStyle(document.documentElement).fontSize);
+        const top = step.getBoundingClientRect().top + window.scrollY - headerHeightPx;
+        window.scrollTo({
+          top,
+          behavior: 'smooth'
+        });
+      }
     }
   }
 

--- a/ddp-workspace/projects/ddp-testboston/src/app/components/app/app.component.ts
+++ b/ddp-workspace/projects/ddp-testboston/src/app/components/app/app.component.ts
@@ -34,8 +34,8 @@ export class AppComponent implements OnInit, OnDestroy {
   public scrollToStep(event: MouseEvent): void {
     const element = event.target as HTMLElement;
     if (element.className.includes('scrollable')) {
-      const id = element.classList[element.classList.length - 1];
-      const step = document.getElementById(id);
+      const anchor = `anchor-${element.classList[element.classList.length - 1]}`;
+      const step = document.getElementsByClassName(anchor)[0];
       if (step) {
         const HEADER_HEIGHT_REM = 7.5;
         const headerHeightPx = HEADER_HEIGHT_REM * parseFloat(getComputedStyle(document.documentElement).fontSize);

--- a/ddp-workspace/projects/ddp-testboston/src/style/activity.scss
+++ b/ddp-workspace/projects/ddp-testboston/src/style/activity.scss
@@ -207,6 +207,12 @@
     }
 }
 
+.scrollable {
+    &:hover {
+        cursor: pointer !important;
+    }
+}
+
 @media only screen and (max-width: 620px) {
     .activity-steps {
         padding: 1rem 0;


### PR DESCRIPTION
We need to allow a user to navigate between different Consent section even Consent is a single page.
Here is a code snippet, which should be added in the content block to show stepper for 1-section consent:
``` HTML
<div class="activity-steps">
    <div class="activity-step active completed scrollable step1">
        <span class="activity-step__number scrollable step1">1</span>
        <span class="activity-step__text scrollable step1">Introduction</span>
    </div>
    <div class="activity-steps__divider"></div>
    <div class="activity-step active completed scrollable step2">
        <span class="activity-step__number scrollable step2">2</span>
        <span class="activity-step__text scrollable step2">Key Information</span>
    </div>
    <div class="activity-steps__divider"></div>
    <div class="activity-step active completed scrollable step3">
        <span class="activity-step__number scrollable step3">3</span>
        <span class="activity-step__text scrollable step3">Full Form</span>
    </div>
</div>
```
Desired section should have id="step1" or id="step2" etc.