### PR TITLE
DDP-6769: Fix css when cancer names are cut off (on mobiles) PANCAN

### DIFF
--- a/ddp-workspace/projects/ddp-pancan/src/styles/activities.scss
+++ b/ddp-workspace/projects/ddp-pancan/src/styles/activities.scss
@@ -459,3 +459,19 @@ select:disabled {
 .mat-checkbox-frame {
     border-color: $checkbox-color !important;
 }
+
+@media screen and (max-width: $mobile-breakpoint) {
+    // autocomplete-picklist-question
+    .autoCompletePanel {
+        .mat-option {
+            white-space: normal;
+            height: auto;
+            border-top: 1px solid #d2d2d2;
+
+            &:last-of-type {
+                border-bottom: 1px solid #d2d2d2;
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Moved an overflowed option text to the next line.
Suggest adding options borders as to distinguish one line option/multiline option easily (for mobiles only)

**_Before:_**
![ab1](https://user-images.githubusercontent.com/7396837/129080519-f3157e3a-201f-4eb5-8f8d-c9ced9cdeb11.png)

**_After:_**
![ab2](https://user-images.githubusercontent.com/7396837/129080538-1ff5f932-46b6-465d-ae1d-b988c1a6bde9.png)
