### PR TITLE
DDP-6103- Fix excess page blinks when moving between Pepper activities

### DIFF
--- a/ddp-workspace/projects/toolkit/src/lib/components/activity/activity-page.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/activity/activity-page.component.ts
@@ -19,11 +19,15 @@ import { map, mergeMap, share, takeUntil } from 'rxjs/operators';
         <toolkit-header [showButtons]="false"
                         [stickySubtitle]="stickySubtitle">
         </toolkit-header>
-        <ddp-activity [studyGuid]="studyGuid"
-                      [activityGuid]="(activityInstance$ | async)?.instanceGuid"
-                      (submit)="raiseSubmit($event)"
-                      (stickySubtitle)="showStickySubtitle($event)">
-        </ddp-activity>`
+
+        <ng-container *ngIf="(activityInstance$ | async)?.instanceGuid as activityInstanceGuid">
+            <ddp-activity [studyGuid]="studyGuid"
+                          [activityGuid]="activityInstanceGuid"
+                          (submit)="raiseSubmit($event)"
+                          (stickySubtitle)="showStickySubtitle($event)">
+            </ddp-activity>
+        </ng-container>
+    `
 })
 export class ActivityPageComponent implements OnInit, OnDestroy {
     @Output() submit: EventEmitter<void> = new EventEmitter();

--- a/ddp-workspace/projects/toolkit/src/lib/components/activity/activity.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/activity/activity.component.ts
@@ -10,7 +10,8 @@ import { ActivityResponse } from 'ddp-sdk';
         <toolkit-header [showButtons]="false"
                         [stickySubtitle]="stickySubtitle">
         </toolkit-header>
-        <ddp-activity [studyGuid]="studyGuid"
+        <ddp-activity *ngIf="id"
+                      [studyGuid]="studyGuid"
                       [activityGuid]="id"
                       (submit)="navigate($event)"
                       (stickySubtitle)="showStickySubtitle($event)">

--- a/ddp-workspace/projects/toolkit/src/lib/components/activity/activity.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/activity/activity.component.ts
@@ -10,15 +10,15 @@ import { ActivityResponse } from 'ddp-sdk';
         <toolkit-header [showButtons]="false"
                         [stickySubtitle]="stickySubtitle">
         </toolkit-header>
-        <ddp-activity *ngIf="id"
+        <ddp-activity *ngIf="instanceGuid"
                       [studyGuid]="studyGuid"
-                      [activityGuid]="id"
+                      [activityGuid]="instanceGuid"
                       (submit)="navigate($event)"
                       (stickySubtitle)="showStickySubtitle($event)">
         </ddp-activity>`
 })
 export class ActivityComponent implements OnInit {
-    public id: string;
+    public instanceGuid: string;
     public studyGuid: string;
     public stickySubtitle: string;
     public activityCode: string;
@@ -29,8 +29,8 @@ export class ActivityComponent implements OnInit {
         @Inject('toolkit.toolkitConfig') private toolkitConfiguration: ToolkitConfigurationService) { }
 
     public ngOnInit(): void {
-        this.activatedRoute.params.subscribe(x => {
-            this.id = x.id;
+        this.activatedRoute.params.subscribe(params => {
+            this.instanceGuid = params.id;
         });
         this.studyGuid = this.toolkitConfiguration.studyGuid;
     }

--- a/ddp-workspace/projects/toolkit/src/lib/components/activity/workflow-start-activity.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/activity/workflow-start-activity.component.ts
@@ -19,7 +19,7 @@ import { filter, map, mergeMap, take } from 'rxjs/operators';
       <toolkit-header [showButtons]="false"
                       [stickySubtitle]="stickySubtitle">
       </toolkit-header>
-      <ddp-activity *ngIf="show"
+      <ddp-activity *ngIf="show && instanceGuid"
                     [studyGuid]="studyGuid"
                     [activityGuid]="instanceGuid"
                     (submit)="navigate($event)"


### PR DESCRIPTION
The fixes suggest displaying `<ddp-activity>` component when we get `activityInstanceGuid` only
   as to avoid reload/partially load of data for the component.

Before fixes we had partially loaded current/previous activity that led to page blick (see screenshots below):
- after `count-me in` registration
![issue1](https://user-images.githubusercontent.com/7396837/118518063-709c1800-b740-11eb-99e1-3e9be2ca4a81.png)

- moving from "**About-you**" to "**Consent**"
![issue2](https://user-images.githubusercontent.com/7396837/118518067-7134ae80-b740-11eb-91ef-7a0364a74a4e.png)
