### PR TITLE
pancan: add path to handle activity-link from emails

### DIFF
--- a/ddp-workspace/projects/ddp-pancan/src/app/app-routing.module.ts
+++ b/ddp-workspace/projects/ddp-pancan/src/app/app-routing.module.ts
@@ -88,6 +88,15 @@ const routes: Routes = [
         ]
     },
     {
+        path: AppRoutes.ActivityLinkId,
+        component: ActivityRedesignedComponent,
+        canActivate: [
+            IrbGuard,
+            BrowserGuard,
+            AuthGuard
+        ]
+    },
+    {
         path: AppRoutes.Error,
         component: ErrorRedesignedComponent
     },

--- a/ddp-workspace/projects/ddp-pancan/src/app/components/app-routes.ts
+++ b/ddp-workspace/projects/ddp-pancan/src/app/components/app-routes.ts
@@ -1,6 +1,7 @@
 export const AppRoutes = {
     Activity: 'activity',
     ActivityId: 'activity/:id',
+    ActivityLinkId: 'activity-link/:id',
     Dashboard: 'dashboard',
     Error: 'error',
     LoginLanding: 'login-landing',


### PR DESCRIPTION
A few emails for pancan will have a button that links back to a specific activity. The pattern we use here is to have the button URL point to `{{baseWebUrl}}/activity-link/{{activityInstanceGuid}}`. This PR adds a route path to handle that.