### PR TITLE
DDP-6781: Fix styles: Center text in redirect button [PanCan | Mobile] 

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/confirmDialog/confirmDialog.component.scss
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/confirmDialog/confirmDialog.component.scss
@@ -21,7 +21,8 @@ $dialog-arrow-half-width: $dialog-arrow-width / 2;
 
         & > button {
             height: var(--modal-activity-block-delete-dialog-button-height, 40px);
-            width: var(--modal-activity-block-delete-dialog-button-width, 9rem);
+            width: var(--modal-activity-block-delete-dialog-button-width, auto);
+            min-width: 9rem;
         }
     }
 }


### PR DESCRIPTION
**_Before_**
![z1](https://user-images.githubusercontent.com/7396837/129196048-f9c10771-db36-44a6-9f96-301f0f8e1de5.png)

**_After_**
![z2](https://user-images.githubusercontent.com/7396837/129196059-9151a80c-a246-4d43-a40e-64e7b5d34246.png)
