### PR TITLE
Language selector hooks

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/internationalization/languageSelector.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/internationalization/languageSelector.component.ts
@@ -41,6 +41,8 @@ import { LoggingService } from '../../services/logging.service';
 export class LanguageSelectorComponent implements OnInit, OnDestroy {
   @Input() isScrolled: boolean;
   @Output() isVisible: EventEmitter<boolean> = new EventEmitter();
+  @Output() beforeLanguageChange: EventEmitter<StudyLanguage> = new EventEmitter<StudyLanguage>();
+  @Output() afterProfileLanguageChange: EventEmitter<void> = new EventEmitter();
   public loaded: boolean;
   public currentLanguage: StudyLanguage;
   public iconURL: string;
@@ -107,6 +109,7 @@ export class LanguageSelectorComponent implements OnInit, OnDestroy {
     if (this.language.canUseLanguage(lang.languageCode)) {
       this.currentLanguage = lang;
       if (this.language.getCurrentLanguage() !== lang.languageCode) {
+        this.beforeLanguageChange.emit(lang);
         const langObs: Observable<any> = this.language.changeLanguageObservable(lang.languageCode);
         let sub;
         if (this.session.isAuthenticatedSession()) {
@@ -138,7 +141,10 @@ export class LanguageSelectorComponent implements OnInit, OnDestroy {
     const profileModifications: UserProfile = new UserProfile();
     profileModifications.preferredLanguage = this.currentLanguage.languageCode;
     return this.profileServiceAgent.updateProfile(profileModifications)
-      .pipe(tap(() => this.language.notifyOfProfileLanguageUpdate()));
+      .pipe(
+        tap(() => this.afterProfileLanguageChange.emit()),
+        tap(() => this.language.notifyOfProfileLanguageUpdate())
+      );
   }
 
   // Find the current language and return true if successful or false otherwise


### PR DESCRIPTION
Currently AT study has multi-governed user and i18n functionality.
When an operator performs actions on behalf of a participant changing the language leads to update in participants profile but not in operators one.
These hooks (events) will allow us to step in before language change request occurs to discard current participants guid and then, when request to update a profile finishes, to set participants guid back.

Note: we need this `afterProfileLanguageChange` event because we want to set participant guid as active before language change notification occurs so that other parts of the application would perform all the requests on behalf of a participant again.