### PR TITLE
DDP-5815 increase the height for native select in testboston

### DIFF
--- a/ddp-workspace/projects/ddp-testboston/src/style/activity.scss
+++ b/ddp-workspace/projects/ddp-testboston/src/style/activity.scss
@@ -457,7 +457,7 @@ select {
     border: none;
     border-bottom: 1px solid rgba(0, 0, 0, .42);
     border-radius: 0;
-    height: 2.65rem;
+    height: 3.1rem;
     transition: all .3s;
     font-family: inherit;
     cursor: pointer;


### PR DESCRIPTION
increase the height for native select in testboston since the solution with material styles adds some top padding which consumes part of the height