### PR TITLE
DDP-6752: *OLD* [Pancan] picklist autocomplete : treat the "-", '/' characters as a space

### DIFF
--- a/ddp-workspace/projects/ddp-pancan/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-pancan/src/app/app.module.ts
@@ -92,6 +92,8 @@ sdkConfig.doGcpErrorReporting = DDP_ENV.doGcpErrorReporting;
 sdkConfig.tooltipIconUrl = 'assets/images/info.png';
 sdkConfig.useStepsWithCircle = true;
 sdkConfig.picklistsWithNoSorting = ['PRIMARY_CANCER_SELF', 'PRIMARY_CANCER_CHILD'];
+sdkConfig.picklistsWithSubstitutionSymbols = ['PRIMARY_CANCER_SELF', 'PRIMARY_CANCER_CHILD'];
+sdkConfig.picklistsSubstitutionSymbols = ['-', '/'];
 
 export function translateFactory(translate: TranslateService,
     injector: Injector,

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activityPicklistAnswer.component.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activityPicklistAnswer.component.spec.ts
@@ -84,7 +84,12 @@ describe('ActivityPicklistAnswer', () => {
             providers: [
                 { provide: NGXTranslateService, useValue: ngxTranslateServiceSpy },
                 { provide: PicklistSortingPolicy, useValue: new PicklistSortingPolicy() },
-                { provide: 'ddp.config', useValue: { picklistsWithNoSorting: [] } }
+                { provide: 'ddp.config',
+                    useValue: {
+                        picklistsWithNoSorting: [],
+                        picklistsWithSubstitutionSymbols: []
+                    }
+                }
             ],
             declarations: [
                 TestHostComponent,

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.spec.ts
@@ -66,7 +66,12 @@ describe('AutocompleteActivityPicklistQuestion', () => {
             providers: [
                 { provide: NGXTranslateService, useValue: ngxTranslateServiceSpy },
                 { provide: PicklistSortingPolicy, useValue:  new PicklistSortingPolicy() },
-                { provide: 'ddp.config', useValue: { picklistsWithNoSorting: [] } }
+                { provide: 'ddp.config',
+                    useValue: {
+                        picklistsWithNoSorting: [],
+                        picklistsWithSubstitutionSymbols: []
+                    }
+                }
             ],
             declarations: [AutocompleteActivityPicklistQuestion, SearchHighlightPipe]
         }).compileComponents();
@@ -289,7 +294,11 @@ describe('AutocompleteActivityPicklistQuestion sorting (with default ALPHABETICA
 
     let component: AutocompleteActivityPicklistQuestion;
     let fixture: ComponentFixture<AutocompleteActivityPicklistQuestion>;
-    const configServiceSpy = jasmine.createSpyObj('ddp.config', null, {picklistsWithNoSorting: []});
+    const configServiceSpy = jasmine.createSpyObj('ddp.config', null,
+        {
+            picklistsWithNoSorting: [],
+            picklistsWithSubstitutionSymbols: []
+        });
 
     beforeEach(() => {
         TestBed.configureTestingModule({

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
@@ -23,13 +23,13 @@ import { RegExpHelper } from '../../../utility/RegExpHelper';
 
         <mat-autocomplete #autoCompleteFromSource="matAutocomplete" class="autoCompletePanel" [displayWith]="displayAutoComplete">
             <mat-optgroup *ngFor="let group of filteredGroups">
-                <strong [innerHtml]="group.name | searchHighlight: userQueryRegExp$.getValue()"></strong>
+                <strong [innerHtml]="group.name | searchHighlight: userQueryRegExp"></strong>
                 <ng-container *ngTemplateOutlet="generalOptionsList; context: {list: group.options}"></ng-container>
             </mat-optgroup>
             <ng-container *ngTemplateOutlet="generalOptionsList; context: {list: filteredOptions}"></ng-container>
             <ng-template #generalOptionsList let-list="list">
                 <mat-option *ngFor="let suggestion of list" class="autoCompleteOption" [value]="suggestion">
-                    <span [innerHtml]="suggestion.optionLabel | searchHighlight: userQueryRegExp$.getValue()"></span>
+                    <span [innerHtml]="suggestion.optionLabel | searchHighlight: userQueryRegExp"></span>
                 </mat-option>
             </ng-template>
         </mat-autocomplete>
@@ -55,7 +55,7 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
     // options w/o a group
     filteredOptions: ActivityPicklistOption[] = [];
     inputFormControl = new FormControl();
-    userQueryRegExp$ = new BehaviorSubject<RegExp>(null);
+    userQueryRegExp: RegExp;
     private substitutableSymbols: string[] = [];
 
     constructor(
@@ -91,9 +91,7 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
             .subscribe((value: string | ActivityPicklistOption) => {
                 const query = typeof value === 'string' ? value : value.optionLabel;
                 if (query) {
-                    this.userQueryRegExp$.next(
-                        RegExpHelper.createSubstitutableSymbolsRegExp(query, this.substitutableSymbols)
-                    );
+                    this.userQueryRegExp = RegExpHelper.createSubstitutableSymbolsRegExp(query, this.substitutableSymbols);
                     this.filteredGroups = this.filterOutEmptyGroups(this.filterGroups(sortedPicklistGroups));
                     this.filteredOptions = this.filterOptions(sortedPicklistOptions);
                 } else {
@@ -173,13 +171,14 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
         return groups
             .map(group => ({
                 name: group.name,
-                options: this.userQueryRegExp$.getValue().test(group.name) ?
-                    group.options : this.filterOptions(group.options)
+                options: this.userQueryRegExp.test(group.name)
+                    ? group.options
+                    : this.filterOptions(group.options)
             }));
     }
 
     private filterOptions(options: ActivityPicklistOption[]): ActivityPicklistOption[] {
-        return options.filter(option => this.userQueryRegExp$.getValue().test(option.optionLabel));
+        return options.filter(option => this.userQueryRegExp.test(option.optionLabel));
     }
 
     private get shouldBeSorted(): boolean {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
@@ -1,6 +1,6 @@
 import { Component, Inject, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
 import { FormControl } from '@angular/forms';
-import { BehaviorSubject, Subject } from 'rxjs';
+import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, map, startWith, takeUntil } from 'rxjs/operators';
 
 import { BaseActivityPicklistQuestion } from './baseActivityPicklistQuestion.component';

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
@@ -11,8 +11,6 @@ import { PicklistSortingPolicy } from '../../../services/picklistSortingPolicy.s
 import { ConfigurationService } from '../../../services/configuration.service';
 import { RegExpHelper } from '../../../utility/RegExpHelper';
 
-const SUBSTITUTABLE_SYMBOLS = ['-', '/'];
-
 @Component({
     selector: 'ddp-activity-autocomplete-picklist-question',
     template: `
@@ -58,6 +56,7 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
     filteredOptions: ActivityPicklistOption[] = [];
     inputFormControl = new FormControl();
     userQueryRegExp$ = new BehaviorSubject<RegExp>(null);
+    private substitutableSymbols: string[] = [];
 
     constructor(
         translate: NGXTranslateService,
@@ -69,6 +68,7 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
 
     public ngOnInit(): void {
         this.initInputValue();
+        this.initSubstitutableSymbols();
 
         const userQueryStream$ = this.inputFormControl.valueChanges.pipe(
             map(value => typeof value === 'string' ? value.trim() : value),
@@ -92,7 +92,7 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
                 const query = typeof value === 'string' ? value : value.optionLabel;
                 if (query) {
                     this.userQueryRegExp$.next(
-                        RegExpHelper.createSubstitutableSymbolsRegExp(query, SUBSTITUTABLE_SYMBOLS)
+                        RegExpHelper.createSubstitutableSymbolsRegExp(query, this.substitutableSymbols)
                     );
                     this.filteredGroups = this.filterOutEmptyGroups(this.filterGroups(sortedPicklistGroups));
                     this.filteredOptions = this.filterOptions(sortedPicklistOptions);
@@ -139,6 +139,12 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
                 ...this.block.picklistOptions
             ].find(option => option.stableId === answer.stableId);
             this.inputFormControl.setValue(value);
+        }
+    }
+
+    private initSubstitutableSymbols(): void {
+        if (this.config.picklistsWithSubstitutionSymbols.includes(this.block.stableId)) {
+            this.substitutableSymbols = this.config.picklistsSubstitutionSymbols;
         }
     }
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/pipes/searchHighlight.pipe.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/pipes/searchHighlight.pipe.ts
@@ -1,19 +1,26 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import { RegExpHelper } from '../utility/RegExpHelper';
 
 @Pipe({
     name: 'searchHighlight'
 })
 export class SearchHighlightPipe implements PipeTransform {
-    transform(text: string, search: string): string {
-        // copied from
-        // https://stackoverflow.com/questions/49653410/mat-autocomplete-filter-to-hightlight-partial-string-matches#answer-49670236
-        const pattern = search
-            .replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')
-            .split(' ')
-            .filter(t => t.length > 0)
-            .join('|');
-        const regex = new RegExp(pattern, 'gi');
+    transform(text: string, search: string | RegExp): string {
+        let regex: RegExp;
+        if (!search) return text;
 
-        return search ? text.replace(regex, match => `<u>${match}</u>`) : text;
+        if (typeof search === 'string') {
+            // copied from
+            // https://stackoverflow.com/questions/49653410/mat-autocomplete-filter-to-hightlight-partial-string-matches#answer-49670236
+            const pattern = RegExpHelper.escapeRegExp(search)
+                .split(' ')
+                .filter(t => t.length > 0)
+                .join('|');
+            regex = new RegExp(pattern, 'gi');
+        } else {
+            regex = search;
+        }
+
+        return text.replace(regex, match => `<u>${match}</u>`);
     }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/configuration.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/configuration.service.ts
@@ -73,4 +73,6 @@ export class ConfigurationService {
     prismDashboardRoute: string;
     prismRoute: string;
     picklistsWithNoSorting: string[] = [];
+    picklistsWithSubstitutionSymbols: string[] = [];
+    picklistsSubstitutionSymbols: string[] = [];
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/utility/RegExpHelper.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/utility/RegExpHelper.spec.ts
@@ -1,0 +1,22 @@
+import { RegExpHelper } from './RegExpHelper';
+
+describe('RegExpHelper', () => {
+    it('should create a regexp for a text without substitutableSymbols', () => {
+        const regex = RegExpHelper.createSubstitutableSymbolsRegExp('just   text');
+        expect(regex).toEqual(/just text/gi);
+        expect('just text').toMatch(regex);
+    });
+
+    it('should create a regexp for a text which contains only substitutableSymbols', () => {
+        const regex = RegExpHelper.createSubstitutableSymbolsRegExp('-', ['-', '/']);
+        expect(regex).toEqual(/\-/gi);
+        expect(' - ').toMatch(regex);
+    });
+
+    it('should create a regexp for a text with substitutableSymbols', () => {
+        const regex = RegExpHelper.createSubstitutableSymbolsRegExp('B  -  cell', ['-', '/']);
+        expect(regex).toEqual(/B\s*[\-\/ ]\s*cell/gi);
+        expect('B-cell').toMatch(regex);
+        expect('B cell').toMatch(regex);
+    });
+});

--- a/ddp-workspace/projects/ddp-sdk/src/lib/utility/RegExpHelper.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/utility/RegExpHelper.ts
@@ -14,15 +14,12 @@ export class RegExpHelper {
         if (substitutableSymbols.includes(text) || !substitutableSymbols.some(s => text.includes(s))) {
             // return same text but space/case insensitive
             return new RegExp(
-                RegExpHelper.replaceEmptySpaces(
-                    RegExpHelper.escapeRegExp(text),
-                    anyAmountOfSpacesRegExp
-                ),
+                RegExpHelper.replaceEmptySpaces(RegExpHelper.escapeRegExp(text)),
                 'gi'
             );
         }
 
-        const escapedSubstitutableSymbols = substitutableSymbols.map(symbol => RegExpHelper.escapeRegExp(symbol));
+        const escapedSubstitutableSymbols = substitutableSymbols.map(symbol => `\\${symbol}`);
         const substitutableSymbolsRegExp = new RegExp(escapedSubstitutableSymbols.join('|'), 'g');
 
         const pattern = RegExpHelper.escapeRegExp(
@@ -33,6 +30,10 @@ export class RegExpHelper {
             )
             .replace(
                 substitutableSymbolsRegExp,
+                // replacing any of substitutableSymbols in origin text with a range of all substitutableSymbols and a replaceValue,
+                // surrounded with any amount of spaces
+                // e.g. substitutableSymbols = ['-', '/'], text = 'asd -   123'
+                // the regex will be /asd\s*[-/ ]\s*123/
                 [anyAmountOfSpacesRegExp, '[', ...escapedSubstitutableSymbols, replaceValue, ']', anyAmountOfSpacesRegExp].join('')
             );
         return new RegExp(pattern, 'gi'); // case-insensitive

--- a/ddp-workspace/projects/ddp-sdk/src/lib/utility/RegExpHelper.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/utility/RegExpHelper.ts
@@ -1,0 +1,39 @@
+export class RegExpHelper {
+
+    /* The method returns a RegExp:
+    *  if text includes symbols to substitute, they match with any of `substitutableSymbols` or `replaceValue`(a space by default),
+    *  (case/space insensitive)
+    *  e.g.
+    *  regExp = createSubstitutableSymbolsRegExp('asd / zxc', ['-', '/'], ' ');
+    *  regExp.test('asd zxc') = true;
+    *  regExp.test('asd / zxc') = true;
+    *  regExp.test('asd -    zxc') = true;
+    */
+    static createSubstitutableSymbolsRegExp(text: string, substitutableSymbols: string[] = [], replaceValue = ' '): RegExp {
+        const anyAmountOfSpacesRegExp = '\\s*';
+        if (substitutableSymbols.includes(text) || !substitutableSymbols.some(s => text.includes(s))) {
+            // return same text but space/case insensitive
+            return new RegExp(
+                RegExpHelper.replaceEmptySpaces(text, anyAmountOfSpacesRegExp),
+                'gi'
+            );
+        }
+
+        const escapedSubstitutableSymbols = substitutableSymbols.map(symbol => RegExpHelper.escapeRegExp(symbol));
+        const substitutableSymbolsRegExp = new RegExp(escapedSubstitutableSymbols.join('|'), 'g');
+        const pattern = RegExpHelper.replaceEmptySpaces(text, '')
+            .replace(
+                substitutableSymbolsRegExp,
+                [anyAmountOfSpacesRegExp, '[', ...escapedSubstitutableSymbols, replaceValue, ']', anyAmountOfSpacesRegExp].join('')
+            );
+        return new RegExp(pattern, 'gi'); // case-insensitive
+    }
+
+    static replaceEmptySpaces(text: string, replaceValue = ' '): string {
+        return text.replace(/ +/g, replaceValue);
+    }
+
+    static escapeRegExp(text): string {
+        return text.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
+    }
+}


### PR DESCRIPTION
The ticket: [DDP-6752](https://broadinstitute.atlassian.net/browse/DDP-6752)
Also see [the slack discussion](https://broadinstitute.slack.com/archives/C02AAP2AM98/p1628262486037600).

Implemented: 
symbols `dash` ('-'), `slash`('/') are also treated as a `space` (' ') in Pancan cancers list autocomplete search.
![b1](https://user-images.githubusercontent.com/7396837/130064982-3df69f17-9ead-428b-b15e-9488364c3d5d.png)
![b2](https://user-images.githubusercontent.com/7396837/130064989-c382feaf-7006-482c-92e6-2b8d03bdae2b.png)
![b3](https://user-images.githubusercontent.com/7396837/130064992-232b4282-dc70-4554-b58f-74902b2fd015.png)

Known issue (extra benefit?) :
Any symbols from `substitutableSymbols` are interchangeable.
Typing 'B/cell' will find 'B/cell' / 'B-cell' / 'B cell' etc.
Requiring strict independent matching is puzzling some kind of generic implementation.
