### PR TITLE
DDP-6350 rgp: remove unused subject panels

### DIFF
--- a/ddp-workspace/projects/ddp-rgp/src/app/components/activity/activity.component.html
+++ b/ddp-workspace/projects/ddp-rgp/src/app/components/activity/activity.component.html
@@ -12,6 +12,7 @@
 
   <ng-container *ngIf="isLoaded && model">
     <section class="section">
+      <!--
       <ddp-subject-panel></ddp-subject-panel>
 
       <ddp-admin-action-panel
@@ -19,6 +20,7 @@
         (requestActivityEdit)="updateIsAdminEditing($event)"
       >
       </ddp-admin-action-panel>
+      -->
     </section>
 
     <section


### PR DESCRIPTION
I did a `git bisect` and tracked it down to a commit that removed something called the `InvitationPipe`. Angular app is having issue because of this missing InvitationPipe. This pipe is used in the subject panels. We don't need these subject panels in RGP -- they are only used for something called the Prism Interface which we don't have in RGP (yet). Let's remove these panels.

Note: removing the `<section>` seems to cause some wonky display issues, so I kept the empty section in there.