### PR TITLE
Ddp 6013 internationalize date label

### DIFF
--- a/ddp-workspace/projects/basil-app/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/basil-app/src/assets/i18n/en.json
@@ -73,6 +73,11 @@
             "November": "November",
             "December": "December"
         },
+        "DateLabel": {
+            "YYYY": "YYYY",
+            "MM": "MM",
+            "DD": "DD"
+        },
         "UserMenu": {
             "DashboardButton": "Dashboard",
             "SignOutButton": "Sign Out"

--- a/ddp-workspace/projects/basil-app/src/assets/i18n/fr.json
+++ b/ddp-workspace/projects/basil-app/src/assets/i18n/fr.json
@@ -73,6 +73,11 @@
           "November": "novembre",
           "December": "décembre"
         },
+        "DateLabel": {
+            "YYYY": "YYYY",
+            "MM": "MM",
+            "DD": "DD"
+        },
         "UserMenu": {
             "DashboardButton": "Dashboard",
             "SignOutButton": "Sign Out"

--- a/ddp-workspace/projects/basil-app/src/assets/i18n/ru.json
+++ b/ddp-workspace/projects/basil-app/src/assets/i18n/ru.json
@@ -73,6 +73,11 @@
           "November": "November",
           "December": "December"
         },
+        "DateLabel": {
+            "YYYY": "YYYY",
+            "MM": "MM",
+            "DD": "DD"
+        },
         "UserMenu": {
             "DashboardButton": "Dashboard",
             "SignOutButton": "Sign Out"

--- a/ddp-workspace/projects/ddp-angio/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-angio/src/assets/i18n/en.json
@@ -533,6 +533,11 @@
             "November": "November",
             "December": "December"
         },
