### PR TITLE
Add delay of 2 secs delay after all busyness has ceased before proceeding with activity PUT

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/baseActivity.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/baseActivity.component.ts
@@ -203,6 +203,8 @@ export abstract class BaseActivityComponent implements OnChanges, OnDestroy {
                     filter(isPageBusy => !isPageBusy),
                     take(1))
                 ),
+                // extra buffer to allow for asynchronous saves like mailing address to complete
+                delay(2000),
                 // if we can't save we are not going past filter, so do necessary cleanup here
                 tap(() => !this.isAllFormContentValid.value && (this.dataEntryDisabled = false)),
                 filter(() => this.isAllFormContentValid.value),


### PR DESCRIPTION
This is the other part of fix discussed in pull request https://github.com/broadinstitute/ddp-study-server/pull/982

The code appeared to be doing the right thing, even doing manual tests locally (withholding response from server when mailing address was saved to ensure it final PUT/activity submit did not execute early).

But server data shows that the strict serialization we were going for was somehow failing. So added a couple of secs buffer on top of retries on the server waiting for mailing address when doing snapshots.