### PR TITLE
DDP-6294 rgp: no validate when next section in read-only mode

### DIFF
--- a/ddp-workspace/projects/ddp-rgp/src/app/components/activity/activity.component.ts
+++ b/ddp-workspace/projects/ddp-rgp/src/app/components/activity/activity.component.ts
@@ -18,4 +18,30 @@ export class ActivityComponent extends ActivityRedesignedComponent {
   get isEnrollmentActivity(): boolean {
     return this.model.activityCode === ActivityCode.Enrollment;
   }
+
+  public incrementStep(scroll: boolean = true): void {
+    const nextIndex = this.nextAvailableSectionIndex();
+    if (nextIndex !== -1) {
+      if (scroll) {
+        this.scrollToTop();
+      }
+
+      let shouldProceed = true;
+      if (!this.model.readonly) {
+        this.validationRequested = true;
+        this.sendSectionAnalytics();
+        this.currentSection.validate();
+        shouldProceed = this.currentSection.valid;
+      }
+
+      if (shouldProceed) {
+        this.resetValidationState();
+        this.currentSectionIndex = nextIndex;
+        this.visitedSectionIndexes[nextIndex] = true;
+        if (!this.model.readonly) {
+          this.saveLastVisitedSectionIndex(nextIndex);
+        }
+      }
+    }
+  }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity.component.ts
@@ -473,7 +473,7 @@ export class ActivityComponent extends BaseActivityComponent implements OnInit, 
         }
     }
 
-    private saveLastVisitedSectionIndex(sectionIndex: number): void {
+    protected saveLastVisitedSectionIndex(sectionIndex: number): void {
         if (this.shouldSaveLastStep && sectionIndex > this.model.sectionIndex) {
             this.serviceAgent.saveLastVisitedActivitySection(this.studyGuid, this.activityGuid, this.currentSectionIndex)
               .pipe(take(1))


### PR DESCRIPTION
There is an edge-case in RGP, where an older migrated user (perhaps from 2017) will not be able to navigate to next sections when survey is in read-only mode. Given how RGP is setup, there's a bit of mismatch of survey questions between Pepper and Gen2, e.g. there are required questions that older migration users might not have answered.

Currently, we run validations when user clicks "next" button, even in read-only mode. Therefore, we get into situation where an older migration user might not be able to view other sections in their survey since they might be missing answers to required questions.

This PR overrides the behavior so that RGP allows navigating without running validations in read-only mode. CC-ing Charlotte and Aleksey since they had worked on RGP frontend.

See DDP-6294 for more details.