### PR TITLE
Fix group picklist 

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/checkboxesActivityPicklistQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/checkboxesActivityPicklistQuestion.component.ts
@@ -155,7 +155,7 @@ export class CheckboxesActivityPicklistQuestion extends BaseActivityPicklistQues
         if (this.block.answer === null) {
             this.block.answer = this.createAnswer();
         }
-        const isParentOption = this.block.picklistOptions.includes(option);
+        const isParentOption = this.block.picklistOptions.includes(option) || this.groupParentOptionSelected(option);
         if (isParentOption) {
             this.parentOptionSelected(value, option);
         } else {
@@ -239,6 +239,10 @@ export class CheckboxesActivityPicklistQuestion extends BaseActivityPicklistQues
             return option && option.exclusive;
         });
         return hasExclusive;
+    }
+
+    private groupParentOptionSelected(option: ActivityPicklistOption): boolean {
+        return this.block.picklistGroups.some(group => group.options.includes(option));
     }
 
     private removeNestedOptionsAnswers(option: ActivityPicklistOption): Array<ActivityPicklistAnswerDto> {


### PR DESCRIPTION
When a user selected the picklist group's option it caused an error:
![image](https://user-images.githubusercontent.com/30126907/99774434-d0618f80-2b1e-11eb-8c70-e5ca59171878.png)
It happened because group options store in the `picklistGroups` not `picklistOptions`, so, I've added one more check.
For now, the backend doesn't support nested options for picklist groups(and it is not known whether this will be necessary for the future) this is why the frontend doesn't support this functionality either.