### PR TITLE
DDP-6457 pancan: update physician component labels

### DIFF
--- a/ddp-workspace/projects/ddp-pancan/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-pancan/src/assets/i18n/en.json
@@ -524,14 +524,14 @@
         },
         "Institutions": {
             "Fields": {
-                "Name": "Physician Name",
+                "Name": "Physician Name (if applicable)",
                 "Institution": "Institution",
-                "InstitutionAny": "Institution (if any)",
+                "InstitutionAny": "Hospital/Institution (if any)",
                 "City": "City",
                 "State": "State"
             },
             "Form" : {
-                "OtherPhysician": "Other physician",
+                "OtherPhysician": "Other hospital/institution",
                 "OtherInstitution": "Other institution"
             },
             "PhysicianValidation": "Please fill out all required fields"

--- a/ddp-workspace/projects/ddp-pancan/src/assets/i18n/es.json
+++ b/ddp-workspace/projects/ddp-pancan/src/assets/i18n/es.json
@@ -524,14 +524,14 @@
         },
         "Institutions": {
             "Fields": {
-                "Name": "Nombre del doctor",
+                "Name": "[ES]Nombre del doctor",
                 "Institution": "Institución",
-                "InstitutionAny": "Institución (si aplica)",
+                "InstitutionAny": "[ES]Institución (si aplica)",
                 "City": "Ciudad",
                 "State": "Estado"
             },
             "Form" : {
-                "OtherPhysician": "Otro doctor",
+                "OtherPhysician": "[ES]Otro doctor",
                 "OtherInstitution": "Otra institución"
             },
             "PhysicianValidation": "Complete todos los campos obligatorios."


### PR DESCRIPTION
We're only using the `physician` component in the medical release form. Need to update the labels. See the release activity configurations in https://github.com/broadinstitute/ddp-study-server/pull/873.

![Screen Shot 2021-07-13 at 3 05 10 PM](https://user-images.githubusercontent.com/5713833/125512261-57032979-63ba-46ec-8c3d-6772de57877b.png)
