### PR TITLE
DDP-6831 do not call for user profile if user is temporal

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/internationalization/languageSelector.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/internationalization/languageSelector.component.ts
@@ -241,7 +241,7 @@ export class LanguageSelectorComponent implements OnInit, OnDestroy {
                     return null;
                 }
             }));
-        return iif(() => this.hasUserProfile(), profileLangObservable, of(null));
+        return iif(() => this.session.isAuthenticatedSession(), profileLangObservable, of(null));
     }
 
     private hasUserProfile(): boolean {


### PR DESCRIPTION
regresssion after https://github.com/broadinstitute/ddp-angular/pull/811
just shouldn't have changed this line, returned it back (we definitely don't need to call for profile for temp users)