### PR TITLE
DDP-6769: Fix cut off picklist options with long names for any screen resolution

### DIFF
--- a/ddp-workspace/projects/ddp-pancan/src/styles/activities.scss
+++ b/ddp-workspace/projects/ddp-pancan/src/styles/activities.scss
@@ -460,18 +460,17 @@ select:disabled {
     border-color: $checkbox-color !important;
 }
 
-@media screen and (max-width: $tablet-breakpoint) {
-    // autocomplete-picklist-question
-    .autoCompletePanel {
-        .mat-option {
-            white-space: normal;
-            height: auto;
-            border-top: 1px solid #d2d2d2;
+// autocomplete-picklist-question
+.autoCompletePanel {
+    .mat-option {
+        white-space: normal;
+        height: auto;
+        border-top: 1px solid #d2d2d2;
 
-            &:last-of-type {
-                border-bottom: 1px solid #d2d2d2;
-            }
+        &:last-of-type {
+            border-bottom: 1px solid #d2d2d2;
         }
     }
 }
+
 


### PR DESCRIPTION
Applied styling with multiline options which have borders for every screen.

Desktop:
**_Before:_** 
![a1](https://user-images.githubusercontent.com/7396837/129916227-94350612-36e4-4805-9688-df407c11f048.png)

**_After:_**
![a2](https://user-images.githubusercontent.com/7396837/129916251-9fe2c92c-1e21-43ce-b743-33265a2aff34.png)
