### PR TITLE
SDK: Participant status service

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/ddp.module.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/ddp.module.ts
@@ -77,6 +77,7 @@ import { SubjectInvitationServiceAgent } from './services/serviceAgents/subjectI
 import { UserManagementServiceAgent } from './services/serviceAgents/userManagementServiceAgent.service';
 import { UserInvitationServiceAgent } from './services/serviceAgents/userInvitationServiceAgent.service';
 import { AnnouncementsServiceAgent } from './services/serviceAgents/announcementsServiceAgent.service';
+import { UserStatusServiceAgent } from './services/serviceAgents/userStatusServiceAgent.service';
 
 import { WindowRef } from './services/windowRef';
 
@@ -305,6 +306,7 @@ export function createTranslateLoader(http: HttpClient): TranslateHttpLoader {
         IrbPasswordService,
         ResendEmailServiceAgent,
         AnnouncementsServiceAgent,
+        UserStatusServiceAgent,
         UserManagementServiceAgent,
         UserInvitationServiceAgent,
         BrowserContentService,

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/userStatusResponse.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/userStatusResponse.ts
@@ -1,0 +1,25 @@
+export interface UserStatusResponse {
+  medicalRecord: {
+    status: string;
+    requestedAt?: number;
+    receivedBackAt?: number;
+  };
+  tissueRecord: {
+    status: string;
+    requestedAt?: number;
+    receivedBackAt?: number;
+  };
+  kits: Array<{
+    kitType: string;
+    status: string;
+    sentAt: number;
+    receivedBackAt: number;
+    trackingId: string;
+    shipper: string;
+  }>;
+  workflows: Array<{
+    workflow: string;
+    status: string;
+    date: string;
+  }>;
+}

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/userStatusServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/userStatusServiceAgent.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { take } from 'rxjs/operators';
+
+import { UserStatusResponse } from '../../models/userStatusResponse';
+import { UserServiceAgent } from './userServiceAgent.service';
+
+@Injectable()
+export class UserStatusServiceAgent extends UserServiceAgent<any> {
+  public getStatus(): Observable<UserStatusResponse> {
+    return this.getObservable(
+      `/studies/${this.configuration.studyGuid}/status`,
+    ).pipe(take(1));
+  }
+}

--- a/ddp-workspace/projects/ddp-sdk/src/public-api.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/public-api.ts
@@ -52,6 +52,7 @@ export * from './lib/models/activity/questionType';
 export * from './lib/models/statistic';
 export * from './lib/models/searchParticipant';
 export * from './lib/models/enrollmentStatusType';
+export * from './lib/models/userStatusResponse';
 
 export * from './lib/services/logging.service';
 export * from './lib/services/serviceAgents/serviceAgent.service';
@@ -83,6 +84,7 @@ export * from './lib/services/internationalization/languageService.service';
 export * from './lib/services/serviceAgents/invitationServiceAgent.service';
 export * from './lib/services/serviceAgents/subjectInvitationServiceAgent.service';
 export * from './lib/services/serviceAgents/userManagementServiceAgent.service';
+export * from './lib/services/serviceAgents/userStatusServiceAgent.service';
 export * from './lib/services/serviceAgents/userInvitationServiceAgent.service';
 export * from './lib/services/submitAnnouncement.service';
 export * from './lib/services/serviceAgents/submissionManager.service';


### PR DESCRIPTION
This PR introduces new `UserStatusService` which can be used to fetch participant's status.

This status includes:
- Medical records
- Tissue records
- Kits information
- Workflows information