### PR TITLE
AT deployment fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,7 +338,7 @@ commands:
               - equal: [ atcp, << parameters.study_key >> ]
           steps:
             - execute-study-specific-commands:
-                study_key: parameters.study_key
+                study_key: << parameters.study_key >>
       - run:
           name: ng build
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,8 @@ commands:
           study_key: << parameters.study_key >>
       - run-linter-check
       - run-tests
-      - build-app
+      - build-app:
+          study_key: << parameters.study_key >>
       - store-app-build
 
   app-build-and-deploy:
@@ -60,7 +61,8 @@ commands:
             - set-deployment-environment
             - run-linter-check
             - run-tests
-            - build-app
+            - build-app:
+                study_key: << parameters.study_key >>
             - deploy-exploded-build:
                 study_key: << parameters.study_key >>
 
@@ -312,22 +314,31 @@ commands:
 
   execute-study-specific-commands:
     description: run study specific commands if necessary
+    parameters:
+      study_key:
+        type: string
+        default: "UNKNOWN"
     steps:
       - when:
           condition:
-            equal: [ atcp, << pipeline.parameters.study_key >> ]
+            equal: [ atcp, << parameters.study_key >> ]
           steps:
             - build-atcp-assets
 
   build-app:
     description: "Build DDP study app"
+    parameters:
+      study_key:
+        type: string
+        default: "UNKNOWN"
     steps:
       - when:
           condition:
             or:
-              - equal: [ atcp, << pipeline.parameters.study_key >> ]
+              - equal: [ atcp, << parameters.study_key >> ]
           steps:
-            - execute-study-specific-commands
+            - execute-study-specific-commands:
+                study_key: parameters.study_key
       - run:
           name: ng build
           command: |


### PR DESCRIPTION
Previously, I made some changes to CircleCI config where I'd rely on `pipeline.parameters.study_key` in order to determine whether an additional command should be executed (needed for AT). I switched to passing the `study_key` as a parameter to the `build_app` command since we don't always have `pipeline.parameters.study_key` set (e.g. in `nightly` workflow).