### PR TITLE
DDP-6472 remove meaningless peaces of code in userActivities component

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/user/activities/userActivities.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/user/activities/userActivities.component.ts
@@ -23,12 +23,12 @@ import { DashboardColumns } from '../../../models/dashboardColumns';
 import { ActivityInstance } from '../../../models/activityInstance';
 import { ConfigurationService } from '../../../services/configuration.service';
 import { BehaviorSubject, Subscription, of } from 'rxjs';
-import { tap, mergeMap, take } from 'rxjs/operators';
+import { take } from 'rxjs/operators';
 
 @Component({
     selector: 'ddp-user-activities',
     template: `
-        <div [hidden]="!loaded">
+        <div [hidden]="!statusesLoaded">
             <mat-table [dataSource]="dataSource" data-ddp-test="activitiesTable" class="ddp-dashboard">
                 <!-- Name Column -->
                 <ng-container matColumnDef="name">
@@ -205,10 +205,10 @@ export class UserActivitiesComponent implements OnInit, OnDestroy, OnChanges, Af
     @Output() open: EventEmitter<string> = new EventEmitter();
     @Output() loadedEvent: EventEmitter<boolean> = new EventEmitter<boolean>();
     public dataSource: UserActivitiesDataSource;
-    public loaded = false;
+    public statusesLoaded = false;
     private states: Array<ActivityInstanceState> | null = null;
     private studyGuidObservable = new BehaviorSubject<string | null>(null);
-    private loadingAnchor: Subscription;
+    private statusesLoadingAnchor: Subscription;
     private readonly LOG_SOURCE = 'UserActivitiesComponent';
 
     constructor(
@@ -225,21 +225,11 @@ export class UserActivitiesComponent implements OnInit, OnDestroy, OnChanges, Af
             this.serviceAgent,
             this.logger,
             this.studyGuidObservable);
-        this.loadingAnchor =
-            this.statusesServiceAgent
-                // lets get Observable for status list
-                .getStatuses().pipe(
-                tap(x => this.states = x),
-                // than we will intersect this observable with 'isNull'
-                // observable stream from main data source, so we will get
-                // single final result when both statuses and activity
-                // instances will be loaded
-                mergeMap(() => this.dataSource.isNull)
-                // here is the final subscription, on which we will update
-                // 'loaded' flag
-            ).subscribe(x => {
-                this.loaded = !x;
-                this.loadedEvent.emit(this.loaded);
+        this.statusesLoadingAnchor = this.statusesServiceAgent.getStatuses()
+            .subscribe((x) => {
+                this.states = x;
+                this.statusesLoaded = true;
+                this.loadedEvent.emit(true);
             });
     }
 
@@ -255,7 +245,7 @@ export class UserActivitiesComponent implements OnInit, OnDestroy, OnChanges, Af
     }
 
     public ngOnDestroy(): void {
-        this.loadingAnchor.unsubscribe();
+        this.statusesLoadingAnchor.unsubscribe();
         this.loadedEvent.emit(false);
     }
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/user/activities/userActivitiesDataSource.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/user/activities/userActivitiesDataSource.ts
@@ -2,22 +2,15 @@ import { DataSource } from '@angular/cdk/collections';
 import { ActivityInstance } from '../../../models/activityInstance';
 import { LoggingService } from '../../../services/logging.service';
 import { UserActivityServiceAgent } from '../../../services/serviceAgents/userActivityServiceAgent.service';
-import { Observable, BehaviorSubject } from 'rxjs';
+import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 export class UserActivitiesDataSource extends DataSource<ActivityInstance> {
-    private nullSource: BehaviorSubject<boolean | null>;
-
     constructor(
         private serviceAgent: UserActivityServiceAgent,
         private logger: LoggingService,
         private study: Observable<string | null>) {
         super();
-        this.nullSource = new BehaviorSubject<boolean | null>(null);
-    }
-
-    public get isNull(): Observable<boolean | null> {
-        return this.nullSource.asObservable();
     }
 
     public connect(): Observable<Array<ActivityInstance>> {


### PR DESCRIPTION
It all looks like we don't actually use `isNull` property of `UserActivitiesDataSource`. 
`loaded `property was just turned to true after only statuses got loaded. I'm not going to change this behavior, but wanna remove meaningless  and useless code and rename some properties to make it more clear 