### PR TITLE
DDP-6563 buttons styles refactoring

### DIFF
--- a/ddp-workspace/projects/ddp-pancan/src/app/components/auth/auth.component.scss
+++ b/ddp-workspace/projects/ddp-pancan/src/app/components/auth/auth.component.scss
@@ -1,7 +1,6 @@
-@import '../../../styles/common';
+@import '../../../styles/buttons';
 
 .action-button {
-    @extend .btn-auth;
     margin-left: 0.9rem;
 }
 

--- a/ddp-workspace/projects/ddp-pancan/src/app/components/auth/auth.component.ts
+++ b/ddp-workspace/projects/ddp-pancan/src/app/components/auth/auth.component.ts
@@ -9,7 +9,7 @@ import { AppRoutes } from '../app-routes';
             <ddp-sign-in-out></ddp-sign-in-out>
         </div>
         <a mat-flat-button
-           class="action-button btn-common"
+           class="action-button btn-auth button button_small"
            [class.dashboard-button]="isAuthenticated"
            [routerLink]="isAuthenticated ? AppRoutes.Dashboard : AppRoutes.CountMeIn"
            color="primary">

--- a/ddp-workspace/projects/ddp-pancan/src/app/components/footer/footer.component.html
+++ b/ddp-workspace/projects/ddp-pancan/src/app/components/footer/footer.component.html
@@ -2,7 +2,7 @@
     <div class="actions">
         <div class="actions__wrapper">
             <button mat-button
-                    class="back-to-top btn-common"
+                    class="back-to-top button button_small"
                     (click)="goToTop()">
                 <mat-icon>arrow_drop_up</mat-icon>
                 {{'App.Footer.BackToTopButton' | translate}}

--- a/ddp-workspace/projects/ddp-pancan/src/app/components/participation/participation.component.html
+++ b/ddp-workspace/projects/ddp-pancan/src/app/components/participation/participation.component.html
@@ -10,7 +10,7 @@
             <a mat-stroked-button *ngIf="step.Button && stepsHref[i]"
                target="_blank"
                [href]="stepsHref[i]"
-               class="step__btn btn-common small-letter-spacing btn-outline">
+               class="step__btn button button_small small-letter-spacing button_secondary">
                 {{step.Button}}
             </a>
         </div>

--- a/ddp-workspace/projects/ddp-pancan/src/app/components/welcome/welcome.component.html
+++ b/ddp-workspace/projects/ddp-pancan/src/app/components/welcome/welcome.component.html
@@ -4,7 +4,7 @@
         <p class="text static-page-paragraph-text" translate>App.HomePage.IntroductionSection.Text</p>
         <a mat-flat-button
            [routerLink]="'/' + AppRoutes.CountMeIn"
-           class="btn join-cmi-btn center btn-common"
+           class="btn join-cmi-btn center button button_small"
            color="primary">
             {{'App.HomePage.JoinCountMeInButton' | translate}}
         </a>
@@ -23,7 +23,7 @@
         <p class="text static-page-paragraph-text" [innerHTML]="'App.HomePage.LearnMoreSection.Text' | translate"></p>
         <a mat-stroked-button
            [routerLink]="'/' + AppRoutes.AboutUs"
-           class="btn learn-more-btn center small-letter-spacing btn-common btn-outline">
+           class="btn learn-more-btn center small-letter-spacing button button_small button_secondary">
             {{'App.HomePage.LearnMoreSection.LearnMoreAboutUsButton' | translate}}
         </a>
     </section>
@@ -57,7 +57,7 @@
         <div class="container">
             <a mat-stroked-button
                [routerLink]="'/' + AppRoutes.Participation"
-               class="btn learn-more-btn center small-letter-spacing btn-common btn-outline">
+               class="btn learn-more-btn center small-letter-spacing button button_small button_secondary">
                 {{'App.HomePage.ParticipateSection.LearnMoreAboutParticipationButton' | translate}}
             </a>
         </div>
@@ -70,7 +70,7 @@
         </div>
         <a mat-stroked-button
            [routerLink]="'/' + AppRoutes.FAQ"
-           class="btn more-faq-btn center small-letter-spacing btn-common btn-outline">
+           class="btn more-faq-btn center small-letter-spacing button button_small button_secondary">
             {{'App.FAQ.Button.MoreFAQs' | translate}}
         </a>
     </section>
@@ -96,7 +96,7 @@
                 </div>
             </div>
             <button mat-stroked-button
-                    class="btn join-btn small-letter-spacing btn-common btn-outline"
+                    class="btn join-btn small-letter-spacing button button_small button_secondary"
                     (click)="openJoinMailingList()">
                 {{'App.HomePage.StayInformedSection.JoinMailingListButton' | translate}}
             </button>
@@ -112,7 +112,7 @@
         <p class="text static-page-paragraph-text" translate>App.HomePage.CountMeInSection.Text</p>
         <a mat-raised-button
            [routerLink]="'/' + AppRoutes.CountMeIn"
-           class="btn join-cmi-btn btn-common"
+           class="btn join-cmi-btn button button_small"
            color="primary">
             {{'App.HomePage.JoinCountMeInButton' | translate}}
         </a>

--- a/ddp-workspace/projects/ddp-pancan/src/styles.scss
+++ b/ddp-workspace/projects/ddp-pancan/src/styles.scss
@@ -44,10 +44,6 @@ body {
     min-height: 100%;
 }
 
