### PR TITLE
DDP-6884 remove redundant EasyPost streetRequiredError

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.ts
@@ -42,7 +42,7 @@ import { AddressError } from '../../models/addressError';
 import { AddressVerificationStatus } from '../../models/addressVerificationStatus';
 import { AddressInputComponent } from './addressInput.component';
 import { MailAddressBlock } from '../../models/activity/MailAddressBlock';
-import { generateTaggedAddress, isStreetRequiredError } from './addressUtils';
+import { generateTaggedAddress } from './addressUtils';
 import { SubmitAnnouncementService } from '../../services/submitAnnouncement.service';
 import { AddressVerificationWarnings } from '../../models/addressVerificationWarnings';
 import { NGXTranslateService } from '../../services/internationalization/ngxTranslate.service';
@@ -488,10 +488,6 @@ export class AddressEmbeddedComponent implements OnDestroy, OnInit {
                     if (currError.field === 'address') {
                         // These are the "global" errors reported by EasyPost
                         errorUpdate.formErrorMessages.push(currError.message);
-                    } else if (isStreetRequiredError(currError)) {
-                        // Seems like EasyPost needs a street address before it verifies other fields.
-                        // Since street1 might not be filled yet, transform message into a "global" error message.
-                        errorUpdate.formErrorMessages.push('Street address is missing, could not verify address.');
                     } else {
                         errorUpdate.fieldErrors.push(currError);
                     }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressUtils.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressUtils.ts
@@ -1,5 +1,4 @@
 import { Address } from '../../models/address';
-import { AddressError } from '../../models/addressError';
 
 type AddressPropName = keyof Address;
 
@@ -75,16 +74,4 @@ export const tagDifferences = (str1: string, str2: string, tag: string): string 
     }
 
     return result;
-};
-
-/**
- * Check to see if error is about EasyPost requiring street address.
- *
- * param {AddressError} error the address verification error object
- * returns {boolean}
- */
-export const isStreetRequiredError = (error: AddressError): boolean => {
-    return error.field === 'street1' &&
-        error.code === 'E.INPUT.INVALID' &&
-        error.message.toLowerCase().indexOf('required') !== -1;
 };


### PR DESCRIPTION
after analizing the current behavior I can say that streetRequired error is not relevant anymore for our component since when the street is not provided we don't request verification on easy post since the form is invalid. 
I also wasn't able to find 'E.INPUT.INVALID' code in backend repo