### PR TITLE
Ddp 5762 refactor hide show blocks

### DIFF
--- a/ddp-workspace/projects/ddp-atcp/src/app/components/activityForm/app-atcp-activity-base.component.ts
+++ b/ddp-workspace/projects/ddp-atcp/src/app/components/activityForm/app-atcp-activity-base.component.ts
@@ -77,7 +77,6 @@ import { combineLatest, merge } from 'rxjs';
                                         [validationRequested]="validationRequested"
                                         [studyGuid]="studyGuid"
                                         [activityGuid]="activityGuid"
-                                        (visibilityChanged)="updateVisibility($event)"
                                         (embeddedComponentsValidationStatus)="updateEmbeddedComponentValidationStatus(0, $event)"
                                         (embeddedComponentBusy)="embeddedComponentBusy$[0].next($event)">
                                 </ddp-activity-section>
@@ -115,7 +114,6 @@ import { combineLatest, merge } from 'rxjs';
                                         [validationRequested]="validationRequested"
                                         [studyGuid]="studyGuid"
                                         [activityGuid]="activityGuid"
-                                        (visibilityChanged)="updateVisibility($event)"
                                         (embeddedComponentsValidationStatus)="updateEmbeddedComponentValidationStatus(1, $event)"
                                         (embeddedComponentBusy)="embeddedComponentBusy$[1].next($event)">
                                 </ddp-activity-section>
@@ -131,7 +129,6 @@ import { combineLatest, merge } from 'rxjs';
                                             [validationRequested]="validationRequested"
                                             [studyGuid]="studyGuid"
                                             [activityGuid]="activityGuid"
-                                            (visibilityChanged)="updateVisibility($event)"
                                             (embeddedComponentsValidationStatus)="updateEmbeddedComponentValidationStatus(2, $event)"
                                             (embeddedComponentBusy)="embeddedComponentBusy$[2].next($event)">
                                     </ddp-activity-section>

--- a/ddp-workspace/projects/ddp-atcp/src/app/components/activityForm/app-atcp-activity.component.ts
+++ b/ddp-workspace/projects/ddp-atcp/src/app/components/activityForm/app-atcp-activity.component.ts
@@ -79,7 +79,6 @@ import * as Routes from '../../router-resources';
                             [validationRequested]="validationRequested"
                             [studyGuid]="studyGuid"
                             [activityGuid]="activityGuid"
-                            (visibilityChanged)="updateVisibility($event)"
                             (embeddedComponentsValidationStatus)="updateEmbeddedComponentValidationStatus(0, $event)"
                             (embeddedComponentBusy)="embeddedComponentBusy$[0].next($event)">
                     </ddp-activity-section>
@@ -134,7 +133,6 @@ import * as Routes from '../../router-resources';
                             [validationRequested]="validationRequested"
                             [studyGuid]="studyGuid"
                             [activityGuid]="activityGuid"
-                            (visibilityChanged)="updateVisibility($event)"
                             (embeddedComponentsValidationStatus)="updateEmbeddedComponentValidationStatus(1, $event)"
                             (embeddedComponentBusy)="embeddedComponentBusy$[1].next($event)">
                     </ddp-activity-section>
@@ -147,7 +145,6 @@ import * as Routes from '../../router-resources';
                                 [validationRequested]="validationRequested"
                                 [studyGuid]="studyGuid"
                                 [activityGuid]="activityGuid"
