### PR TITLE
DDP-5504 hide question errors if block is hidden

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activityQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activityQuestion.component.ts
@@ -18,12 +18,12 @@ import { delay, filter, map, shareReplay, startWith, takeUntil, tap } from 'rxjs
                   [validationRequested]="validationRequested$ | async"
                   (valueChanged)="enteredValue$.next($event)">
           </ddp-activity-answer>
-          <div *ngIf="block.shown">
+          <ng-container *ngIf="block.shown">
             <div class="ddp-activity-validation" *ngIf="errorMessage$ | async as errorMsg">
                 <ddp-validation-message [message]="errorMsg">
                 </ddp-validation-message>
             </div>
-          </div>
+          </ng-container>
       </div>`
 })
 export class ActivityQuestionComponent implements OnInit, OnDestroy {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activityQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activityQuestion.component.ts
@@ -18,9 +18,11 @@ import { delay, filter, map, shareReplay, startWith, takeUntil, tap } from 'rxjs
                   [validationRequested]="validationRequested$ | async"
                   (valueChanged)="enteredValue$.next($event)">
           </ddp-activity-answer>
-          <div class="ddp-activity-validation" *ngIf="errorMessage$ | async as errorMsg">
-              <ddp-validation-message [message]="errorMsg">
-              </ddp-validation-message>
+          <div *ngIf="block.shown">
+            <div class="ddp-activity-validation" *ngIf="errorMessage$ | async as errorMsg">
+                <ddp-validation-message [message]="errorMsg">
+                </ddp-validation-message>
+            </div>
           </div>
       </div>`
 })


### PR DESCRIPTION
Fixes DDP-5504. The bug is caused by not hiding the validation messages if the block is hidden, so we add a check to the component template.