### PR TITLE
DDP-5457 pass in is_admin_client flag for admin logins

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/authentication/auth0Adapter.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/authentication/auth0Adapter.service.ts
@@ -196,6 +196,7 @@ export class Auth0AdapterService implements OnDestroy {
         const auth0Params = {
             study_guid: this.configuration.studyGuid,
             mode: Auth0Mode.LoginOnly,
+            is_admin_client: true,
             ...(additionalParams && additionalParams)
         };
         if (this.configuration.doLocalRegistration) {


### PR DESCRIPTION
Update SDK to pass in `is_admin_client` flag during admin logins so we can use it in the Auth0 Universal Login page.