### PR TITLE
DDP-6331: Apply `study redirect` for Pancan

### DIFF
--- a/ddp-workspace/projects/ddp-pancan/src/styles.scss
+++ b/ddp-workspace/projects/ddp-pancan/src/styles.scss
@@ -3,7 +3,7 @@
 @import 'styles/common';
 @import 'styles/activities';
 @import 'styles/buttons';
-
+@import 'styles/redirect';
 
 html,
 body {

--- a/ddp-workspace/projects/ddp-pancan/src/styles/redirect.scss
+++ b/ddp-workspace/projects/ddp-pancan/src/styles/redirect.scss
@@ -1,0 +1,30 @@
+@import './variables';
+
+.study-redirect-dialog {
+    .confirm-dialog {
+        &-title {
+            border-bottom: 1px solid grey;
+            font-size: 1.3rem !important;
+            margin-bottom: 0 !important;
+            padding-bottom: 10px;
+        }
+
+        &-content {
+            line-height: 1.5rem;
+            text-align: center;
+            margin: 1rem;
+        }
+    }
+}
+
+@media screen and (max-width: $tablet-breakpoint) {
+    .study-redirect-dialog {
+        max-width: 360px !important;
+    }
+}
+
+@media screen and (max-width: $mobile-breakpoint) {
+    .study-redirect-dialog {
+        max-width: 270px !important;
+    }
+}

--- a/ddp-workspace/projects/toolkit/src/lib/services/commands/studyRedirectCommand.service.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/services/commands/studyRedirectCommand.service.ts
@@ -37,10 +37,11 @@ export class StudyRedirectCommand implements WorkflowCommand {
 
         const dialogRef = this.dialog.open(ConfirmDialogComponent, config);
         dialogRef.afterClosed().subscribe((confirmRedirect: boolean) => {
-            if (!confirmRedirect) {
+            if (confirmRedirect) {
+                this.action.data && this.redirect(this.action.data.redirectUrl);
+            } else {
                 window.location.reload();
             }
-            this.action.data && this.redirect(this.action.data.redirectUrl);
         });
     }
 

--- a/ddp-workspace/projects/toolkit/src/lib/services/commands/studyRedirectCommand.service.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/services/commands/studyRedirectCommand.service.ts
@@ -1,9 +1,8 @@
 import { Injectable } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-import { NoopScrollStrategy } from '@angular/cdk/overlay';
 import { Observable } from 'rxjs';
 
-import { ConfirmDialogComponent } from 'ddp-sdk';
+import { ConfirmDialogComponent, DEFAULT_DIALOG_SETTINGS } from 'ddp-sdk';
 import { WorkflowCommand } from '../../models/workflowCommand';
 import { StudyRedirectWorkflowAction } from '../../models/actions/studyRedirectWorkflowAction';
 
@@ -21,9 +20,7 @@ export class StudyRedirectCommand implements WorkflowCommand {
 
     private openDialog(): void {
         const config = {
-            hasBackdrop: true,
-            autoFocus: false,
-            scrollStrategy: new NoopScrollStrategy(),
+            ...DEFAULT_DIALOG_SETTINGS,
             panelClass: 'study-redirect-dialog',
             maxWidth: '500px',
             data: {


### PR DESCRIPTION
Added mostly styling (+ small fixes from PR#721). 
There were translations already.
Common workflow is in [PR#721](https://github.com/broadinstitute/ddp-angular/pull/721).

![1](https://user-images.githubusercontent.com/7396837/126202321-a5c86461-0097-4b3d-85c1-f8bdf1002ffd.png)

![2](https://user-images.githubusercontent.com/7396837/126202323-054a9632-77db-4c0f-9fc8-ab38ee7403e8.png)

![3](https://user-images.githubusercontent.com/7396837/126202324-bef1bcbc-d8c5-4e93-b60b-bc955793c713.png)
