### PR TITLE
DDP-5770: Bug fix

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/embeddedActivityBlock/embeddedActivityBlock.component.html
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/embeddedActivityBlock/embeddedActivityBlock.component.html
@@ -5,7 +5,7 @@
 <ng-template #sections>
     <div class="instance__divider"></div>
     <div class="instance__header">
-        <span class="instance__label">{{instance.activityTitle}}</span>
+        <span class="instance__label">{{instance.activityName}}</span>
         <button *ngIf="instance.canDelete"
                 mat-icon-button class="instance__close-btn"
                 #delete_button


### PR DESCRIPTION
Use correct field (`activityName`) for the nested embedded activity label as it implemented for modal activity block as well