### PR TITLE
DDP-6682: Force scroll to top after submit an activity

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity.component.ts
@@ -165,6 +165,7 @@ export class ActivityComponent extends BaseActivityComponent implements OnInit, 
     }
 
     public flush(): void {
+        this.scrollToTop();
         this.sendLastSectionAnalytics();
         this.sendActivityAnalytics(AnalyticsEventCategories.SubmitSurvey);
         super.flush();


### PR DESCRIPTION
Can't reproduce any issue from [DDP-6682](https://broadinstitute.atlassian.net/browse/DDP-6682), [DDP-6813](https://broadinstitute.atlassian.net/browse/DDP-6813).

Suggest to call explicitly the `scrollToTop` method when an activity is submited.