### PR TITLE
Datepicker required validation

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activityDateAnswer.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activityDateAnswer.component.ts
@@ -33,14 +33,16 @@ export class ActivityDateAnswer {
     constructor(private logger: LoggingService) { }
 
     public handleChange(value: DatePickerValue | null): void {
-        if (value == null) {
-            return;
+        let dateValue: DatePickerValue | null = value;
+
+        if (value !== null) {
+            dateValue = {
+                month: value.month,
+                day: value.day,
+                year: value.year
+            };
         }
-        const dateValue: DatePickerValue = {
-            month: value.month,
-            day: value.day,
-            year: value.year
-        };
+
         // Assign answer value and trigger validations.
         this.block.answer = dateValue;
         this.logger.logEvent(this.LOG_SOURCE, `value ${JSON.stringify(dateValue)}`);

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activityDateAnswer.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activityDateAnswer.component.ts
@@ -33,7 +33,7 @@ export class ActivityDateAnswer {
     constructor(private logger: LoggingService) { }
 
     public handleChange(value: DatePickerValue | null): void {
-        let dateValue: DatePickerValue | null = value;
+        let dateValue: DatePickerValue | null = null;
 
         if (value !== null) {
             dateValue = {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/datePicker.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/datePicker.component.ts
@@ -295,6 +295,8 @@ export class DatePickerComponent implements OnChanges {
             this.selectedDay = day.toString();
             this.selectedYear = year.toString();
             this.emitValue(year, month, day);
+        } else {
+            this.discardValue();
         }
     }
 
@@ -401,6 +403,10 @@ export class DatePickerComponent implements OnChanges {
             day: this.includeDayField() ? day : null,
         };
         this.valueChanged.emit(valueToEmit);
+    }
+
+    private discardValue(): void {
+        this.valueChanged.emit(null);
     }
 
     private includeMonthField(): boolean {


### PR DESCRIPTION
These changes make sure that once user clears out date picker value manually the `null` value is emitted and validation is triggered.