### PR TITLE
DDP-6725 Global activity error message shown on recently loaded activities

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity.component.ts
@@ -91,7 +91,8 @@ export class ActivityComponent extends BaseActivityComponent implements OnInit, 
     public ngOnInit(): void {
         this.getActivity();
         this.initStepperState();
-        const submitSub = this.submitAttempted.subscribe(() => this.submitAnnouncementService.announceSubmit());
+        const submitSub = this.submitAttempted.pipe(filter(attempted => attempted))
+            .subscribe(() => this.submitAnnouncementService.announceSubmit());
 
         // all PATCH responses routed to here
         const resSub = this.submissionManager.answerSubmissionResponse$.subscribe(

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/baseActivity.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/baseActivity.component.ts
@@ -69,6 +69,9 @@ export abstract class BaseActivityComponent implements OnChanges, OnDestroy {
         this.workflow = injector.get(WorkflowServiceAgent);
         this.submissionManager = injector.get(SubmissionManager);
         this.router = injector.get(Router);
+        // next line ensures that when we navigate from one activity to the next
+        // activity component is reloaded/ngOnInit executes. Otherwise component is not initialized
+        // after routing
         this.config = injector.get<ConfigurationService>('ddp.config' as any);
         this.studyGuidObservable = new BehaviorSubject<string | null>(null);
         this.activityGuidObservable = new BehaviorSubject<string | null>(null);
@@ -116,6 +119,7 @@ export abstract class BaseActivityComponent implements OnChanges, OnDestroy {
                     this.activityCode.emit(this.model.activityCode);
                     this.initSteps();
                 }
+                this.submitAttempted.next(false);
                 this.isLoaded$.next(true);
 
                 // combine the latest status updates from the form model
@@ -126,7 +130,7 @@ export abstract class BaseActivityComponent implements OnChanges, OnDestroy {
                         this.submissionManager.answerSubmissionResponse$,
                         // We don't automatically get model updates if local validation fails
                         // so trigger one when submit
-                        this.submitAttempted
+                        this.submitAttempted.pipe(filter(attempted => attempted))
                     ).pipe(
                         map(() => this.model.validate()),
                         // let's start with whatever it is the initial state of the form

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/baseActivity.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/baseActivity.component.ts
@@ -69,9 +69,6 @@ export abstract class BaseActivityComponent implements OnChanges, OnDestroy {
         this.workflow = injector.get(WorkflowServiceAgent);
         this.submissionManager = injector.get(SubmissionManager);
         this.router = injector.get(Router);
-        // next line ensures that when we navigate from one activity to the next
-        // activity component is reloaded/ngOnInit executes. Otherwise component is not initialized
-        // after routing
         this.config = injector.get<ConfigurationService>('ddp.config' as any);
         this.studyGuidObservable = new BehaviorSubject<string | null>(null);
         this.activityGuidObservable = new BehaviorSubject<string | null>(null);


### PR DESCRIPTION
Learned something new about Angular that perhaps you guys already knew:

I had been under impression that whenever router takes you from one page to another, the component displaying the current page would get ngDestroyed and a new component would be instantiated, ngOnInit etc would be called, etc. I was wrong.

If router goes from one route/url to another AND the destination component is the same as the last one, it just keep using the original component. Only thing that might change are router params.

So if we click to EDIT an activity listed in dashboard, the ActivityRedesignedComponent will go through the full Angular lifecycle (constructor ngOnInit ngOnChange etc.). Any component state will start fresh.

But if we hit the SUBMIT button on an activity and the application workflow directs Angular to go to another activity, the full Angular lifecycle is not executed: any state that was in component from the previous activity instance will be preserved unless explicitly reset.

So the problem was being caused by this chunk of code:

```typescript
private setupDisplayGlobalErrorObservable(): void {
        this.displayGlobalError$ = this.isAllFormContentValid.pipe(
            withLatestFrom(this.submitAttempted),
            map(([valid, submit]) => this.model && submit && !valid),
            shareReplay()
        );
    }
```
Basically, we displayGlobalError if submitAttempted is true (observable emits when Submit button is pressed) and we have invalid contents.

The bug is that `withLatestFrom` operator was still remembering the submitAttempted = true from the previous activity.
So when going to an activity that had required fields if would find invalid content (required field values are missing) and show the global error.

The fix is that is calling submitAttempted.next(false) when activity is retrieved from back-end. And making sure that any code that depends on this observable checks the value and not just assume that if it emits it means a submit was attempted.

More:
My original fix (and one that I would like to implement in the future) is to change the component loading behavior when routing. I want to create a ActivityRedesignedComponent on every route. Simplifies life to know same things happen every time you go a new URL.
This can be done tweaking the RouteReuseStrategy https://angular.io/api/router/RouteReuseStrategy

It did what what I wanted to do, forcing constructor/ngOnInit etc when routing BUT was seeing some other weird stuff. Specifically, the button in top right of page "Dashboard" simply stopped working.

I don't know what the reason was, but was afraid that this REAL fix would introduce other unknown side effects so backed out.

But when we get around refactoring the activity component this lifecycle issue will be important to deal with.



