### PR TITLE
DDP-5925 cmi: bootstrap angio prism login

### DIFF
--- a/config/pepperConfig.js.ctmpl
+++ b/config/pepperConfig.js.ctmpl
@@ -57,11 +57,13 @@ var DDP_ENV = {
         DDP_ENV['auth0Audience'] = "datadonationplatform.auth0.com";
         DDP_ENV['basePepperUrl'] = "https://pepper.datadonationplatform.org";
     {{end}}
+    DDP_ENV['adminLoginLandingUrl'] = location.origin + '/admin-login-landing';
 {{end}}
 
 {{if eq $study_guid "ANGIO"}}
     {{if eq $environment "dev"}}
         DDP_ENV['auth0ClientId'] = "5ps6MnYXmzpuo4OePvfcW0Dfv6cMPNIC";
+        DDP_ENV['adminClientId'] = "A9BfOF2DjkZpxcW3jHjRWOa2lVH0j9Mv";
         DDP_ENV['projectGAToken'] = "UA-108484823-1";
     {{else if eq $environment "test"}}
         DDP_ENV['auth0ClientId'] = "cXRfKyziX5oiMsHjY0oY2mWx6BLZUdl8";
@@ -78,6 +80,7 @@ var DDP_ENV = {
 {{if eq $study_guid "CMI-OSTEO"}}
     {{if eq $environment "dev"}}
         DDP_ENV['auth0ClientId'] = "6TzsngIUkYEo6zLiGyHM0YfmNZOQ8vGz";
+        DDP_ENV['adminClientId'] = "oMRluWDHR2FCgmyqzvJufR3oz884Rwcl";
         DDP_ENV['projectGAToken'] = "UA-108484823-1";
     {{else if eq $environment "test"}}
         DDP_ENV['auth0ClientId'] = "T3fooL5KuYbBgStW09dk3724KFDNAnoM";
@@ -94,6 +97,7 @@ var DDP_ENV = {
 {{if eq $study_guid "cmi-esc"}}
     {{if eq $environment "dev"}}
         DDP_ENV['auth0ClientId'] = "2LLtNaf1eoiwyMiORtgrcOzL0aASMNC3";
+        DDP_ENV['adminClientId'] = "MlllmEYTiSwzWVStyFUGEK8k7O5iGCwc";
         DDP_ENV['projectGAToken'] = "UA-108484823-1";
     {{else if eq $environment "test"}}
         DDP_ENV['auth0ClientId'] = "E4gkqFvzKwM8qdz8y2299g0KlevQeHw5";
@@ -110,6 +114,7 @@ var DDP_ENV = {
 {{if eq $study_guid "cmi-brain"}}
     {{if eq $environment "dev"}}
         DDP_ENV['auth0ClientId'] = "ZYh16tmcKQrMbWEqFOXSw4wQTvAcaQIJ";
+        DDP_ENV['adminClientId'] = "DLJb63JrTVfb7qodr0ngzvyk6e55Vg9j";
         DDP_ENV['projectGAToken'] = "UA-108484823-1";
     {{else if eq $environment "test"}}
         DDP_ENV['auth0ClientId'] = "xLdUBKkOGWpMoXzPUqxpPv2kF3GgHXU0";
@@ -127,6 +132,7 @@ var DDP_ENV = {
 {{if eq $study_guid "cmi-mbc"}}
     {{if eq $environment "dev"}}
         DDP_ENV['auth0ClientId'] = "qTF3AZlx12Dg7AZ3fCcC7b0Nj7JarNcz";
+        DDP_ENV['adminClientId'] = "DwOJcesN6TJlIUkdiH9BTZQcjT4yXa6Z";
         DDP_ENV['projectGAToken'] = "UA-108484823-1";
     {{else if eq $environment "test"}}
         DDP_ENV['auth0ClientId'] = "U27zbNPjGPWhLfvLKLSalY1rTvOZblIH";
@@ -161,6 +167,7 @@ var DDP_ENV = {
 {{if eq $study_guid "cmi-mpc"}}
     {{if eq $environment "dev"}}
         DDP_ENV['auth0ClientId'] = "nf57q2TAUTNMtVj0PVibzwFDDAbsaERN";
+        DDP_ENV['adminClientId'] = "KMpGazJEse5Sg1UgcLSDcqBll9OZ3LIE";
         DDP_ENV['projectGAToken'] = "UA-108484823-1";
     {{else if eq $environment "test"}}
         DDP_ENV['auth0ClientId'] = "Wc3S3um2jJhDhpxMC19LjfucbGTzHFTe";

--- a/ddp-workspace/projects/ddp-angio/src/app/app-routing.module.ts
+++ b/ddp-workspace/projects/ddp-angio/src/app/app-routing.module.ts
@@ -5,7 +5,8 @@ import {
     Auth0CodeCallbackComponent,
     AuthGuard,
     IrbGuard,
-    BrowserGuard
+    BrowserGuard,
+    AdminAuthGuard
 } from 'ddp-sdk';
 
 import {
@@ -22,15 +23,38 @@ import {
     SessionExpiredComponent,
     ActivityLinkComponent,
     LovedOneThankYouComponent,
-    RedirectToAuth0LoginComponent
+    RedirectToAuth0LoginComponent,
+    AdminLoginLandingComponent
 } from 'toolkit';
 
 import { AboutUsComponent } from './components/about-us/about-us.component';
 import { DataReleaseComponent } from './components/data-release/data-release.component';
 import { MoreDetailsComponent } from './components/more-details/more-details.component';
+import { PrismComponent } from './components/prism/prism.component';
 import { WelcomeComponent } from './components/welcome/welcome.component';
 
 const routes: Routes = [
+    {
+        path: 'prism',
+        component: PrismComponent,
+        canActivate: [
+            IrbGuard,
+            AdminAuthGuard
+        ]
+    },
+    {
+        path: 'admin-login-landing',
+        component: AdminLoginLandingComponent,
+        canActivate: [IrbGuard]
+    },
+    {
+        path: 'admin-session-expired',
+        component: SessionExpiredComponent,
+        canActivate: [IrbGuard],
+        data: {
+            isAdmin: true
+        }
+    },
     {
         path: 'about-you',
         component: ActivityPageComponent,

--- a/ddp-workspace/projects/ddp-angio/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-angio/src/app/app.module.ts
@@ -22,6 +22,7 @@ import {
 import { AboutUsComponent } from './components/about-us/about-us.component';
 import { DataReleaseComponent } from './components/data-release/data-release.component';
 import { MoreDetailsComponent } from './components/more-details/more-details.component';
+import { PrismComponent } from './components/prism/prism.component';
 import { WelcomeComponent } from './components/welcome/welcome.component';
 
 const baseElt = document.getElementsByTagName('base');
@@ -48,6 +49,7 @@ tkCfg.lovedOneUrl = 'loved-one';
 tkCfg.consentUrl = 'consent';
 tkCfg.releaseUrl = 'release-survey';
 tkCfg.dashboardUrl = 'dashboard';
+tkCfg.adminDashboardUrl = 'prism';
 tkCfg.activityUrl = 'activity';
 tkCfg.errorUrl = 'error';
 tkCfg.stayInformedUrl = 'stay-informed';
@@ -71,11 +73,13 @@ export const config = new ConfigurationService();
 config.backendUrl = DDP_ENV.basePepperUrl;
 config.auth0Domain = DDP_ENV.auth0Domain;
 config.auth0ClientId = DDP_ENV.auth0ClientId;
+config.adminClientId = DDP_ENV.adminClientId;
 config.studyGuid = DDP_ENV.studyGuid;
 config.logLevel = DDP_ENV.logLevel;
 config.baseUrl = location.origin + base;
 config.auth0SilentRenewUrl = DDP_ENV.auth0SilentRenewUrl;
 config.loginLandingUrl = DDP_ENV.loginLandingUrl;
+config.adminLoginLandingUrl = DDP_ENV.adminLoginLandingUrl;
 config.auth0CodeRedirect = location.origin + base + 'auth';
 config.localRegistrationUrl = config.backendUrl + '/pepper/v1/register';
 config.doLocalRegistration = DDP_ENV.doLocalRegistration;
@@ -115,6 +119,7 @@ export function translateFactory(translate: TranslateService, injector: Injector
     AboutUsComponent,
     DataReleaseComponent,
     MoreDetailsComponent,
+    PrismComponent,
     WelcomeComponent
   ],
   providers: [

--- a/ddp-workspace/projects/ddp-angio/src/app/components/prism/prism.component.ts
+++ b/ddp-workspace/projects/ddp-angio/src/app/components/prism/prism.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'app-prism',
+    template: '<p>angio prism</p>',
+    styles: []
+})
+export class PrismComponent {
+}

--- a/ddp-workspace/projects/toolkit/src/lib/components/session-expired/session-expired-redesigned.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/session-expired/session-expired-redesigned.component.ts
@@ -24,25 +24,15 @@ import { ActivatedRoute } from '@angular/router';
         </main>`
 })
 export class SessionExpiredRedesignedComponent extends SessionExpiredComponent implements OnInit {
-    private isAdminSessionExpired: boolean;
 
     constructor(
-        private activatedRoute: ActivatedRoute,
+        private _activatedRoute: ActivatedRoute,
         private headerConfig: HeaderConfigurationService,
         private _auth0: Auth0AdapterService) {
-        super(_auth0);
+        super(_activatedRoute, _auth0);
     }
 
     public ngOnInit(): void {
         this.headerConfig.setupDefaultHeader();
-        this.isAdminSessionExpired = !!this.activatedRoute.snapshot.data.isAdmin;
-    }
-
-    public signin(): void {
-        if (this.isAdminSessionExpired) {
-            this._auth0.adminLogin();
-        } else {
-            super.signin();
-        }
     }
 }

--- a/ddp-workspace/projects/toolkit/src/lib/components/session-expired/session-expired.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/session-expired/session-expired.component.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { Auth0AdapterService } from 'ddp-sdk';
 
 @Component({
@@ -41,10 +42,22 @@ import { Auth0AdapterService } from 'ddp-sdk';
             </article>
         </div>`
 })
-export class SessionExpiredComponent {
-    constructor(private auth0: Auth0AdapterService) { }
+export class SessionExpiredComponent implements OnInit {
+    private isAdminSessionExpired: boolean;
+
+    constructor(
+        private activatedRoute: ActivatedRoute,
+        private auth0: Auth0AdapterService) { }
+
+    public ngOnInit(): void {
+        this.isAdminSessionExpired = !!this.activatedRoute.snapshot.data.isAdmin;
+    }
 
     public signin(): void {
-        this.auth0.login();
+        if (this.isAdminSessionExpired) {
+            this.auth0.adminLogin();
+        } else {
+            this.auth0.login();
+        }
     }
 }


### PR DESCRIPTION
This is the minimum to setup the prism routes for Angio and get admin logins working. See the necessary Auth0 changes here: https://github.com/broadinstitute/ddp-study-server/pull/735.