### PR TITLE
DDP-5708 rgp: styling for required questions

### DIFF
--- a/ddp-workspace/projects/ddp-rgp/src/styles/_activity.scss
+++ b/ddp-workspace/projects/ddp-rgp/src/styles/_activity.scss
@@ -197,6 +197,10 @@
   }
 }
 
+.ddp-required-question-prompt:after {
+    content: ' *';
+}
+
 .ddp-helper {
   display: none;
 }

--- a/ddp-workspace/projects/ddp-rgp/src/styles/_activity.scss
+++ b/ddp-workspace/projects/ddp-rgp/src/styles/_activity.scss
@@ -202,7 +202,7 @@
 }
 
 .ddp-helper {
-  display: none;
+  display: none !important;
 }
 
 .ddp-textarea {


### PR DESCRIPTION
I see that other projects use CSS for styling required questions. Doing the same for RGP so we remove the `*` from actual question prompt text in the backend configuration (see https://github.com/broadinstitute/ddp-study-server/pull/689).