### PR TITLE
DDP-6419 fix handling of invalid numeric answer

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.ts
@@ -53,7 +53,11 @@ export class ActivityNumericAnswer implements OnInit, OnChanges {
             this.numericField.setValue('');
             this.emitAnswer(null);
         } else if (this.numericField.invalid) {
-            this.emitAnswer(null);
+            // If it's invalid, it most likely mean it's out-of-range, which
+            // also implies we have an INT_RANGE validation rule. We should
+            // store and emit the answer (rather than null) so we run validation
+            // rule on it.
+            this.emitAnswer(answer);
         } else {
             this.numericField.setValue(answer);
             this.emitAnswer(answer);


### PR DESCRIPTION
See DDP-6419 for a bit more details. The old code emits a `null` when the input is invalid (out-of-range). This causes a PATCH API request with `null` as the answer value, and causes the `block.answer` to be `null` which means the validation rule doesn't have anything to validate against.

You can reproduce the bug in `basil`. Configs for `basil` are here, along with the RareX config changes that surfaced the bug: https://github.com/broadinstitute/ddp-study-server/pull/818.

![Screen Shot 2021-06-17 at 11 50 45 AM](https://user-images.githubusercontent.com/5713833/122440067-3655ae80-cf6a-11eb-815d-4b97e40379bd.png)
