### PR TITLE
DDP-6487 refactor handling of visibility updates

### DIFF
--- a/ddp-workspace/projects/ddp-atcp/src/app/components/activityForm/app-atcp-activity-base.component.ts
+++ b/ddp-workspace/projects/ddp-atcp/src/app/components/activityForm/app-atcp-activity-base.component.ts
@@ -79,6 +79,7 @@ import { combineLatest, merge } from 'rxjs';
                     [validationRequested]="validationRequested"
                     [studyGuid]="studyGuid"
                     [activityGuid]="activityGuid"
+                    (visibilityChanged)="updateVisibility($event)"
                     (embeddedComponentsValidationStatus)="updateEmbeddedComponentValidationStatus(0, $event)"
                     (componentBusy)="embeddedComponentBusy$[0].next($event)">
                   </ddp-activity-section>
@@ -116,6 +117,7 @@ import { combineLatest, merge } from 'rxjs';
                     [validationRequested]="validationRequested"
                     [studyGuid]="studyGuid"
                     [activityGuid]="activityGuid"
+                    (visibilityChanged)="updateVisibility($event)"
                     (embeddedComponentsValidationStatus)="updateEmbeddedComponentValidationStatus(1, $event)"
                     (componentBusy)="embeddedComponentBusy$[1].next($event)">
                   </ddp-activity-section>
@@ -131,6 +133,7 @@ import { combineLatest, merge } from 'rxjs';
                       [validationRequested]="validationRequested"
                       [studyGuid]="studyGuid"
                       [activityGuid]="activityGuid"
+                      (visibilityChanged)="updateVisibility($event)"
                       (embeddedComponentsValidationStatus)="updateEmbeddedComponentValidationStatus(2, $event)"
                       (componentBusy)="embeddedComponentBusy$[2].next($event)">
                     </ddp-activity-section>

--- a/ddp-workspace/projects/ddp-atcp/src/app/components/activityForm/app-atcp-activity.component.ts
+++ b/ddp-workspace/projects/ddp-atcp/src/app/components/activityForm/app-atcp-activity.component.ts
@@ -81,6 +81,7 @@ import * as Routes from '../../router-resources';
                             [validationRequested]="validationRequested"
                             [studyGuid]="studyGuid"
                             [activityGuid]="activityGuid"
+                            (visibilityChanged)="updateVisibility($event)"
                             (embeddedComponentsValidationStatus)="updateEmbeddedComponentValidationStatus(0, $event)"
                             (componentBusy)="embeddedComponentBusy$[0].next($event)">
                     </ddp-activity-section>
@@ -135,6 +136,7 @@ import * as Routes from '../../router-resources';
                             [validationRequested]="validationRequested"
                             [studyGuid]="studyGuid"
                             [activityGuid]="activityGuid"
+                            (visibilityChanged)="updateVisibility($event)"
                             (embeddedComponentsValidationStatus)="updateEmbeddedComponentValidationStatus(1, $event)"
                             (componentBusy)="embeddedComponentBusy$[1].next($event)">
                     </ddp-activity-section>
@@ -147,6 +149,7 @@ import * as Routes from '../../router-resources';
                                 [validationRequested]="validationRequested"
                                 [studyGuid]="studyGuid"
                                 [activityGuid]="activityGuid"
+                                (visibilityChanged)="updateVisibility($event)"
                                 (embeddedComponentsValidationStatus)="updateEmbeddedComponentValidationStatus(2, $event)"
                                 (componentBusy)="embeddedComponentBusy$[2].next($event)">
                         </ddp-activity-section>

--- a/ddp-workspace/projects/ddp-rarex/src/app/components/activity/activity.component.html
+++ b/ddp-workspace/projects/ddp-rarex/src/app/components/activity/activity.component.html
@@ -27,6 +27,7 @@
             [validationRequested]="validationRequested"
             [studyGuid]="studyGuid"
             [activityGuid]="activityGuid"
+            (visibilityChanged)="updateVisibility($event)"
             (embeddedComponentsValidationStatus)="
               updateEmbeddedComponentValidationStatus(0, $event)
             "
@@ -71,6 +72,7 @@
             [validationRequested]="validationRequested"
             [studyGuid]="studyGuid"
             [activityGuid]="activityGuid"
+            (visibilityChanged)="updateVisibility($event)"
             (embeddedComponentsValidationStatus)="
               updateEmbeddedComponentValidationStatus(1, $event)
             "
@@ -89,6 +91,7 @@
               [validationRequested]="validationRequested"
               [studyGuid]="studyGuid"
               [activityGuid]="activityGuid"
