### PR TITLE
DDP-6537: FIX-2: Fix a bug in the parental consent workflow

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.ts
@@ -520,9 +520,12 @@ export class AddressEmbeddedComponent implements OnDestroy, OnInit {
 
         const removeTempAddressOperator = () => (val$: Observable<any>) => val$.pipe(
             withLatestFrom(this.state$),
-            filter(([_, state]) => !!state.activityInstanceGuid),
+            filter(([savedAddress, state]) => !!state.activityInstanceGuid),
             tap(() => busyCounter$.next(1)),
-            concatMap(([_, state]) => this.addressService.deleteTempAddress(state.activityInstanceGuid)),
+            concatMap(([savedAddress, state]) => {
+                this.addressService.deleteTempAddress(state.activityInstanceGuid);
+                return of(savedAddress);
+            }),
             catchError(() => {
                 this.logger.logDebug(this.LOG_SOURCE, 'Temp delete failed. This is OK.');
                 return of(null);


### PR DESCRIPTION
   **_Flow to reproduce_**: When attempting to submit the consent the first time causes the mail address form to be cleared.
   It has to be entered a second time  in order for the consent to be submitted.

  ---------------
   I believe that the bug cause is that `removeTempAddressOperator` returns http response
   from `this.addressService.deleteTempAddress(state.activityInstanceGuid)`, not Address. 
   (see screenshots below)
   Seems like previously the API returned another value? 
   Anyway, fixed by passing the correct address through Observables chain.

![debug1](https://user-images.githubusercontent.com/7396837/127568868-ee3421d3-a5b9-4841-9199-39144dd44862.png)
![debug3](https://user-images.githubusercontent.com/7396837/127568870-d78dd20b-1616-4670-8ea7-98a151609c91.png)
![debug4](https://user-images.githubusercontent.com/7396837/127568872-b2ee59da-e1da-45d4-b21a-fee25a69f48b.png)