-                                (visibilityChanged)="updateVisibility($event)"
                                 (embeddedComponentsValidationStatus)="updateEmbeddedComponentValidationStatus(2, $event)"
                                 (embeddedComponentBusy)="embeddedComponentBusy$[2].next($event)">
                         </ddp-activity-section>

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityQuestion.component.ts
@@ -39,7 +39,6 @@ export class ActivityQuestionComponent implements OnInit, OnDestroy {
   @Input() studyGuid: string;
   @Input() activityGuid: string;
   @Output() valueChanged: EventEmitter<AnswerValue> = new EventEmitter();
-  @Output() visibilityChanged: EventEmitter<BlockVisibility[]> = new EventEmitter();
   public errorMessage$: Observable<string | string[] | null>;
   @ViewChild('scrollAnchor', { static: true }) scrollAnchor: ElementRef;
   private ngUnsubscribe = new Subject<void>();

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/conditionalBlock.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/conditionalBlock.component.ts
@@ -1,4 +1,4 @@
-import { Input, OnDestroy, OnInit, Component, Output, EventEmitter } from '@angular/core';
+import { Input, OnDestroy, OnInit, Component, Output, EventEmitter, ChangeDetectorRef } from '@angular/core';
 import { AnswerValue } from '../../../models/activity/answerValue';
 import { ConditionalBlock } from '../../../models/activity/conditionalBlock';
 import { BlockVisibility } from '../../../models/activity/blockVisibility';
@@ -13,8 +13,7 @@ import { CompositeDisposable } from '../../../compositeDisposable';
                             [validationRequested]="validationRequested"
                             [studyGuid]="studyGuid"
                             [activityGuid]="activityGuid"
-                            (valueChanged)="handleChange($event)"
-                            (visibilityChanged)="updateVisibility($event)">
+                            (valueChanged)="handleChange($event)">
     </ddp-activity-question>
     <ddp-group-block [block]="block.nestedGroupBlock"
                         [readonly]="readonly"
@@ -24,39 +23,15 @@ import { CompositeDisposable } from '../../../compositeDisposable';
                         (valueChanged)="handleChange($event)">
     </ddp-group-block>`
 })
-export class ConditionalBlockComponent implements OnInit, OnDestroy {
+export class ConditionalBlockComponent {
     @Input() block: ConditionalBlock;
     @Input() readonly: boolean;
     @Input() validationRequested: boolean;
     @Input() studyGuid: string;
     @Input() activityGuid: string;
     @Output() valueChanged: EventEmitter<AnswerValue> = new EventEmitter();
-    private anchor: CompositeDisposable;
-
-    constructor(private submissionManager: SubmissionManager) { }
-
-    public ngOnInit(): void {
-        const sub = this.submissionManager.answerSubmissionResponse$.subscribe((response) => {
-            this.updateVisibility(response.blockVisibility);
-        });
-        this.anchor = new CompositeDisposable(sub);
-    }
-
-    public ngOnDestroy(): void {
-        this.anchor.removeAll();
-    }
 
     public handleChange(value: AnswerValue): void {
         this.valueChanged.emit(value);
-    }
-
-    public updateVisibility(visibility: BlockVisibility[]): void {
-        visibility.forEach(shownBlockStatus => {
-            const matchingBlock = this.block.nestedGroupBlock
-                .nestedBlocks.find(nestedBlock => nestedBlock.id === shownBlockStatus.blockGuid);
-            if (matchingBlock) {
-                matchingBlock.shown = shownBlockStatus.shown;
-            }
-        });
     }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/conditionalBlock.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/conditionalBlock.component.ts
@@ -1,9 +1,6 @@
-import { Input, OnDestroy, OnInit, Component, Output, EventEmitter, ChangeDetectorRef } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { AnswerValue } from '../../../models/activity/answerValue';
 import { ConditionalBlock } from '../../../models/activity/conditionalBlock';
-import { BlockVisibility } from '../../../models/activity/blockVisibility';
-import { SubmissionManager } from '../../../services/serviceAgents/submissionManager.service';
-import { CompositeDisposable } from '../../../compositeDisposable';
 
 @Component({
     selector: 'ddp-conditional-block',

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity.component.ts
@@ -69,7 +69,6 @@ import { ActivityStatusCodes } from '../../models/activity/activityStatusCodes';
                                         [validationRequested]="validationRequested"
                                         [studyGuid]="studyGuid"
                                         [activityGuid]="activityGuid"
-                                        (visibilityChanged)="updateVisibility($event)"
                                         (embeddedComponentsValidationStatus)="updateEmbeddedComponentValidationStatus(0, $event)"
                                         (embeddedComponentBusy)="embeddedComponentBusy$[0].next($event)">
                                 </ddp-activity-section>
@@ -107,7 +106,6 @@ import { ActivityStatusCodes } from '../../models/activity/activityStatusCodes';
                                         [validationRequested]="validationRequested"
                                         [studyGuid]="studyGuid"
                                         [activityGuid]="activityGuid"
-                                        (visibilityChanged)="updateVisibility($event)"
                                         (embeddedComponentsValidationStatus)="updateEmbeddedComponentValidationStatus(1, $event)"
                                         (embeddedComponentBusy)="embeddedComponentBusy$[1].next($event)">
                                 </ddp-activity-section>
@@ -123,7 +121,6 @@ import { ActivityStatusCodes } from '../../models/activity/activityStatusCodes';
                                             [validationRequested]="validationRequested"
                                             [studyGuid]="studyGuid"
                                             [activityGuid]="activityGuid"
-                                            (visibilityChanged)="updateVisibility($event)"
                                             (embeddedComponentsValidationStatus)="updateEmbeddedComponentValidationStatus(2, $event)"
                                             (embeddedComponentBusy)="embeddedComponentBusy$[2].next($event)">
                                     </ddp-activity-section>

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/MailAddressBlock.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/MailAddressBlock.ts
@@ -17,6 +17,10 @@ export class MailAddressBlock extends ActivityBlock {
         return BlockType.MailAddress;
     }
 
+    get blocks(): Array<ActivityBlock> {
+        return [this];
+    }
+
     public validate(): boolean {
         return true;
     }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/abstractActivityQuestionBlock.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/abstractActivityQuestionBlock.ts
@@ -30,6 +30,10 @@ export abstract class AbstractActivityQuestionBlock extends ActivityBlock {
     return BlockType.Question;
   }
 
+  get blocks(): Array<ActivityBlock> {
+    return [this];
+  }
+
   public abstract get questionType(): QuestionType;
 
   public canPatch(): boolean {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityActivityBlock.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityActivityBlock.ts
@@ -14,4 +14,8 @@ export class ActivityActivityBlock extends ActivityBlock {
     public get blockType(): BlockType {
         return BlockType.Activity;
     }
+
+    get blocks(): Array<ActivityBlock> {
+        return [this];
+    }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityBlock.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityBlock.ts
@@ -8,6 +8,11 @@ export abstract class ActivityBlock {
 
     abstract get blockType(): BlockType;
 
+    /**
+     * all block contained by this block, including self
+     */
+    abstract get blocks(): Array<ActivityBlock>;
+
     public shouldScrollToFirstInvalidQuestion(): boolean {
         if (this.shown) {
             this.scrollTo = !this.valid;

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityContentBlock.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityContentBlock.ts
@@ -10,6 +10,10 @@ export class ActivityContentBlock extends ActivityBlock {
         return BlockType.Content;
     }
 
+    get blocks(): Array<ActivityBlock> {
+        return [this];
+    }
+
     public validate(): boolean {
         return true;
     }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityGroupBlock.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityGroupBlock.ts
@@ -13,6 +13,10 @@ export class ActivityGroupBlock extends ActivityBlock {
         return BlockType.Group;
     }
 
+    get blocks(): Array<ActivityBlock> {
+        return ([this] as Array<ActivityBlock>).concat(this.nestedBlocks);
+    }
+
     public validate(): boolean {
         let isValid = true;
         for (const nestedBlock of this.nestedBlocks) {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityInstitutionBlock.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityInstitutionBlock.ts
@@ -15,6 +15,10 @@ export class ActivityInstitutionBlock extends ActivityBlock {
         return BlockType.Institution;
     }
 
+    get blocks(): Array<ActivityBlock> {
+        return [this];
+    }
+
     public validate(): boolean {
         return true;
     }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activitySection.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activitySection.ts
@@ -17,6 +17,11 @@ export class ActivitySection {
         return this.getIcon('INCOMPLETE');
     }
 
+    // recursively return all the child blocks contained in section
+    public allChildBlocks(): Array<ActivityBlock> {
+        return this.blocks.reduce((acc, val) => acc.concat(val.blocks), []);
+    }
+
     public get completeIcon(): string {
         return this.getIcon('COMPLETE');
     }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/conditionalBlock.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/conditionalBlock.ts
@@ -12,6 +12,12 @@ export class ConditionalBlock extends ActivityBlock {
         return BlockType.Conditional;
     }
 
+    public get blocks(): Array<ActivityBlock> {
+        return [this as ActivityBlock]
+            .concat(this.controlQuestion.blocks as ActivityBlock[])
+            .concat(this.nestedGroupBlock.blocks as ActivityBlock[]);
+    }
+
     public validate(): boolean {
         let isValid = true;
         if (this.controlQuestion && this.controlQuestion.shown) {

--- a/ddp-workspace/projects/toolkit/src/lib/components/activity/modal-activity.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/activity/modal-activity.component.ts
@@ -36,7 +36,6 @@ import { ModalActivityData } from '../../models/modalActivityData';
             [validationRequested]="validationRequested"
             [studyGuid]="studyGuid"
             [activityGuid]="activityGuid"
-            (visibilityChanged)="updateVisibility($event)"
             (embeddedComponentsValidationStatus)="updateEmbeddedComponentValidationStatus(1, $event)"
             (embeddedComponentBusy)="embeddedComponentBusy$[1].next($event)">
           </ddp-activity-section>


### PR DESCRIPTION
**Needs to be re-reviewed after merge and minor refactoring of imports.**
Trying to deal with a few issues:
1. Centralizing the hide/show functionality on ActivitySection (before it was done higher up in component hierarchy, but hide/show is done at the level of Blocks and these are below the Section level. This is important because ActivitySection component is also reused by the embedded and modal activity blocks. This is main reason functionality was not working in these blocks. The key change here: https://github.com/broadinstitute/ddp-angular/pull/500/files#diff-45705fe892c0b18587e0c4c566460622e324b44d968c0e6b64c9c5f069b641a2R122
2. To centralize the hide/show we implement a recursive collection of all the relevant blocks (the model for blocks is all subclassed from ActivityBlock. https://github.com/broadinstitute/ddp-angular/pull/500/files#r615435297 . All the blocks come together in this short little snippet:  https://github.com/broadinstitute/ddp-angular/pull/500/files#diff-d7a01d134bc92c1387f6103f133dd9dd025c669bee24befe6df5da24ed92760bR20
2. Got rid of the visiblityChanged output parameters. They were not being used as far as I can see. If someone can find a use them do let me know and will bring them back. 