+              (visibilityChanged)="updateVisibility($event)"
               (embeddedComponentsValidationStatus)="
                 updateEmbeddedComponentValidationStatus(2, $event)
               "

--- a/ddp-workspace/projects/ddp-rgp/src/app/components/activity/activity.component.html
+++ b/ddp-workspace/projects/ddp-rgp/src/app/components/activity/activity.component.html
@@ -53,6 +53,7 @@
           [validationRequested]="validationRequested"
           [studyGuid]="studyGuid"
           [activityGuid]="activityGuid"
+          (visibilityChanged)="updateVisibility($event)"
           (embeddedComponentsValidationStatus)="
             updateEmbeddedComponentValidationStatus(0, $event)
           "
@@ -97,6 +98,7 @@
         [validationRequested]="validationRequested"
         [studyGuid]="studyGuid"
         [activityGuid]="activityGuid"
+        (visibilityChanged)="updateVisibility($event)"
         (embeddedComponentsValidationStatus)="
           updateEmbeddedComponentValidationStatus(1, $event)
         "
@@ -192,6 +194,7 @@
             [validationRequested]="validationRequested"
             [studyGuid]="studyGuid"
             [activityGuid]="activityGuid"
+            (visibilityChanged)="updateVisibility($event)"
             (embeddedComponentsValidationStatus)="
               updateEmbeddedComponentValidationStatus(2, $event)
             "

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-redesigned.component.html
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-redesigned.component.html
@@ -45,6 +45,7 @@
                     [validationRequested]="validationRequested"
                     [studyGuid]="studyGuid"
                     [activityGuid]="activityGuid"
+                    (visibilityChanged)="updateVisibility($event)"
                     (embeddedComponentsValidationStatus)="updateEmbeddedComponentValidationStatus(0, $event)"
                     (componentBusy)="embeddedComponentBusy$[0].next($event)">
                 </ddp-activity-section>
@@ -62,6 +63,7 @@
                     [validationRequested]="validationRequested"
                     [studyGuid]="studyGuid"
                     [activityGuid]="activityGuid"
+                    (visibilityChanged)="updateVisibility($event)"
                     (embeddedComponentsValidationStatus)="updateEmbeddedComponentValidationStatus(1, $event)"
                     (componentBusy)="embeddedComponentBusy$[1].next($event)">
                 </ddp-activity-section>
@@ -74,6 +76,7 @@
                         [validationRequested]="validationRequested"
                         [studyGuid]="studyGuid"
                         [activityGuid]="activityGuid"
+                        (visibilityChanged)="updateVisibility($event)"
                         (embeddedComponentsValidationStatus)="updateEmbeddedComponentValidationStatus(2, $event)"
                         (componentBusy)="embeddedComponentBusy$[2].next($event)">
                     </ddp-activity-section>

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity.component.ts
@@ -78,6 +78,7 @@ import { ParticipantsSearchServiceAgent } from '../../services/serviceAgents/par
                                     [validationRequested]="validationRequested"
                                     [studyGuid]="studyGuid"
                                     [activityGuid]="activityGuid"
+                                    (visibilityChanged)="updateVisibility($event)"
                                     (embeddedComponentsValidationStatus)="updateEmbeddedComponentValidationStatus(0, $event)"
                                     (componentBusy)="embeddedComponentBusy$[0].next($event)">
                                 </ddp-activity-section>
@@ -115,6 +116,7 @@ import { ParticipantsSearchServiceAgent } from '../../services/serviceAgents/par
                                     [validationRequested]="validationRequested"
                                     [studyGuid]="studyGuid"
                                     [activityGuid]="activityGuid"
+                                    (visibilityChanged)="updateVisibility($event)"
                                     (embeddedComponentsValidationStatus)="updateEmbeddedComponentValidationStatus(1, $event)"
                                     (componentBusy)="embeddedComponentBusy$[1].next($event)">
                                 </ddp-activity-section>
@@ -130,6 +132,7 @@ import { ParticipantsSearchServiceAgent } from '../../services/serviceAgents/par
                                         [validationRequested]="validationRequested"
                                         [studyGuid]="studyGuid"
                                         [activityGuid]="activityGuid"
+                                        (visibilityChanged)="updateVisibility($event)"
                                         (embeddedComponentsValidationStatus)="updateEmbeddedComponentValidationStatus(2, $event)"
                                         (componentBusy)="embeddedComponentBusy$[2].next($event)">
                                     </ddp-activity-section>
