### PR TITLE
DDP-6537: Fix a bug when Mailing Address Component prevents submission when used in multiple sections

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity.component.ts
@@ -203,7 +203,7 @@ export class ActivityComponent extends BaseActivityComponent implements OnInit, 
 
                 this.isPageBusy.pipe(
                     tap(_ => this.isLoaded$.next(false)),
-                    debounceTime(250),
+                    debounceTime(this.timeToDebounce),
                     filter(busy => !busy),
                     take(1)
                 ).subscribe(_ => {
@@ -228,7 +228,7 @@ export class ActivityComponent extends BaseActivityComponent implements OnInit, 
 
             this.isPageBusy.pipe(
                 tap(_ => this.isLoaded$.next(false)),
-                debounceTime(250),
+                debounceTime(this.timeToDebounce),
                 filter(busy => !busy),
                 take(1)
             ).subscribe(_ => {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity.component.ts
@@ -23,7 +23,7 @@ import { ActivitySection } from '../../models/activity/activitySection';
 import { AnalyticsEventCategories } from '../../models/analyticsEventCategories';
 import { CompositeDisposable } from '../../compositeDisposable';
 import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
-import { delay, filter, map, take, tap } from 'rxjs/operators';
+import { debounceTime, delay, filter, map, take, tap } from 'rxjs/operators';
 import { BlockType } from '../../models/activity/blockType';
 import { AbstractActivityQuestionBlock } from '../../models/activity/abstractActivityQuestionBlock';
 import { LoggingService } from '../../services/logging.service';
@@ -91,7 +91,9 @@ export class ActivityComponent extends BaseActivityComponent implements OnInit, 
     public ngOnInit(): void {
         this.getActivity();
         this.initStepperState();
-        const submitSub = this.submitAttempted.subscribe(() => this.submitService.announceSubmit(null));
+        const submitSub = this.submitAttempted.subscribe((isSubmit: boolean) => {
+            this.submitService.announceSubmit(isSubmit);
+        });
 
         // all PATCH responses routed to here
         const resSub = this.submissionManager.answerSubmissionResponse$.subscribe(
@@ -187,18 +189,29 @@ export class ActivityComponent extends BaseActivityComponent implements OnInit, 
     public incrementStep(scroll: boolean = true): void {
         const nextIndex = this.nextAvailableSectionIndex();
         if (nextIndex !== -1) {
-            if (scroll) {
-                this.scrollToTop();
-            }
             // enable any validation errors to be visible
             this.validationRequested = true;
             this.sendSectionAnalytics();
             this.currentSection.validate();
+
+            if (scroll) {
+                this.scrollToTop();
+            }
+
             if (this.currentSection.valid) {
                 this.resetValidationState();
-                this.currentSectionIndex = nextIndex;
-                this.visitedSectionIndexes[nextIndex] = true;
-                this.saveLastVisitedSectionIndex(nextIndex);
+
+                this.isPageBusy.pipe(
+                    tap(_ => this.isLoaded$.next(false)),
+                    debounceTime(250),
+                    filter(busy => !busy),
+                    take(1)
+                ).subscribe(_ => {
+                    this.isLoaded$.next(true);
+                    this.currentSectionIndex = nextIndex;
+                    this.visitedSectionIndexes[nextIndex] = true;
+                    this.saveLastVisitedSectionIndex(nextIndex);
+                });
             }
         }
     }
@@ -208,10 +221,20 @@ export class ActivityComponent extends BaseActivityComponent implements OnInit, 
         if (previousIndex !== -1) {
             // if we move forwards or backwards, let's reset our validation display
             this.resetValidationState();
-            this.currentSectionIndex = previousIndex;
+
             if (scroll) {
                 this.scrollToTop();
             }
+
+            this.isPageBusy.pipe(
+                tap(_ => this.isLoaded$.next(false)),
+                debounceTime(250),
+                filter(busy => !busy),
+                take(1)
+            ).subscribe(_ => {
+                this.isLoaded$.next(true);
+                this.currentSectionIndex = previousIndex;
+            });
         }
     }
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/baseActivity.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/baseActivity.component.ts
@@ -51,7 +51,7 @@ export abstract class BaseActivityComponent implements OnChanges, OnDestroy {
     public model: ActivityForm;
     public validationRequested = false;
     public isLoaded$ = new BehaviorSubject<boolean>(false);
-    public isPageBusy: Subject<boolean> = new BehaviorSubject(false);
+    public isPageBusy = new BehaviorSubject(false);
     public isAllFormContentValid: BehaviorSubject<boolean> = new BehaviorSubject(false);
     public displayGlobalError$: Observable<boolean>;
     // flag to indicate to form to not allow data entry

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/baseActivity.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/baseActivity.component.ts
@@ -62,6 +62,7 @@ export abstract class BaseActivityComponent implements OnChanges, OnDestroy {
     protected anchor: CompositeDisposable;
     protected visitedSectionIndexes: Array<boolean> = [true];
     protected submitAttempted = new Subject<boolean>();
+    protected readonly timeToDebounce = 250;
 
     protected constructor(injector: Injector) {
         this.serviceAgent = injector.get(ActivityServiceAgent);
@@ -194,7 +195,7 @@ export abstract class BaseActivityComponent implements OnChanges, OnDestroy {
                 // Wait for activity in page to cease
                 // if not busy for debounce time then we good to go
                 concatMap(() => this.isPageBusy.pipe(
-                    debounceTime(250),
+                    debounceTime(this.timeToDebounce),
                     filter(isPageBusy => !isPageBusy),
                     take(1))
                 ),

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.ts
@@ -537,7 +537,11 @@ export class AddressEmbeddedComponent implements OnDestroy, OnInit {
         const saveRealAddressAction$ = this.saveTrigger$.pipe(
             withLatestFrom(this.formErrorMessages$, currentAddress$),
             filter(([_, formErrors, addressToSave]) => {
-                return !formErrors?.length && canSaveRealAddress(addressToSave);
+                const canSave = canSaveRealAddress(addressToSave);
+                if (!canSave) {
+                    this.block.hasValidAddress = false;
+                }
+                return !formErrors?.length && canSave;
             }),
             tap(() => busyCounter$.next(1)),
             concatMap(([_, formErrors, addressToSave]) => this.addressService.saveAddress(addressToSave, false)),
@@ -626,7 +630,7 @@ export class AddressEmbeddedComponent implements OnDestroy, OnInit {
 
 
     private meetsActivityRequirements(currentAddress: Address | null): boolean {
-        if (this.block.requireVerified && !currentAddress) {
+        if (this.block.requireVerified && !this.enoughDataToVerify(currentAddress)) {
             return false;
         }
         if (this.block.requirePhone && currentAddress && !(currentAddress.phone)) {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.ts
@@ -364,11 +364,11 @@ export class AddressEmbeddedComponent implements OnDestroy, OnInit {
             tap(() => addressSuggestion$.next(null)),
             tap(() => busyCounter$.next(1)),
             tap(() => ++initiatedVerifyAddressCalls),
+            tap(_ => {
+                this.block.hasValidAddress = false;
+            }),
             switchMap(inputAddress =>
                 this.addressService.verifyAddress(inputAddress).pipe(
-                    tap(_ => {
-                        this.block.hasValidAddress = false;
-                    }),
                     map(verifyResponse => ({
                         entered: inputAddress,
                         suggested: new Address(verifyResponse),

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.component.ts
@@ -390,9 +390,9 @@ export class AddressInputComponent implements OnInit, OnDestroy {
     });
   }
 
-  public touchAllControls(): void {
-    _.values(this.ais.addressForm.controls).forEach((control: FormControl) =>
-        control.markAsTouched({ onlySelf: true }));
+  public markAddressTouched(): void {
+    this.ais.addressForm.markAllAsTouched();
+    this.cdr.detectChanges();
   }
 
   public get disableAutofill(): string {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/MailAddressBlock.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/MailAddressBlock.ts
@@ -7,6 +7,7 @@ export class MailAddressBlock extends ActivityBlock {
     public subtitleText: string | null;
     public requireVerified: boolean;
     public requirePhone: boolean;
+    public hasValidAddress: boolean;
 
     constructor(displayNumber: number) {
         super();
@@ -21,7 +22,11 @@ export class MailAddressBlock extends ActivityBlock {
         return [this];
     }
 
-    public validate(): boolean {
+    protected validateInternally(): boolean {
+        if (this.requireVerified) {
+            return this.hasValidAddress;
+        }
+
         return true;
     }
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityComponentConverter.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityComponentConverter.service.ts
@@ -28,7 +28,9 @@ export class ActivityComponentConverter {
         const block = new MailAddressBlock(inputBlock.displayNumber);
         block.titleText = params.titleText;
         block.subtitleText = params.subtitleText;
-        block.requireVerified = !!params.requireVerified;
+
+        // TODO: JUST FOR DEBUG ! FIX BACK AFTER DEBUGGING !
+        block.requireVerified = true; // !!params.requireVerified;
         block.requirePhone = !!params.requirePhone;
         return block;
     }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityComponentConverter.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityComponentConverter.service.ts
@@ -28,9 +28,7 @@ export class ActivityComponentConverter {
         const block = new MailAddressBlock(inputBlock.displayNumber);
         block.titleText = params.titleText;
         block.subtitleText = params.subtitleText;
-
-        // TODO: JUST FOR DEBUG ! FIX BACK AFTER DEBUGGING !
-        block.requireVerified = true; // !!params.requireVerified;
+        block.requireVerified = !!params.requireVerified;
         block.requirePhone = !!params.requirePhone;
         return block;
     }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/submitAnnouncement.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/submitAnnouncement.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
-import { ActivityResponse } from '../models/activity/activityResponse';
 
 /**
  * Service provides way for a parent or ancestor in component hierarchy to let a child or descendant that
@@ -14,18 +13,13 @@ import { ActivityResponse } from '../models/activity/activityResponse';
  */
 @Injectable()
 export class SubmitAnnouncementService {
-    private _submitAnnounced$: Observable<ActivityResponse>;
-    private submitAnnouncedSource: Subject<ActivityResponse>;
+    private submitAnnouncedSource = new Subject<boolean>();
 
-    constructor() {
-        this.submitAnnouncedSource = new Subject<ActivityResponse>();
-        this._submitAnnounced$ = this.submitAnnouncedSource.asObservable();
-    }
-    get submitAnnounced$(): Observable<ActivityResponse> {
-      return this._submitAnnounced$;
+    get submitAnnounced$(): Observable<boolean> {
+      return this.submitAnnouncedSource.asObservable();
     }
 
-    public announceSubmit(response: ActivityResponse): void {
-        this.submitAnnouncedSource.next(response);
+    public announceSubmit(submitOccurred: boolean): void {
+        this.submitAnnouncedSource.next(submitOccurred);
     }
 }


### PR DESCRIPTION
The root cause of the bug is freezing Next/Prev buttons in sections due to `isPageBusy$` status.
Previously we checked if Mailing Address is valid by the form submit only.

Moreover, the Mailing address was optional and located in `Medical Release` activity. 
For Pancan study it is obligatory and moved to `Consent` activity.
Trying to align the component according to the new requirements/behavior.