### PR TITLE
SDK: Remove redundant operator

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity.component.ts
@@ -501,7 +501,6 @@ export class ActivityComponent extends BaseActivityComponent implements OnInit, 
         this.getIsLoaded$()
             .pipe(
                 filter(Boolean),
-                take(1),
                 tap(() => {
                     if (this.model.statusCode !== ActivityStatusCodes.COMPLETE) {
                         this.shouldSaveLastStep = this.config.usesVerticalStepper.includes(this.model.activityCode);


### PR DESCRIPTION
Removed `take(1)` operator so that on each new activity stepper state is reinitialized.