@@ -250,7 +253,7 @@ export class ActivityComponent extends BaseActivityComponent implements OnInit, 
         // all PATCH responses routed to here
         const resSub = this.submissionManager.answerSubmissionResponse$.subscribe(
             (response) => {
-                this.updateVisibility((response as PatchAnswerResponse).blockVisibility);
+                this.updateVisibility();
                 this.updateServerValidationMessages(response);
                 this.communicationErrorOccurred = false;
             },

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activitySection.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activitySection.component.ts
@@ -114,6 +114,7 @@ export class ActivitySectionComponent implements OnInit, OnDestroy {
     @Input() public activityGuid: string;
     @Output() embeddedComponentsValidationStatus: EventEmitter<boolean> = new EventEmitter();
     @Output() componentBusy: EventEmitter<boolean> = new EventEmitter(true);
+    @Output() visibilityChanged: EventEmitter<boolean> = new EventEmitter();
     private subscription: Subscription;
     private embeddedValidationStatus: boolean[] = new Array(3).fill(true);
 
@@ -140,11 +141,17 @@ export class ActivitySectionComponent implements OnInit, OnDestroy {
                     if (block.shown !== element.shown) {
                         block.shown = element.shown;
                         blockVisibilityChanged = true;
+                        if (block.blockType === BlockType.Activity && !block.shown) {
+                            this.updateEmbeddedComponentValidationStatus(2, true);
+                        }
                     }
                 }
             });
         });
-        blockVisibilityChanged && this.cdr.detectChanges();
+        if (blockVisibilityChanged) {
+            this.visibilityChanged.next(true);
+            this.cdr.detectChanges();
+        }
     }
 
     public updateEmbeddedComponentValidationStatus(componentIndex: number, isValid: boolean): void {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/baseActivity.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/baseActivity.component.ts
@@ -27,7 +27,6 @@ import { WorkflowServiceAgent } from '../../services/serviceAgents/workflowServi
 import { ActivityServiceAgent } from '../../services/serviceAgents/activityServiceAgent.service';
 import { ActivityResponse } from '../../models/activity/activityResponse';
 import { ActivityForm } from '../../models/activity/activityForm';
-import { BlockVisibility } from '../../models/activity/blockVisibility';
 import { CompositeDisposable } from '../../compositeDisposable';
 import { SubmissionManager } from '../../services/serviceAgents/submissionManager.service';
 import { ConfigurationService } from '../../services/configuration.service';
@@ -155,17 +154,7 @@ export abstract class BaseActivityComponent implements OnChanges, OnDestroy {
         this.activityGuidObservable.next(this.activityGuidObservable.value);
     }
 
-    public updateVisibility(visibility: BlockVisibility[]): void {
-        visibility.forEach(element => {
-            this.model.sections.forEach(section => {
-                section.blocks.forEach(block => {
-                    if (block.id === element.blockGuid) {
-                        block.shown = element.shown;
-                    }
-                });
-            });
-        });
-        this.model.recalculateSectionsVisibility();
+    public updateVisibility(_changed?: boolean): void {
         this.sectionsVisibilityChanged.emit(this.model.visibleSectionsCount());
     }
 

--- a/ddp-workspace/projects/toolkit/src/lib/components/activity/modal-activity.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/activity/modal-activity.component.ts
@@ -38,6 +38,7 @@ import { ModalActivityData } from '../../models/modalActivityData';
             [validationRequested]="validationRequested"
             [studyGuid]="studyGuid"
             [activityGuid]="activityGuid"
+            (visibilityChanged)="updateVisibility($event)"
             (embeddedComponentsValidationStatus)="updateEmbeddedComponentValidationStatus(1, $event)"
             (componentBusy)="embeddedComponentBusy$[1].next($event)">
           </ddp-activity-section>


### PR DESCRIPTION
See DDP-6487. Not too sure if this is right, but here's my guess of what's causing the issue:

* When embedded activity component is visible and you click submit, it fails validation.
* `embeddedComponentsValidStatusChanged` observable resolves to `false` (means invalid).
* `isAllFormContentValid` resolves to `false` and we're prevented from submitting.
* You answer question and hide the embedded activity component via block visibility response from server.
* `BaseActivityComponent.updateVisibility()` runs and sets the embedded activity block to hidden, and causes Angular to offload the block from rendering.
* Which means `ActivitySectionComponent` has no chance of updating `embeddedComponentsValidationStatus`.
* Which means `isAllFormContentValid` will never be `true` and we can't ever submit the form...