+        "DateLabel": {
+            "YYYY": "YYYY",
+            "MM": "MM",
+            "DD": "DD"
+        },
         "UserMenu": {
             "DashboardButton": "Dashboard",
             "SignOutButton": "Sign Out"

--- a/ddp-workspace/projects/ddp-atcp/src/assets/i18n/de.json
+++ b/ddp-workspace/projects/ddp-atcp/src/assets/i18n/de.json
@@ -354,6 +354,11 @@
       "September": "September",
       "Year": "Jahr wählen ..."
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "DetailsPlaceholder": {
       "PluralForm": "Zeichen verbleibend",
       "SingularForm": "Zeichen verbleibend"

--- a/ddp-workspace/projects/ddp-atcp/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-atcp/src/assets/i18n/en.json
@@ -481,6 +481,11 @@
       "September": "September",
       "Year": "Choose year..."
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "DetailsPlaceholder": {
       "PluralForm": "characters remaining",
       "SingularForm": "character remaining"

--- a/ddp-workspace/projects/ddp-atcp/src/assets/i18n/es.json
+++ b/ddp-workspace/projects/ddp-atcp/src/assets/i18n/es.json
@@ -354,6 +354,11 @@
       "September": "Septiembre",
       "Year": "Seleccione el año..."
     },
+    "DateLabel": {
+      "YYYY": "AAAA",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "DetailsPlaceholder": {
       "PluralForm": "caracteres restantes",
       "SingularForm": "carácter restante"

--- a/ddp-workspace/projects/ddp-atcp/src/assets/i18n/fr.json
+++ b/ddp-workspace/projects/ddp-atcp/src/assets/i18n/fr.json
@@ -354,6 +354,11 @@
       "September": "Septembre",
       "Year": "Choisir l'année..."
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "DetailsPlaceholder": {
       "PluralForm": "caractères restants",
       "SingularForm": "caractère restant"

--- a/ddp-workspace/projects/ddp-atcp/src/assets/i18n/hi.json
+++ b/ddp-workspace/projects/ddp-atcp/src/assets/i18n/hi.json
@@ -364,6 +364,11 @@
       "September": "सितंबर",
       "Year": "वर्ष चुनें..."
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "DetailsPlaceholder": {
       "PluralForm": "बाकी बचे वर्ण",
       "SingularForm": "बाकी बचा वर्ण"

--- a/ddp-workspace/projects/ddp-atcp/src/assets/i18n/it.json
+++ b/ddp-workspace/projects/ddp-atcp/src/assets/i18n/it.json
@@ -354,6 +354,11 @@
       "September": "Settembre",
       "Year": "Scegli l'anno..."
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "DetailsPlaceholder": {
       "PluralForm": "caratteri rimanenti",
       "SingularForm": "carattere rimanente"

--- a/ddp-workspace/projects/ddp-atcp/src/assets/i18n/ja.json
+++ b/ddp-workspace/projects/ddp-atcp/src/assets/i18n/ja.json
@@ -354,6 +354,11 @@
       "September": "9月",
       "Year": "年を選択してください..."
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "DetailsPlaceholder": {
       "PluralForm": "文字残っています",
       "SingularForm": "文字残っています"

--- a/ddp-workspace/projects/ddp-atcp/src/assets/i18n/pl.json
+++ b/ddp-workspace/projects/ddp-atcp/src/assets/i18n/pl.json
@@ -354,6 +354,11 @@
       "September": "wrzesień",
       "Year": "Wybierz rok..."
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "DetailsPlaceholder": {
       "PluralForm": "pozostało znaków",
       "SingularForm": "pozostał znak"

--- a/ddp-workspace/projects/ddp-atcp/src/assets/i18n/pt.json
+++ b/ddp-workspace/projects/ddp-atcp/src/assets/i18n/pt.json
@@ -354,6 +354,11 @@
       "September": "Setembro",
       "Year": "Escolher ano..."
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "DetailsPlaceholder": {
       "PluralForm": "caracteres restantes",
       "SingularForm": "caractere restante"

--- a/ddp-workspace/projects/ddp-atcp/src/assets/i18n/ru.json
+++ b/ddp-workspace/projects/ddp-atcp/src/assets/i18n/ru.json
@@ -355,9 +355,9 @@
       "Year": "Выбрать год..."
     },
     "DateLabel": {
-      "YYYY": "YYYY",
+      "YYYY": "ГГГГ",
       "MM": "MM",
-      "DD": "DD"
+      "DD": "ДД"
     },
     "DetailsPlaceholder": {
       "PluralForm": "символов осталось",

--- a/ddp-workspace/projects/ddp-atcp/src/assets/i18n/ru.json
+++ b/ddp-workspace/projects/ddp-atcp/src/assets/i18n/ru.json
@@ -354,6 +354,11 @@
       "September": "Сентябрь",
       "Year": "Выбрать год..."
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "DetailsPlaceholder": {
       "PluralForm": "символов осталось",
       "SingularForm": "символ остался"

--- a/ddp-workspace/projects/ddp-atcp/src/assets/i18n/tr.json
+++ b/ddp-workspace/projects/ddp-atcp/src/assets/i18n/tr.json
@@ -354,6 +354,11 @@
       "September": "Eylül",
       "Year": "Yıl seçin..."
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "DetailsPlaceholder": {
       "PluralForm": "karakter kaldı",
       "SingularForm": "karakter kaldı"

--- a/ddp-workspace/projects/ddp-atcp/src/assets/i18n/zh.json
+++ b/ddp-workspace/projects/ddp-atcp/src/assets/i18n/zh.json
@@ -359,6 +359,11 @@
       "September": "9 月",
       "Year": "选择年份..."
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "DetailsPlaceholder": {
       "PluralForm": "个剩余字符",
       "SingularForm": "个剩余字符"

--- a/ddp-workspace/projects/ddp-brain/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-brain/src/assets/i18n/en.json
@@ -761,6 +761,11 @@
             "November": "November",
             "December": "December"
         },
+        "DateLabel": {
+            "YYYY": "YYYY",
+            "MM": "MM",
+            "DD": "DD"
+        },
         "UserMenu": {
             "DashboardButton": "Dashboard",
             "SignOutButton": "Sign Out"

--- a/ddp-workspace/projects/ddp-esc/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-esc/src/assets/i18n/en.json
@@ -483,6 +483,11 @@
             "November": "November",
             "December": "December"
         },
+        "DateLabel": {
+            "YYYY": "YYYY",
+            "MM": "MM",
+            "DD": "DD"
+        },
         "UserMenu": {
             "DashboardButton": "Dashboard",
             "SignOutButton": "Sign Out"

--- a/ddp-workspace/projects/ddp-mbc/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-mbc/src/assets/i18n/en.json
@@ -573,6 +573,11 @@
             "November": "November",
             "December": "December"
         },
+        "DateLabel": {
+            "YYYY": "YYYY",
+            "MM": "MM",
+            "DD": "DD"
+        },
         "UserMenu": {
             "DashboardButton": "Dashboard",
             "SignOutButton": "Sign Out"

--- a/ddp-workspace/projects/ddp-mbc/src/assets/i18n/es.json
+++ b/ddp-workspace/projects/ddp-mbc/src/assets/i18n/es.json
@@ -573,6 +573,11 @@
             "November": "noviembre",
             "December": "diciembre"
         },
+        "DateLabel": {
+            "YYYY": "AAAA",
+            "MM": "MM",
+            "DD": "DD"
+        },
         "UserMenu": {
             "DashboardButton": "Tablero de Progreso",
             "SignOutButton": "Cerrar Sesión"
@@ -690,5 +695,6 @@
         "Validators": {
             "DateNavyValidationRule": "[es]Entered date is invalid"
         }
+
     }
 }

--- a/ddp-workspace/projects/ddp-mpc/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-mpc/src/assets/i18n/en.json
@@ -505,6 +505,11 @@
             "November": "November",
             "December": "December"
         },
+        "DateLabel": {
+            "YYYY": "YYYY",
+            "MM": "MM",
+            "DD": "DD"
+        },
         "UserMenu": {
             "DashboardButton": "Dashboard",
             "SignOutButton": "Sign Out"

--- a/ddp-workspace/projects/ddp-osteo/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-osteo/src/assets/i18n/en.json
@@ -621,6 +621,11 @@
             "November": "November",
             "December": "December"
         },
+        "DateLabel": {
+            "YYYY": "YYYY",
+            "MM": "MM",
+            "DD": "DD"
+        },
         "UserMenu": {
             "DashboardButton": "Dashboard",
             "SignOutButton": "Sign Out"

--- a/ddp-workspace/projects/ddp-prion/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-prion/src/assets/i18n/en.json
@@ -679,6 +679,11 @@
       "November": "November",
       "December": "December"
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "UserMenu": {
       "DashboardButton": "My Dashboard",
       "SignOutButton": "Sign Out"

--- a/ddp-workspace/projects/ddp-prion/src/assets/i18n/es.json
+++ b/ddp-workspace/projects/ddp-prion/src/assets/i18n/es.json
@@ -679,6 +679,11 @@
       "November": "noviembre",
       "December": "diciembre"
     },
+    "DateLabel": {
+      "YYYY": "AAAA",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "UserMenu": {
       "DashboardButton": "Mi panel",
       "SignOutButton": "Cerrar sesión"

--- a/ddp-workspace/projects/ddp-prion/src/assets/i18n/he.json
+++ b/ddp-workspace/projects/ddp-prion/src/assets/i18n/he.json
@@ -679,6 +679,11 @@
       "November": "נובמבר",
       "December": "דצמבר"
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "UserMenu": {
       "DashboardButton": "לוח המחוונים שלי",
       "SignOutButton": "יציאה"

--- a/ddp-workspace/projects/ddp-prion/src/assets/i18n/zh.json
+++ b/ddp-workspace/projects/ddp-prion/src/assets/i18n/zh.json
@@ -679,6 +679,11 @@
       "November": "十一月",
       "December": "十二月"
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "UserMenu": {
       "DashboardButton": "我的控制面板",
       "SignOutButton": "退出"

--- a/ddp-workspace/projects/ddp-rarex/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-rarex/src/assets/i18n/en.json
@@ -369,6 +369,11 @@
       "November": "November",
       "December": "December"
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "TooltipAlt": "Information",
     "SignInOut": {
       "SignIn": "Log In",

--- a/ddp-workspace/projects/ddp-rgp/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-rgp/src/assets/i18n/en.json
@@ -1208,6 +1208,11 @@
             "November": "November",
             "December": "December"
         },
+        "DateLabel": {
+            "YYYY": "YYYY",
+            "MM": "MM",
+            "DD": "DD"
+        },
         "UserMenu": {
             "DashboardButton": "Dashboard",
             "SignOutButton": "Sign Out"

--- a/ddp-workspace/projects/ddp-rgp/src/assets/i18n/es.json
+++ b/ddp-workspace/projects/ddp-rgp/src/assets/i18n/es.json
@@ -1213,6 +1213,11 @@
             "November": "[es]November",
             "December": "[es]December"
         },
+        "DateLabel": {
+            "YYYY": "AAAA",
+            "MM": "MM",
+            "DD": "DD"
+        },
         "UserMenu": {
             "DashboardButton": "[es]Dashboard",
             "SignOutButton": "[es]Sign Out"

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/datePicker.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/datePicker.component.ts
@@ -15,7 +15,7 @@ import { DateRenderMode } from '../models/activity/dateRenderMode';
               <mat-label *ngIf="label" [innerHTML]="label && fieldIdx === 0 ? label : ('')"></mat-label>
               <input matInput
                      appInputRestriction="integer"
-                     [placeholder]="placeholder && dateFields.length == 1 ? placeholder : 'MM'"
+                     [placeholder]="placeholder && dateFields.length == 1 ? placeholder : ('SDK.DateLabel.MM' | translate)"
                      size="3"
                      maxlength="2"
                      #MM
@@ -31,7 +31,7 @@ import { DateRenderMode } from '../models/activity/dateRenderMode';
               <mat-label *ngIf="label" [innerHTML]="label && fieldIdx === 0 ? label : ('')"></mat-label>
               <input matInput
                      appInputRestriction="integer"
-                     [placeholder]="placeholder && dateFields.length === 1 ? placeholder : 'DD'"
+                     [placeholder]="placeholder && dateFields.length === 1 ? placeholder : ('SDK.DateLabel.DD' | translate)"
                      size="3"
                      maxlength="2"
                      #DD
@@ -47,7 +47,7 @@ import { DateRenderMode } from '../models/activity/dateRenderMode';
               <mat-label *ngIf="label" [innerHTML]="label && fieldIdx === 0 ? label : ('')"></mat-label>
               <input matInput
                      appInputRestriction="integer"
-                     [placeholder]="(placeholder && dateFields.length == 1) ? placeholder : 'YYYY'"
+                     [placeholder]="(placeholder && dateFields.length == 1) ? placeholder : ('SDK.DateLabel.YYYY' | translate)"
                      size="5"
                      maxlength="4"
                      #YYYY

--- a/ddp-workspace/projects/ddp-testboston/src/assets/i18n/ar.json
+++ b/ddp-workspace/projects/ddp-testboston/src/assets/i18n/ar.json
@@ -494,6 +494,11 @@
       "November": "نوفمبر",
       "December": "ديسمبر"
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "UserMenu": {
       "DashboardButton": "لوحة المعلومات",
       "SignOutButton": "تسجيل الخروج"

--- a/ddp-workspace/projects/ddp-testboston/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-testboston/src/assets/i18n/en.json
@@ -494,6 +494,11 @@
       "November": "November",
       "December": "December"
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "UserMenu": {
       "DashboardButton": "Dashboard",
       "SignOutButton": "Sign Out"

--- a/ddp-workspace/projects/ddp-testboston/src/assets/i18n/es.json
+++ b/ddp-workspace/projects/ddp-testboston/src/assets/i18n/es.json
@@ -494,6 +494,11 @@
       "November": "Noviembre",
       "December": "Diciembre"
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "UserMenu": {
       "DashboardButton": "Panel",
       "SignOutButton": "Cerrar sesión"

--- a/ddp-workspace/projects/ddp-testboston/src/assets/i18n/fr.json
+++ b/ddp-workspace/projects/ddp-testboston/src/assets/i18n/fr.json
@@ -494,6 +494,11 @@
       "November": "Novembre",
       "December": "Décembre"
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "UserMenu": {
       "DashboardButton": "Tableau de bord",
       "SignOutButton": "Déconnexion"

--- a/ddp-workspace/projects/ddp-testboston/src/assets/i18n/ht.json
+++ b/ddp-workspace/projects/ddp-testboston/src/assets/i18n/ht.json
@@ -494,6 +494,11 @@
       "November": "Novanm",
       "December": "Desanm"
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "UserMenu": {
       "DashboardButton": "Dach",
       "SignOutButton": "Dekonekte"

--- a/ddp-workspace/projects/ddp-testboston/src/assets/i18n/pt.json
+++ b/ddp-workspace/projects/ddp-testboston/src/assets/i18n/pt.json
@@ -494,6 +494,11 @@
       "November": "Novembro",
       "December": "Dezembro"
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "UserMenu": {
       "DashboardButton": "Painel",
       "SignOutButton": "Encerrar sessão"

--- a/ddp-workspace/projects/ddp-testboston/src/assets/i18n/ru.json
+++ b/ddp-workspace/projects/ddp-testboston/src/assets/i18n/ru.json
@@ -494,6 +494,11 @@
       "November": "Ноябрь",
       "December": "Декабрь"
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "UserMenu": {
       "DashboardButton": "Контрольная панель",
       "SignOutButton": "Выйти из системы"

--- a/ddp-workspace/projects/ddp-testboston/src/assets/i18n/vi.json
+++ b/ddp-workspace/projects/ddp-testboston/src/assets/i18n/vi.json
@@ -494,6 +494,11 @@
       "November": "Tháng Mười Một",
       "December": "Tháng Mười Hai"
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "UserMenu": {
       "DashboardButton": "Bảng điều khiển",
       "SignOutButton": "Thoát ra"

--- a/ddp-workspace/projects/ddp-testboston/src/assets/i18n/zh.json
+++ b/ddp-workspace/projects/ddp-testboston/src/assets/i18n/zh.json
@@ -494,6 +494,11 @@
       "November": "十一月",
       "December": "十二月"
     },
+    "DateLabel": {
+      "YYYY": "YYYY",
+      "MM": "MM",
+      "DD": "DD"
+    },
     "UserMenu": {
       "DashboardButton": "控制面板",
       "SignOutButton": "签退"

--- a/ddp-workspace/projects/sandbox-app/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/sandbox-app/src/assets/i18n/en.json
@@ -73,6 +73,11 @@
             "November": "November",
             "December": "December"
         },
+        "DateLabel": {
+            "YYYY": "YYYY",
+            "MM": "MM",
+            "DD": "DD"
+        },
         "UserMenu": {
             "DashboardButton": "Dashboard",
             "SignOutButton": "Sign Out"

--- a/ddp-workspace/projects/sandbox-app/src/assets/i18n/fr.json
+++ b/ddp-workspace/projects/sandbox-app/src/assets/i18n/fr.json
@@ -73,6 +73,11 @@
           "November": "novembre",
           "December": "décembre"
         },
+        "DateLabel": {
+            "YYYY": "YYYY",
+            "MM": "MM",
+            "DD": "DD"
+        },
         "UserMenu": {
             "DashboardButton": "Dashboard",
             "SignOutButton": "Sign Out"

--- a/ddp-workspace/projects/sandbox-app/src/assets/i18n/ru.json
+++ b/ddp-workspace/projects/sandbox-app/src/assets/i18n/ru.json
@@ -73,6 +73,11 @@
           "November": "November",
           "December": "December"
         },
+        "DateLabel": {
+            "YYYY": "YYYY",
+            "MM": "MM",
+            "DD": "DD"
+        },
         "UserMenu": {
             "DashboardButton": "Dashboard",
             "SignOutButton": "Sign Out"


### PR DESCRIPTION
Internationalize default placeholder (which becomes label if one does not exist) for dates.
The placeholder for year field was YYYY (for **Y**ear)
In Spanish, the word for year is Año , so want to update to make it AAAA for Spanish translation.

To not break existing usage in other apps, I made sure the translation was added to all our language entries.

For the Spanish ones (es.json), I used AAAA . For all the other ones, I just put in YYYY . Don't want to guess and leaves everything working like it did before.

The only code change: https://github.com/broadinstitute/ddp-angular/pull/529/files#diff-0ce549659d92f1426f5c868cd1f1901b9763bfc8092ff0f19a4ce354caf57b1bR50