### PR TITLE
Sign out return url

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/login/signInOut.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/login/signInOut.component.ts
@@ -23,6 +23,7 @@ import { Subscription } from 'rxjs';
     </button>`
 })
 export class SignInOutComponent implements OnInit, OnDestroy {
+    @Input() signOutReturnToUrl: string = '';
     @Input() signInCaption: string;
     @Input() signOutCaption: string;
     @Input() isScrolled: boolean;
@@ -60,6 +61,6 @@ export class SignInOutComponent implements OnInit, OnDestroy {
     }
 
     public doSignOut(): void {
-        this.auth0.logout();
+        this.auth0.logout(this.signOutReturnToUrl);
     }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/authentication/auth0Adapter.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/authentication/auth0Adapter.service.ts
@@ -268,7 +268,12 @@ export class Auth0AdapterService implements OnDestroy {
         this.session.clear();
         this.log.logEvent(this.LOG_SOURCE, 'logout');
         this.analytics.emitCustomEvent(AnalyticsEventCategories.Authentication, AnalyticsEventActions.Logout);
-        const returnTo = `${baseUrl}${baseUrl.endsWith('/') ? '' : '/'}${returnToUrl}`;
+
+        let returnTo = `${baseUrl}${baseUrl.endsWith('/') ? '' : '/'}${returnToUrl}`;
+        if (returnToUrl.startsWith('http')) {
+          returnTo = returnToUrl;
+        }
+
         if (wasAdmin) {
             this.adminWebAuth.logout({
                 returnTo,


### PR DESCRIPTION
With these changes we will be able to configure url to return to after signing out successfully. Additionally, if this return url starts with `http` then we assume that this is a link to an outside web page.