### PR TITLE
DDP-5744: Fix saving child instances after wizard navigation

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityBlock/activityBlock.component.html
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityBlock/activityBlock.component.html
@@ -9,8 +9,7 @@
                                           [validationRequested]="validationRequested"
                                           [studyGuid]="studyGuid"
                                           [parentActivityInstanceGuid]="parentActivityInstanceGuid"
-                                          (deletedActivity)="onDeleteChildInstance($event)"
-                                          (editedActivity)="onEditChildInstance($event)">
+                                          (deletedActivity)="onDeleteChildInstance($event)">
                 </ddp-modal-activity-block>
             </ng-container>
             <ng-template #embedded>

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityBlock/activityBlock.component.html
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityBlock/activityBlock.component.html
@@ -9,7 +9,8 @@
                                           [validationRequested]="validationRequested"
                                           [studyGuid]="studyGuid"
                                           [parentActivityInstanceGuid]="parentActivityInstanceGuid"
-                                          (deleteActivity)="onDeleteChildInstance($event)">
+                                          (deletedActivity)="onDeleteChildInstance($event)"
+                                          (editedActivity)="onEditChildInstance($event)">
                 </ddp-modal-activity-block>
             </ng-container>
             <ng-template #embedded>

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityBlock/activityBlock.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityBlock/activityBlock.component.ts
@@ -42,8 +42,11 @@ export class ActivityBlockComponent implements OnInit, OnDestroy {
     }
 
     onDeleteChildInstance(instanceGuid: string): void {
-        const index = this.childInstances.findIndex(instance => instance.instanceGuid === instanceGuid);
-        this.childInstances.splice(index, 1);
+        this.replaceInChildInstancesById(instanceGuid, 1);
+    }
+
+    onEditChildInstance(editedInstance: ActivityInstance): void {
+        this.replaceInChildInstancesById(editedInstance.instanceGuid, 1, editedInstance);
     }
 
     createChildInstance(): void {
@@ -67,5 +70,14 @@ export class ActivityBlockComponent implements OnInit, OnDestroy {
     ngOnDestroy(): void {
         this.ngUnsubscribe.next();
         this.ngUnsubscribe.complete();
+    }
+
+    private replaceInChildInstancesById(instanceGuid: string, amountOfInstancesToRemove: number, replaceWith?: ActivityInstance): void {
+        const index = this.childInstances.findIndex(instance => instance.instanceGuid === instanceGuid);
+        const params: [number, number, ActivityInstance?] = [index, amountOfInstancesToRemove];
+        if (replaceWith) {
+            params.push(replaceWith);
+        }
+        this.childInstances.splice(...params);
     }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityBlock/activityBlock.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityBlock/activityBlock.component.ts
@@ -42,11 +42,8 @@ export class ActivityBlockComponent implements OnInit, OnDestroy {
     }
 
     onDeleteChildInstance(instanceGuid: string): void {
-        this.replaceInChildInstancesById(instanceGuid, 1);
-    }
-
-    onEditChildInstance(editedInstance: ActivityInstance): void {
-        this.replaceInChildInstancesById(editedInstance.instanceGuid, 1, editedInstance);
+        const index = this.childInstances.findIndex(instance => instance.instanceGuid === instanceGuid);
+        this.childInstances.splice(index, 1);
     }
 
     createChildInstance(): void {
@@ -70,14 +67,5 @@ export class ActivityBlockComponent implements OnInit, OnDestroy {
     ngOnDestroy(): void {
         this.ngUnsubscribe.next();
         this.ngUnsubscribe.complete();
-    }
-
-    private replaceInChildInstancesById(instanceGuid: string, amountOfInstancesToRemove: number, replaceWith?: ActivityInstance): void {
-        const index = this.childInstances.findIndex(instance => instance.instanceGuid === instanceGuid);
-        const params: [number, number, ActivityInstance?] = [index, amountOfInstancesToRemove];
-        if (replaceWith) {
-            params.push(replaceWith);
-        }
-        this.childInstances.splice(...params);
     }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityBlock/activityBlock.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityBlock/activityBlock.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { Subject, throwError } from 'rxjs';
 import { catchError, concatMap, takeUntil } from 'rxjs/operators';
 
@@ -12,7 +12,8 @@ import { LoggingService } from '../../../../services/logging.service';
 @Component({
     selector: 'ddp-activity-block',
     templateUrl: './activityBlock.component.html',
-    styleUrls: ['./activityBlock.component.scss']
+    styleUrls: ['./activityBlock.component.scss'],
+    changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class ActivityBlockComponent implements OnInit, OnDestroy {
     @Input() block: ActivityActivityBlock;
@@ -27,7 +28,8 @@ export class ActivityBlockComponent implements OnInit, OnDestroy {
     private readonly LOG_SOURCE = 'ActivityBlockComponent';
 
     constructor(private activityServiceAgent: ActivityServiceAgent,
-                private logger: LoggingService) {
+                private logger: LoggingService,
+                private cdr: ChangeDetectorRef) {
     }
 
     ngOnInit(): void {
@@ -40,7 +42,8 @@ export class ActivityBlockComponent implements OnInit, OnDestroy {
     }
 
     onDeleteChildInstance(instanceGuid: string): void {
-        this.childInstances = this.childInstances.filter(instance => instance.instanceGuid !== instanceGuid);
+        const index = this.childInstances.findIndex(instance => instance.instanceGuid === instanceGuid);
+        this.childInstances.splice(index, 1);
     }
 
     createChildInstance(): void {
@@ -57,6 +60,7 @@ export class ActivityBlockComponent implements OnInit, OnDestroy {
             )
             .subscribe((instance: ActivityInstance) => {
                 this.childInstances.push(instance);
+                this.cdr.detectChanges();
             });
     }
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/modalActivityBlock/modalActivityBlock.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/modalActivityBlock/modalActivityBlock.component.ts
@@ -47,7 +47,6 @@ export class ModalActivityBlockComponent {
     @Input() validationRequested: boolean;
     @Input() readonly: boolean;
     @Output() deletedActivity = new EventEmitter<string>();
-    @Output() editedActivity = new EventEmitter<ActivityInstance>();
 
     @ViewChild('edit_dialog') private editModalRef: TemplateRef<any>;
     @ViewChild('delete_dialog') private deleteModalRef: TemplateRef<any>;
@@ -99,8 +98,7 @@ export class ModalActivityBlockComponent {
             }),
             take(1)
         ).subscribe((activityInstance: ActivityInstance) => {
-            this.instance = activityInstance;
-            this.editedActivity.emit(activityInstance);
+            this.mutateWithNewPropertiesValues(this.instance, activityInstance);
             this.cdr.detectChanges();
             this.dialog.closeAll();
         });
@@ -171,5 +169,10 @@ export class ModalActivityBlockComponent {
             top: `${box.top - dialogHeight - verticalGap}px`,
             left
         };
+    }
+
+    private mutateWithNewPropertiesValues(target: ActivityInstance, source: ActivityInstance): void {
+        // mutate the target instance (copy all properties from source to target)
+        Object.assign(target, source);
     }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/modalActivityBlock/modalActivityBlock.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/modalActivityBlock/modalActivityBlock.component.ts
@@ -46,7 +46,8 @@ export class ModalActivityBlockComponent {
     @Input() instance: ActivityInstance;
     @Input() validationRequested: boolean;
     @Input() readonly: boolean;
-    @Output() deleteActivity = new EventEmitter<string>();
+    @Output() deletedActivity = new EventEmitter<string>();
+    @Output() editedActivity = new EventEmitter<ActivityInstance>();
 
     @ViewChild('edit_dialog') private editModalRef: TemplateRef<any>;
     @ViewChild('delete_dialog') private deleteModalRef: TemplateRef<any>;
@@ -71,7 +72,7 @@ export class ModalActivityBlockComponent {
             take(1)
             )
             .subscribe(() => {
-                this.deleteActivity.emit(this.instance.instanceGuid);
+                this.deletedActivity.emit(this.instance.instanceGuid);
                 this.dialog.closeAll();
             });
     }
@@ -99,6 +100,7 @@ export class ModalActivityBlockComponent {
             take(1)
         ).subscribe((activityInstance: ActivityInstance) => {
             this.instance = activityInstance;
+            this.editedActivity.emit(activityInstance);
             this.cdr.detectChanges();
             this.dialog.closeAll();
         });


### PR DESCRIPTION
Refactored that any changes of child instances lead to the whole (Family History) activity mutation.
It helped to fix the bug with losing changes (adding/removing) during the wizard navigation.