-button {
-    cursor: pointer;
-}
-
 a {
     cursor: pointer;
     text-decoration: none;
@@ -67,28 +63,6 @@ h1 {
     font-family: $primary-font-medium;
     font-size: 1.5rem;
     font-weight: normal;
-}
-
-.SimpleButton {
-    @extend .btn-common;
-    @extend .btn-auth;
-
-    background-color: transparent;
-    border-width: 0;
-
-    ddp-sign-in-out & {
-        @extend .btn-outline;
-    }
-
-    ddp-language-selector & {
-        display: flex;
-        align-items: center;
-    }
-
-    .footer & {
-        color: white;
-        border-color: white;
-    }
 }
 
 // language selector
@@ -121,18 +95,6 @@ ddp-language-selector {
 
 .Link {
     color: $primary-color;
-}
-
-.button-link {
-    border: none;
-    background: none;
-    font-size: inherit;
-    font-family: inherit;
-    color: $primary-color;
-
-    &:hover, &:focus {
-        text-decoration: underline;
-    }
 }
 
 .Modal-title {

--- a/ddp-workspace/projects/ddp-pancan/src/styles/buttons.scss
+++ b/ddp-workspace/projects/ddp-pancan/src/styles/buttons.scss
@@ -1,8 +1,9 @@
-@import "../theme.scss";
-@import "common";
-@import "variables";
+@import '../theme.scss';
+@import 'common';
+@import 'variables';
 
-.button {
+.button,
+.SimpleButton {
     padding: 0.625rem 2rem;
     font-family: $primary-font-medium;
     border-radius: 4px;
@@ -14,15 +15,16 @@
     transition: 0.3s;
     white-space: nowrap;
 }
-//
-//.button,
-//.button:active,
-//.button:hover,
-//.button:focus {
-//    text-decoration: none;
-//}
-//
-.button_small {
+
+.button,
+.button:active,
+.button:hover,
+.button:focus {
+    text-decoration: none;
+}
+
+.button_small,
+.SimpleButton {
     font-size: 1rem;
     line-height: 1.25rem;
 }
@@ -42,7 +44,6 @@
     background-color: mat-color($app-primary, 500);
     border: 2px solid mat-color($app-primary, 500);
     color: white;
-    @extend .btn-common;
 
     &:hover:not([disabled]),
     :hover:enabled {
@@ -52,9 +53,9 @@
 }
 
 .button_secondary {
-    background-color: white;
+    background-color: transparent;
     color: $text-color;
-    border: 2px solid $text-color;
+    border: 2px solid $text-color !important;
 
     &:hover:not([disabled]),
     &:hover:enabled,
@@ -76,37 +77,49 @@
     margin-bottom: 2rem;
 }
 
-//.simple-button,
-//.SimpleButton {
-//    background: none;
-//    border: none;
-//    padding: 0;
-//    cursor: pointer;
-//    color: mat-color($app-primary, 200);
-//    text-decoration: none;
-//    font-size: 16px;
-//    line-height: 20px;
-//    font-family: inherit;
-//    white-space: nowrap;
-//    transition: 0.3s;
-//}
-//
-//.simple-button:hover,
-//.SimpleButton:hover {
-//    text-decoration: underline;
-//}
-//
-//.simple-button:focus,
-//.SimpleButton:focus {
-//    text-decoration: underline;
-//}
-//
-//.menu {
-//
-//    .button,
-//    .simple-button,
-//    .SimpleButton {
-//        font-size: 1.875rem;
-//        line-height: 2.25rem;
-//    }
-//}
+.SimpleButton {
+    @extend .btn-auth;
+
+    background-color: transparent;
+    border-width: 0;
+
+    ddp-sign-in-out & {
+        border: 2px solid $text-color;
+        background-color: transparent;
+    }
+
+    ddp-language-selector & {
+        display: flex;
+        align-items: center;
+    }
+
+    .footer & {
+        color: white;
+        border-color: white;
+    }
+}
+
+.btn-auth {
+    padding: 0.65rem 1.5rem !important;
+    line-height: 20px !important;
+
+    &.dashboard-button {
+        padding: 0.65rem !important;
+    }
+}
+
+.small-letter-spacing {
+    letter-spacing: -0.016rem;
+}
+
+.button-link {
+    border: none;
+    background: none;
+    font-size: inherit;
+    font-family: inherit;
+    color: $primary-color;
+
+    &:hover, &:focus {
+        text-decoration: underline;
+    }
+}

--- a/ddp-workspace/projects/ddp-pancan/src/styles/common.scss
+++ b/ddp-workspace/projects/ddp-pancan/src/styles/common.scss
@@ -28,36 +28,3 @@
     letter-spacing: -0.07px;
     line-height: 24px;
 }
-
-.btn-common {
-    font-family: $primary-font-medium;
-    text-decoration: none;
-    border-radius: 4px;
-    font-size: 1rem;
-}
-
-.btn-outline {
-    border-width: 1px;
-    border-color: $text-color;
-    background-color: transparent;
-}
-
-.btn-auth {
-    padding: 0.65rem 1.5rem;
-    line-height: 20px;
-
-    &.dashboard-button {
-        padding: 0.65rem;
-    }
-}
-
-// for buttons
-.small-letter-spacing {
-    letter-spacing: -0.016rem;
-}
-
-@media screen and (min-width: $desktop-breakpoint) {
-    .btn-outline {
-        border-width: 2px;
-    }
-}


### PR DESCRIPTION
- move all buttons styles to buttons.scss file
- get rid of custom classes btn-common and btn-outline and use button, button_secondary and button_small instead
- remove not used styles