### PR TITLE
DDP-5312 prism activity-link component

### DIFF
--- a/ddp-workspace/projects/ddp-testboston/src/app/app-routes.ts
+++ b/ddp-workspace/projects/ddp-testboston/src/app/app-routes.ts
@@ -14,6 +14,7 @@ export const AppRoutes = {
     SymptomSurvey: 'symptom-survey',
     Dashboard: 'dashboard',
     Prism: 'prism',
+    PrismActivityLink: 'prism/activity-link',
     Password: 'password',
     SessionExpired: 'session-expired',
     AdminSessionExpired: 'admin-session-expired',

--- a/ddp-workspace/projects/ddp-testboston/src/app/app-routing.module.ts
+++ b/ddp-workspace/projects/ddp-testboston/src/app/app-routing.module.ts
@@ -7,6 +7,7 @@ import { ActivityGuids } from './activity-guids';
 import { WelcomeComponent } from './components/welcome/welcome.component';
 import { UserRegistrationPrequalComponent } from './components/user-registration-prequal/user-registration-prequal.component';
 import { PrismComponent } from './components/prism/prism.component';
+import { PrismActivityLinkComponent } from './components/prism-activity-link/prism-activity-link.component';
 import { EnrollmentComponent } from './components/enrollment/enrollment.component';
 import { HelpComponent } from './components/help/help.component';
 
@@ -138,6 +139,14 @@ const routes: Routes = [
   {
     path: AppRoutes.Prism,
     component: PrismComponent,
+    canActivate: [
+      IrbGuard,
+      AdminAuthGuard
+    ]
+  },
+  {
+    path: AppRoutes.PrismActivityLink,
+    component: PrismActivityLinkComponent,
     canActivate: [
       IrbGuard,
       AdminAuthGuard

--- a/ddp-workspace/projects/ddp-testboston/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-testboston/src/app/app.module.ts
@@ -35,6 +35,7 @@ import { WelcomeComponent } from './components/welcome/welcome.component';
 import { MailingListComponent } from './components/mailing-list/mailing-list.component';
 import { UserRegistrationPrequalComponent } from './components/user-registration-prequal/user-registration-prequal.component';
 import { PrismComponent } from './components/prism/prism.component';
+import { PrismActivityLinkComponent } from './components/prism-activity-link/prism-activity-link.component';
 import { EnrollmentComponent } from './components/enrollment/enrollment.component';
 import { HelpComponent } from './components/help/help.component';
 
@@ -143,6 +144,7 @@ export function languageFactory(language: LanguageService): string {
         MailingListComponent,
         UserRegistrationPrequalComponent,
         PrismComponent,
+        PrismActivityLinkComponent,
         EnrollmentComponent,
         HelpComponent
     ],

--- a/ddp-workspace/projects/ddp-testboston/src/app/components/prism-activity-link/prism-activity-link.component.ts
+++ b/ddp-workspace/projects/ddp-testboston/src/app/components/prism-activity-link/prism-activity-link.component.ts
@@ -1,0 +1,58 @@
+import { Component, OnInit, Inject } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { take } from 'rxjs/operators';
+import {
+  SubjectInvitationServiceAgent,
+  SessionMementoService,
+  LoggingService
+} from 'ddp-sdk';
+
+@Component({
+  selector: 'app-prism-activity-link',
+  template: `<p></p>`
+})
+export class PrismActivityLinkComponent implements OnInit {
+  // This component handles redirecting a study staff to a specific activity for a specific user. This is
+  // handy for embedding a URL in a study staff email. The required arguments to this component is the
+  // user's invite code and activity instance guid. These are expected to be passed as query parameters.
+
+  private readonly LOG_SOURCE = 'PrismActivityLinkComponent';
+
+  constructor(
+    private router: Router,
+    private logger: LoggingService,
+    private activatedRoute: ActivatedRoute,
+    private sessionService: SessionMementoService,
+    private subjectInvitation: SubjectInvitationServiceAgent) { }
+
+  public ngOnInit(): void {
+    this.activatedRoute.queryParams.subscribe(q => {
+      const invitationId = q.invitationId;
+      const instanceGuid = q.instanceGuid;
+      if (invitationId && instanceGuid) {
+        // First, lookup the invitation and setup the session.
+        const currentInvitationId = this.sessionService.session.invitationId;
+        if (invitationId === currentInvitationId) {
+          // Study staff already looking at this invitation, so just navigate.
+          this.router.navigateByUrl(`/activity/${instanceGuid}`);
+        } else {
+          this.subjectInvitation.lookupInvitation(invitationId)
+            .pipe(take(1))
+            .subscribe(response => {
+              if (response) {
+                this.sessionService.setInvitationId(response.invitationId);
+                this.sessionService.setParticipant(response.userGuid);
+                this.router.navigateByUrl(`/activity/${instanceGuid}`);
+              } else {
+                this.logger.logError(this.LOG_SOURCE, `Error while looking up invitationId: ${invitationId}`);
+                this.router.navigateByUrl(`/error`);
+              }
+            });
+        }
+      } else {
+        this.logger.logError(this.LOG_SOURCE, 'Either `invitationId` or `instanceGuid` query parameters are missing');
+        this.router.navigateByUrl(`/error`);
+      }
+    });
+  }
+}

--- a/ddp-workspace/projects/ddp-testboston/src/app/components/prism-activity-link/prism-activity-link.component.ts
+++ b/ddp-workspace/projects/ddp-testboston/src/app/components/prism-activity-link/prism-activity-link.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Inject } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { take } from 'rxjs/operators';
 import {


### PR DESCRIPTION
Part of DDP-5312 and DDP-5276. This PR adds a new component in TestBoston app for linking to an activity instance for study staff. So far it seems to work for me locally. Only think I couldn't get working is the logger.