### PR TITLE
circleci: add prion to build and deploy steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -436,6 +436,8 @@ jobs:
           study_key: atcp
       - conditionally-launch-build-and-store:
           study_key: rgp
+      - conditionally-launch-build-and-store:
+          study_key: prion
 
   app-build-and-store-job:
     working_directory: *ng_workspace_path
@@ -518,7 +520,6 @@ workflows:
                 - staging
                 - production
           study_key: osteo
-
       - deploy-stored-build-job:
           <<: *deploy_branch_filters
           study_key: brain
@@ -540,6 +541,9 @@ workflows:
       - deploy-stored-build-job:
           <<: *deploy_branch_filters
           study_key: rgp
+      - deploy-stored-build-job:
+          <<: *deploy_branch_filters
+          study_key: prion
 
   nightly:
     triggers:
@@ -574,3 +578,6 @@ workflows:
       - build-and-deploy-job:
           name: rgp-nightly
           study_key: rgp
+      - build-and-deploy-job:
+          name: prion-nightly
+          study_key: prion


### PR DESCRIPTION
CircleCI is failing because we didn't deploy prion. Adding it to the list.