### PR TITLE
DDP-5396 better handling of failed admin logins

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/login/auth0-code-callback.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/login/auth0-code-callback.component.ts
@@ -64,7 +64,12 @@ export class Auth0CodeCallbackComponent implements OnInit, OnDestroy {
                 this.windowRef.nativeWindow.location.href = nextUrl;
             });
         } else {
-            throw new Error('No auth code present in url.');
+            const error = this.route.snapshot.queryParams['error'];
+            const errorDescription = this.route.snapshot.queryParams['error_description'];
+            this.log.logError(this.LOG_SOURCE, 'No auth code present in url');
+            this.log.logError(this.LOG_SOURCE, `Error: ${error}`);
+            this.log.logError(this.LOG_SOURCE, `Error Description: ${errorDescription}`);
+            this.adapter.logout();
         }
     }
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/login/auth0-code-callback.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/login/auth0-code-callback.component.ts
@@ -69,7 +69,7 @@ export class Auth0CodeCallbackComponent implements OnInit, OnDestroy {
             this.log.logError(this.LOG_SOURCE, 'No auth code present in url');
             this.log.logError(this.LOG_SOURCE, `Error: ${error}`);
             this.log.logError(this.LOG_SOURCE, `Error Description: ${errorDescription}`);
-            this.adapter.logout();
+            this.adapter.logout(this.configuration.errorPageUrl);
         }
     }
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/authentication/auth0Adapter.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/authentication/auth0Adapter.service.ts
@@ -219,16 +219,9 @@ export class Auth0AdapterService implements OnDestroy {
                 this.analytics.emitCustomEvent(AnalyticsEventCategories.Authentication, AnalyticsEventActions.Login);
             } else if (err) {
                 this.log.logError(`${this.LOG_SOURCE}.handleAdminAuthentication`, err);
-                let error = null;
-                try {
-                    error = JSON.parse(decodeURIComponent(err.errorDescription));
-                } catch (e) {
-                    this.log.logError(`${this.LOG_SOURCE}.handleAdminAuthentication.Problem decoding authentication error`, e);
-                }
-                if (onErrorCallback && error) {
-                    // We might encounter errors from Auth0 that is not in expected
-                    // JSON format, so only run callback if decoding is successful.
-                    onErrorCallback(error);
+                if (onErrorCallback) {
+                    // Let callback handle whether to decode error or not.
+                    onErrorCallback(err.errorDescription);
                 }
             }
         });
@@ -263,7 +256,7 @@ export class Auth0AdapterService implements OnDestroy {
 
     public logout(returnToUrl: string = ''): void {
         const baseUrl = this.configuration.baseUrl;
-        const wasAdmin = this.session.session.isAdmin;
+        const wasAdmin = this.session.session && this.session.session.isAdmin;
         // Remove tokens and expiry time from localStorage
         this.session.clear();
         this.log.logEvent(this.LOG_SOURCE, 'logout');

--- a/ddp-workspace/projects/toolkit/src/lib/components/login-landing/admin-login-landing.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/login-landing/admin-login-landing.component.ts
@@ -53,10 +53,11 @@ export class AdminLoginLandingComponent implements OnInit, OnDestroy {
   }
 
   private handleAuthError(error: any | null): void {
-    if (error) {
-      this.logger.logError(this.LOG_SOURCE, error);
-    }
-    this.router.navigateByUrl(this.toolkitConfiguration.errorUrl);
+    // No need to decode error, and it should have already been logged.
+
+    // Logout to clear any potentially leftover state. Otherwise, user might be stuck in error mode
+    // and cannot re-attempt login until browser cache is cleared manually.
+    this.auth0.logout(this.toolkitConfiguration.errorUrl);
   }
 
   private redirect(): void {


### PR DESCRIPTION
This PR improves our handling of failed admin login attempts. With the changes in https://github.com/broadinstitute/ddp-study-server/pull/563, we will have fine control of which google account can login to TestBoston Prism. If a google account is not pre-authorized, it will error now. I discovered that when login fails, Auth0 caches some session information in their layer (see [here](https://auth0.com/docs/logout) for the different layers). So when you go back in to retry login, it reuses the cached information and fail you again. This means once someone fails the first login, they will have difficulty logging in even after we authorized them to login. This will be problematic for TestBoston admin logins.

Basic idea here is to call Auth0's `logout` API after a failed login attempt. This should clear an cached Auth0 information. I have verified this to work for local registration as well as in `dev` environment.