### PR TITLE
DDP-6563 call super.ngOnDestroy() in ActivityComponent

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity.component.ts
@@ -140,6 +140,7 @@ export class ActivityComponent extends BaseActivityComponent implements OnInit, 
     }
 
     public ngOnDestroy(): void {
+        super.ngOnDestroy();
         this.anchors.forEach(anchor => anchor.removeAll());
     }
 


### PR DESCRIPTION
it looks like an old bug. The subscriptions from baseActivity wasn't cleared.