### PR TITLE
DDP-6103 Hide submit buttons for not loaded activities

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-redesigned.component.html
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-redesigned.component.html
@@ -90,7 +90,7 @@
                     <span class="last-updated">{{model.lastUpdatedText}} </span>
                 </ng-container>
 
-                <div class="activity-buttons"
+                <div class="activity-buttons" *ngIf="activityGuid"
                      [ngClass]="{'activity-buttons_mobile': (!isStepped || isLastStep) && isAgree() && isLoaded && !isReadonly()}">
                     <ng-container *ngIf="isLoaded && isStepped; then navigationButtons"></ng-container>
                     <ng-container *ngIf="(!isStepped || isLastStep) && isLoaded; then lastStepButtons"></ng-container>


### PR DESCRIPTION
  mostly for osteo and brain
  for instance: moving from release activity -> Medical Questionnaire (About You)
  or going from homepage to the count-me-in/prequalifier page