### PR TITLE
FIX: Return back the missed invitationPipe provider

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/ddp.module.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/ddp.module.ts
@@ -322,6 +322,7 @@ export function createTranslateLoader(http: HttpClient): TranslateHttpLoader {
         StatisticsServiceAgent,
         ModalDialogService,
         FileUploadService,
+        InvitationPipe,
         FileAnswerMapperService,
         ParticipantsSearchServiceAgent,
         {


### PR DESCRIPTION
Returned back the missed invitationPipe provider that was removed by mistake. 