### PR TITLE
DDP-6123: Handle failed user deletion in rare-x

### DIFF
--- a/ddp-workspace/projects/ddp-rarex/src/app/components/participants-list/participants-list.component.html
+++ b/ddp-workspace/projects/ddp-rarex/src/app/components/participants-list/participants-list.component.html
@@ -19,6 +19,10 @@
     *ngTemplateOutlet="participants.length ? participantsList : noParticipants"
   ></ng-container>
 
+  <div *ngIf="errorMessage" class="ErrorMessage">
+    <span>{{ errorMessage }}</span>
+  </div>
+
   <div class="controls">
     <button
       class="button button_primary button_medium"

--- a/ddp-workspace/projects/ddp-rarex/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-rarex/src/assets/i18n/en.json
@@ -314,7 +314,8 @@
   "ParticipantsList": {
     "Title": "Participant Dashboard",
     "NewParticipant": "New Participant",
-    "NoParticipants": "You don't have any participants at this moment. You can add one by clicking the button below."
+    "NoParticipants": "You don't have any participants at this moment. You can add one by clicking the button below.",
+    "DeleteError": "This participant has already consented and can’t be deleted here. If you wish to withdraw consent, please contact Rare-X study personnel directly"
   },
   "ParticipantDeletionDialog": {
     "Text": "Are you sure you want to delete this participant? All data entered for this participant will be cleared."

--- a/ddp-workspace/projects/ddp-rarex/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-rarex/src/assets/i18n/en.json
@@ -315,7 +315,7 @@
     "Title": "Participant Dashboard",
     "NewParticipant": "New Participant",
     "NoParticipants": "You don't have any participants at this moment. You can add one by clicking the button below.",
-    "DeleteError": "This participant has already consented and can’t be deleted here. If you wish to withdraw consent, please contact Rare-X study personnel directly"
+    "DeleteError": "This participant has already consented and can’t be deleted here. If you wish to withdraw consent, please contact Rare-X study personnel directly."
   },
   "ParticipantDeletionDialog": {
     "Text": "Are you sure you want to delete this participant? All data entered for this participant will be cleared."

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/userManagementServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/userManagementServiceAgent.service.ts
@@ -7,6 +7,6 @@ import { SessionServiceAgent } from './sessionServiceAgent.service';
 @Injectable()
 export class UserManagementServiceAgent extends SessionServiceAgent<void> {
   public deleteUser(userGuid: string): Observable<void> {
-    return this.deleteObservable(`/user/${userGuid}`).pipe(take(1));
+    return this.deleteObservable(`/user/${userGuid}`, null, true).pipe(take(1));
   }
 }


### PR DESCRIPTION
User Deletion errors were not being handled, probably because they had not happened.
With changes introduced in rare-x study configuration, users will be moving to ENROLLED status when consent is completed.
And when they are ENROLLED, back-end will send back 422 errors. Deletion is forbidden.
This PR tries to handle this situation.

![Screen Shot 2021-05-12 at 10 19 48 PM](https://user-images.githubusercontent.com/29984380/118068371-3f9e9a80-b370-11eb-85f4-6ed85d9b47e9.png)
