### PR TITLE
Circadia: Sleep Log integration

### DIFF
--- a/config/pepperConfig.js.ctmpl
+++ b/config/pepperConfig.js.ctmpl
@@ -276,6 +276,10 @@ var DDP_ENV = {
 {{end}}
 
 {{if eq $study_guid "circadia"}}
+    {{with secret (printf "secret/pepper/%s/%s/%s/conf" $environment $version $study) }}
+        DDP_ENV['sleepLogConnectorUrl'] = "{{.Data.sleepLogConnectorUrl}}",
+    {{end}}
+
     {{if eq $environment "local"}}
         DDP_ENV['auth0ClientId'] = "GMMFtLjB1c38Fmr3UVEm8WqBsvCIeJ9d";
         DDP_ENV['auth0Domain'] = "circadia-dev.us.auth0.com";

--- a/ddp-workspace/projects/ddp-circadia/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-circadia/src/app/app.module.ts
@@ -1,7 +1,8 @@
 import { NgModule, Injector, APP_INITIALIZER } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { LOCATION_INITIALIZED } from '@angular/common';
+import { DatePipe, LOCATION_INITIALIZED } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { HttpClientModule } from '@angular/common/http';
 import { TranslateService } from '@ngx-translate/core';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
@@ -142,6 +143,7 @@ export function translateFactory(
     BrowserModule,
     FormsModule,
     ReactiveFormsModule,
+    HttpClientModule,
     MatExpansionModule,
     MatProgressSpinnerModule,
     MatFormFieldModule,
@@ -156,6 +158,7 @@ export function translateFactory(
     AppRoutingModule,
   ],
   providers: [
+    DatePipe,
     {
       provide: 'ddp.config',
       useValue: sdkConfig,

--- a/ddp-workspace/projects/ddp-circadia/src/app/components/pages/dashboard/dashboard.component.html
+++ b/ddp-workspace/projects/ddp-circadia/src/app/components/pages/dashboard/dashboard.component.html
@@ -12,6 +12,9 @@
   <app-user-activities
     [activities]="activities"
     [sleepLogUrl]="diaryUrl"
+    [sleepLogStatus]="diaryStatus"
+    [sleepLogUrlError]="diaryUrlError"
+    [sleepLogStatusError]="diaryStatusError"
     (startActivity)="onStartActivity($event)"
     (continueActivity)="onContinueActivity($event)"
     (viewActivity)="onViewActivity($event)"

--- a/ddp-workspace/projects/ddp-circadia/src/app/components/pages/dashboard/dashboard.component.html
+++ b/ddp-workspace/projects/ddp-circadia/src/app/components/pages/dashboard/dashboard.component.html
@@ -11,6 +11,7 @@
 <ng-template #userActivities>
   <app-user-activities
     [activities]="activities"
+    [sleepLogUrl]="diaryUrl"
     (startActivity)="onStartActivity($event)"
     (continueActivity)="onContinueActivity($event)"
     (viewActivity)="onViewActivity($event)"

--- a/ddp-workspace/projects/ddp-circadia/src/app/components/pages/dashboard/dashboard.component.ts
+++ b/ddp-workspace/projects/ddp-circadia/src/app/components/pages/dashboard/dashboard.component.ts
@@ -76,6 +76,18 @@ export class DashboardComponent implements OnInit, OnDestroy {
     return this.sleepLogService.diaryUrl$.getValue();
   }
 
+  get diaryStatus(): string | null {
+    return this.sleepLogService.diaryStatus$.getValue();
+  }
+
+  get diaryStatusError(): boolean | null {
+    return this.sleepLogService.diaryStatusError$.getValue();
+  }
+
+  get diaryUrlError(): boolean | null {
+    return this.sleepLogService.diaryUrlError$.getValue();
+  }
+
   private fetchData(): Observable<{
     activities: ActivityInstance[];
     announcements: AnnouncementMessage[];

--- a/ddp-workspace/projects/ddp-circadia/src/app/components/pages/dashboard/dashboard.component.ts
+++ b/ddp-workspace/projects/ddp-circadia/src/app/components/pages/dashboard/dashboard.component.ts
@@ -1,15 +1,19 @@
 import { Component, Inject, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { of } from 'rxjs';
-import { take } from 'rxjs/operators';
+import { forkJoin, Observable, of } from 'rxjs';
+import { concatMap, map, take, tap } from 'rxjs/operators';
 
 import {
   ActivityInstance,
+  AnnouncementMessage,
+  AnnouncementsServiceAgent,
   ConfigurationService,
   UserActivityServiceAgent,
 } from 'ddp-sdk';
 
 import { Route } from '../../../constants/route';
+import { ActivityCode } from '../../../constants/activity-code';
+import { SleepLogService } from '../../../services/sleep-log.service';
 
 @Component({
   selector: 'app-dashboard',
@@ -23,11 +27,29 @@ export class DashboardComponent implements OnInit {
   constructor(
     private router: Router,
     private userActivityService: UserActivityServiceAgent,
+    private announcementsService: AnnouncementsServiceAgent,
     @Inject('ddp.config') private config: ConfigurationService,
+    private sleepLogService: SleepLogService,
   ) {}
 
   ngOnInit(): void {
-    this.fetchActivities();
+    this.fetchData()
+      .pipe(
+        map(({ activities, announcements }) => ({
+          activities,
+          sleepLogCodes:
+            this.sleepLogService.extractSleepLogAnnouncements(announcements),
+        })),
+        concatMap(({ activities, sleepLogCodes }) =>
+          this.sleepLogService.runSleepLogActions(
+            sleepLogCodes,
+            !!activities.find(
+              activity => activity.activityCode === ActivityCode.MiniSleepLog,
+            ),
+          ),
+        ),
+      )
+      .subscribe();
   }
 
   onStartActivity(activity: ActivityInstance): void {
@@ -42,15 +64,40 @@ export class DashboardComponent implements OnInit {
     this.router.navigate([Route.Activity, activity.instanceGuid]);
   }
 
-  private fetchActivities(): void {
+  get diaryUrl(): string | null {
+    return this.sleepLogService.diaryUrl$.getValue();
+  }
+
+  private fetchData(): Observable<{
+    activities: ActivityInstance[];
+    announcements: AnnouncementMessage[];
+  }> {
     this.loading = true;
 
-    this.userActivityService
-      .getActivities(of(this.config.studyGuid))
-      .pipe(take(1))
-      .subscribe(activities => {
-        this.activities = activities;
+    return forkJoin({
+      activities: this.fetchActivities(),
+      announcements: this.fetchAnnouncements(),
+    }).pipe(
+      tap(() => {
         this.loading = false;
-      });
+      }),
+    );
+  }
+
+  private fetchActivities(): Observable<ActivityInstance[]> {
+    return this.userActivityService
+      .getActivities(of(this.config.studyGuid))
+      .pipe(
+        take(1),
+        tap(activities => {
+          this.activities = activities;
+        }),
+      );
+  }
+
+  private fetchAnnouncements(): Observable<AnnouncementMessage[]> {
+    return this.announcementsService
+      .getMessages(this.config.studyGuid)
+      .pipe(take(1));
   }
 }

--- a/ddp-workspace/projects/ddp-circadia/src/app/components/user-activities/user-activities.component.html
+++ b/ddp-workspace/projects/ddp-circadia/src/app/components/user-activities/user-activities.component.html
@@ -105,6 +105,23 @@
           </button>
         </ng-container>
 
+        <ng-container *ngSwitchCase="ActivityCode.MiniSleepLog">
+          <mat-spinner
+            *ngIf="!sleepLogUrl"
+            diameter="32"
+            style="margin: 6px 0 6px 1.5em;"
+          ></mat-spinner>
+
+          <a
+            *ngIf="sleepLogUrl"
+            class="button button--sm button--yellow-outline"
+            target="_blank"
+            [href]="sleepLogUrl"
+          >
+            {{ 'UserActivities.Actions.Start' | translate }}
+          </a>
+        </ng-container>
+
         <ng-container *ngSwitchDefault>
           <button
             *ngIf="activity.statusCode === ActivityStatusCode.CREATED"

--- a/ddp-workspace/projects/ddp-circadia/src/app/components/user-activities/user-activities.component.html
+++ b/ddp-workspace/projects/ddp-circadia/src/app/components/user-activities/user-activities.component.html
@@ -46,6 +46,45 @@
           &mdash;
         </ng-container>
 
+        <ng-container *ngSwitchCase="ActivityCode.MiniSleepLog">
+          <div class="activity-status">
+            <ng-container *ngIf="sleepLogStatusError">
+              &mdash;
+            </ng-container>
+
+            <mat-spinner
+              *ngIf="!sleepLogStatus && sleepLogStatusError === null"
+              diameter="32"
+              style="margin: 6px 0 6px 1.5em;"
+            ></mat-spinner>
+
+            <ng-container *ngIf="sleepLogStatus">
+              <ng-container
+                *ngIf="sleepLogStatus === ActivityStatusCode.CREATED"
+              >
+                <mat-icon class="status-icon status-icon--created">info</mat-icon
+                >{{ 'UserActivities.Statuses.Created' | translate }}
+              </ng-container>
+
+              <ng-container
+                *ngIf="sleepLogStatus === ActivityStatusCode.IN_PROGRESS"
+              >
+                <mat-icon class="status-icon status-icon--in-progress"
+                  >pending</mat-icon
+                >{{ 'UserActivities.Statuses.InProgress' | translate }}
+              </ng-container>
+
+              <ng-container
+                *ngIf="sleepLogStatus === ActivityStatusCode.COMPLETE"
+              >
+                <mat-icon class="status-icon status-icon--complete"
+                  >check_circle</mat-icon
+                >{{ 'UserActivities.Statuses.Complete' | translate }}
+              </ng-container>
+            </ng-container>
+          </div>
+        </ng-container>
+
         <ng-container *ngSwitchDefault>
           <div class="activity-status">
             <ng-container
@@ -106,20 +145,42 @@
         </ng-container>
 
         <ng-container *ngSwitchCase="ActivityCode.MiniSleepLog">
+          <ng-container *ngIf="sleepLogUrlError">
+            &mdash;
+          </ng-container>
+
           <mat-spinner
-            *ngIf="!sleepLogUrl"
+            *ngIf="!sleepLogUrl && sleepLogUrlError === null"
             diameter="32"
             style="margin: 6px 0 6px 1.5em;"
           ></mat-spinner>
 
-          <a
-            *ngIf="sleepLogUrl"
-            class="button button--sm button--yellow-outline"
-            target="_blank"
-            [href]="sleepLogUrl"
-          >
-            {{ 'UserActivities.Actions.Start' | translate }}
-          </a>
+          <ng-container *ngIf="sleepLogUrl">
+            <a
+              target="_blank"
+              [href]="sleepLogUrl"
+              class="button button--sm button--yellow-outline"
+              *ngIf="sleepLogStatus === ActivityStatusCode.CREATED"
+            >
+              {{ 'UserActivities.Actions.Start' | translate }}
+            </a>
+            <a
+              target="_blank"
+              [href]="sleepLogUrl"
+              class="button button--sm button--yellow-outline"
+              *ngIf="sleepLogStatus === ActivityStatusCode.IN_PROGRESS"
+            >
+              {{ 'UserActivities.Actions.Continue' | translate }}
+            </a>
+            <a
+              target="_blank"
+              [href]="sleepLogUrl"
+              class="button button--sm button--blue"
+              *ngIf="sleepLogStatus === ActivityStatusCode.COMPLETE"
+            >
+              {{ 'UserActivities.Actions.View' | translate }}
+            </a>
+          </ng-container>
         </ng-container>
 
         <ng-container *ngSwitchDefault>

--- a/ddp-workspace/projects/ddp-circadia/src/app/components/user-activities/user-activities.component.ts
+++ b/ddp-workspace/projects/ddp-circadia/src/app/components/user-activities/user-activities.component.ts
@@ -12,6 +12,9 @@ import { ActivityCode } from '../../constants/activity-code';
 export class UserActivitiesComponent {
   @Input() activities: ActivityInstance[];
   @Input() sleepLogUrl: string | null = null;
+  @Input() sleepLogStatus: string | null = null;
+  @Input() sleepLogUrlError: boolean | null = null;
+  @Input() sleepLogStatusError: boolean | null = null;
   @Output() startActivity = new EventEmitter<ActivityInstance>();
   @Output() continueActivity = new EventEmitter<ActivityInstance>();
   @Output() viewActivity = new EventEmitter<ActivityInstance>();

--- a/ddp-workspace/projects/ddp-circadia/src/app/components/user-activities/user-activities.component.ts
+++ b/ddp-workspace/projects/ddp-circadia/src/app/components/user-activities/user-activities.component.ts
@@ -11,6 +11,7 @@ import { ActivityCode } from '../../constants/activity-code';
 })
 export class UserActivitiesComponent {
   @Input() activities: ActivityInstance[];
+  @Input() sleepLogUrl: string | null = null;
   @Output() startActivity = new EventEmitter<ActivityInstance>();
   @Output() continueActivity = new EventEmitter<ActivityInstance>();
   @Output() viewActivity = new EventEmitter<ActivityInstance>();

--- a/ddp-workspace/projects/ddp-circadia/src/app/constants/http-method.ts
+++ b/ddp-workspace/projects/ddp-circadia/src/app/constants/http-method.ts
@@ -1,0 +1,5 @@
+export enum HttpMethod {
+  Get = 'GET',
+  Post = 'POST',
+  Put = 'PUT',
+}

--- a/ddp-workspace/projects/ddp-circadia/src/app/constants/sleep-log-code.ts
+++ b/ddp-workspace/projects/ddp-circadia/src/app/constants/sleep-log-code.ts
@@ -1,0 +1,7 @@
+export enum SleepLogCode {
+  CreateUser = 'SLEEP_LOG__CREATE_USER',
+}
+
+export enum UtilitySleepLogCode {
+  GetInfo = 'SLEEP_LOG__GET_INFO',
+}

--- a/ddp-workspace/projects/ddp-circadia/src/app/constants/sleep-log-code.ts
+++ b/ddp-workspace/projects/ddp-circadia/src/app/constants/sleep-log-code.ts
@@ -4,4 +4,5 @@ export enum SleepLogCode {
 
 export enum UtilitySleepLogCode {
   GetInfo = 'SLEEP_LOG__GET_INFO',
+  GetDiary = 'SLEEP_LOG__GET_DIARY',
 }

--- a/ddp-workspace/projects/ddp-circadia/src/app/interfaces/CommonSleepLogProxyPayload.ts
+++ b/ddp-workspace/projects/ddp-circadia/src/app/interfaces/CommonSleepLogProxyPayload.ts
@@ -1,0 +1,8 @@
+import { HttpMethod } from '../constants/http-method';
+
+export interface CommonSleepLogProxyPayload {
+  auth0ClientId: string;
+  auth0Domain: string;
+  url: string;
+  method: HttpMethod;
+}

--- a/ddp-workspace/projects/ddp-circadia/src/app/interfaces/CreateUserPayload.ts
+++ b/ddp-workspace/projects/ddp-circadia/src/app/interfaces/CreateUserPayload.ts
@@ -2,6 +2,4 @@ import { CommonSleepLogProxyPayload } from './CommonSleepLogProxyPayload';
 
 export interface CreateUserPayload extends CommonSleepLogProxyPayload {
   email: string;
-  start: string;
-  end: string;
 }

--- a/ddp-workspace/projects/ddp-circadia/src/app/interfaces/CreateUserPayload.ts
+++ b/ddp-workspace/projects/ddp-circadia/src/app/interfaces/CreateUserPayload.ts
@@ -1,0 +1,7 @@
+import { CommonSleepLogProxyPayload } from './CommonSleepLogProxyPayload';
+
+export interface CreateUserPayload extends CommonSleepLogProxyPayload {
+  email: string;
+  start: string;
+  end: string;
+}

--- a/ddp-workspace/projects/ddp-circadia/src/app/interfaces/CreateUserResponse.ts
+++ b/ddp-workspace/projects/ddp-circadia/src/app/interfaces/CreateUserResponse.ts
@@ -1,0 +1,16 @@
+export interface CreateUserResponse {
+  email: string;
+  start: {
+    date: string;
+    timezone_type: number;
+    timezone: string;
+  };
+  end: {
+    date: string;
+    timezone_type: number;
+    timezone: string;
+  };
+  cohort: string;
+  unique_id: string;
+  diary_url: string;
+}

--- a/ddp-workspace/projects/ddp-circadia/src/app/interfaces/DiaryResponse.ts
+++ b/ddp-workspace/projects/ddp-circadia/src/app/interfaces/DiaryResponse.ts
@@ -1,0 +1,7 @@
+export interface DiaryResponse {
+  email: string;
+  cohort: string;
+  active: boolean;
+  end_date: string;
+  completed: boolean;
+}

--- a/ddp-workspace/projects/ddp-circadia/src/app/interfaces/GetUserInfoPayload.ts
+++ b/ddp-workspace/projects/ddp-circadia/src/app/interfaces/GetUserInfoPayload.ts
@@ -1,0 +1,5 @@
+import { CommonSleepLogProxyPayload } from './CommonSleepLogProxyPayload';
+
+export interface GetUserInfoPayload extends CommonSleepLogProxyPayload {
+  email: string;
+}

--- a/ddp-workspace/projects/ddp-circadia/src/app/interfaces/UserInfoResponse.ts
+++ b/ddp-workspace/projects/ddp-circadia/src/app/interfaces/UserInfoResponse.ts
@@ -1,0 +1,16 @@
+export interface UserInfoResponse {
+  email: string;
+  start: {
+    date: string;
+    timezone_type: number;
+    timezone: string;
+  };
+  end: {
+    date: string;
+    timezone_type: number;
+    timezone: string;
+  };
+  cohort: string;
+  unique_id: string;
+  diary_url: string;
+}

--- a/ddp-workspace/projects/ddp-circadia/src/app/services/sleep-log.service.ts
+++ b/ddp-workspace/projects/ddp-circadia/src/app/services/sleep-log.service.ts
@@ -1,0 +1,193 @@
+import { Inject, Injectable } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { BehaviorSubject, from, Observable, of } from 'rxjs';
+import { catchError, concatMap, filter, take, tap } from 'rxjs/operators';
+
+import {
+  AnnouncementMessage,
+  AnnouncementsServiceAgent,
+  Auth0AdapterService,
+  ConfigurationService,
+  LoggingService,
+  SessionMementoService,
+} from 'ddp-sdk';
+
+import { HttpMethod } from '../constants/http-method';
+import { SleepLogCode, UtilitySleepLogCode } from '../constants/sleep-log-code';
+import { GetUserInfoPayload } from '../interfaces/GetUserInfoPayload';
+import { UserInfoResponse } from '../interfaces/UserInfoResponse';
+import { CreateUserPayload } from '../interfaces/CreateUserPayload';
+import { CreateUserResponse } from '../interfaces/CreateUserResponse';
+import { CommonSleepLogProxyPayload } from '../interfaces/CommonSleepLogProxyPayload';
+
+declare const DDP_ENV: Record<string, any>;
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SleepLogService {
+  private static readonly CONNECTOR_URL: string = DDP_ENV.sleepLogConnectorUrl;
+  private static readonly SLEEP_LOG_CODES: string[] =
+    Object.values(SleepLogCode);
+  private static readonly LOG_SOURCE = 'SleepLogService';
+  private static readonly WEEK_MS = 6.048e8;
+  private static readonly SLEEP_LOG_DURATION_MULTIPLIER = 6;
+  private static readonly DATE_FORMAT = 'yyyy-MM-dd';
+  diaryUrl$ = new BehaviorSubject<string | null>(null);
+  private userEmail: string | null = null;
+  private initialized$ = new BehaviorSubject<boolean>(false);
+
+  constructor(
+    private http: HttpClient,
+    private datePipe: DatePipe,
+    private sessionService: SessionMementoService,
+    private auth0Service: Auth0AdapterService,
+    private loggingService: LoggingService,
+    private announcementsService: AnnouncementsServiceAgent,
+    @Inject('ddp.config') private config: ConfigurationService,
+  ) {
+    this.sessionService.sessionObservable
+      .pipe(
+        filter(session => !!session && !!session.accessToken),
+        tap(({ accessToken }) =>
+          this.auth0Service.webAuth.client.userInfo(
+            accessToken,
+            (err, user) => {
+              if (err) {
+                this.loggingService.logError(
+                  SleepLogService.LOG_SOURCE,
+                  'Error occured when tried to fetch user info',
+                  err,
+                );
+
+                return;
+              }
+
+              this.userEmail = user.name;
+              this.initialized$.next(true);
+            },
+          ),
+        ),
+        take(1),
+      )
+      .subscribe();
+  }
+
+  extractSleepLogAnnouncements(
+    announcements: AnnouncementMessage[],
+  ): SleepLogCode[] {
+    const sleepLogAnnouncements: SleepLogCode[] = [];
+
+    announcements.forEach(announcement => {
+      if (SleepLogService.SLEEP_LOG_CODES.includes(announcement.message)) {
+        sleepLogAnnouncements.push(announcement.message as SleepLogCode);
+      }
+    });
+
+    return sleepLogAnnouncements;
+  }
+
+  runSleepLogActions(
+    codes: SleepLogCode[],
+    hasSleepLogActivity: boolean,
+  ): Observable<CreateUserResponse | UserInfoResponse | null> {
+    let actions: (SleepLogCode | UtilitySleepLogCode)[] = [];
+
+    if (!codes.length) {
+      if (hasSleepLogActivity) {
+        actions = [UtilitySleepLogCode.GetInfo];
+      }
+    } else if (!codes.includes(SleepLogCode.CreateUser)) {
+      actions = [...actions, UtilitySleepLogCode.GetInfo];
+    } else {
+      actions = codes;
+    }
+
+    return this.initialized$.pipe(
+      filter(Boolean),
+      take(1),
+      concatMap(() => from(actions)),
+      concatMap(action => this.createSleepLogAction(action)),
+    );
+  }
+
+  private createSleepLogAction(
+    code: SleepLogCode | UtilitySleepLogCode,
+  ): Observable<any> {
+    switch (code) {
+      case SleepLogCode.CreateUser:
+        return this.createUser();
+      case UtilitySleepLogCode.GetInfo:
+        return this.getUserInfo();
+      default:
+        return of(null);
+    }
+  }
+
+  private createUser(): Observable<CreateUserResponse | null> {
+    const payload: CreateUserPayload = {
+      ...this.getCommonProxyPayload(HttpMethod.Post),
+      start: this.datePipe.transform(Date.now(), SleepLogService.DATE_FORMAT),
+      end: this.datePipe.transform(
+        Date.now() +
+          SleepLogService.SLEEP_LOG_DURATION_MULTIPLIER *
+            SleepLogService.WEEK_MS,
+        SleepLogService.DATE_FORMAT,
+      ),
+      email: this.userEmail,
+    };
+
+    return this.http
+      .post<CreateUserResponse>(SleepLogService.CONNECTOR_URL, payload)
+      .pipe(
+        tap(data => this.diaryUrl$.next(data.diary_url)),
+        catchError((err: HttpErrorResponse) => {
+          if (err.status === 409) {
+            // Account already exists for some reason
+            this.loggingService.logError(
+              SleepLogService.LOG_SOURCE,
+              'An account with this email already exists!',
+            );
+          } else {
+            // Unknown error
+            this.loggingService.logError(
+              SleepLogService.LOG_SOURCE,
+              'Unknown error during user registration in sleep log',
+              err,
+            );
+          }
+
+          return of(null);
+        }),
+      );
+  }
+
+  private getUserInfo(): Observable<UserInfoResponse | null> {
+    const payload: GetUserInfoPayload = {
+      ...this.getCommonProxyPayload(HttpMethod.Get),
+      email: this.userEmail,
+    };
+
+    return this.http
+      .post<UserInfoResponse>(SleepLogService.CONNECTOR_URL, payload)
+      .pipe(
+        tap(data => {
+          this.diaryUrl$.next(data.diary_url);
+        }),
+        catchError(() => of(null)),
+      );
+  }
+
+  private getCommonProxyPayload(
+    method: HttpMethod,
+    url = 'api/user/',
+  ): CommonSleepLogProxyPayload {
+    return {
+      auth0Domain: this.config.auth0Domain,
+      auth0ClientId: this.config.auth0ClientId,
+      url,
+      method,
+    };
+  }
+}

--- a/ddp-workspace/projects/ddp-circadia/src/app/services/sleep-log.service.ts
+++ b/ddp-workspace/projects/ddp-circadia/src/app/services/sleep-log.service.ts
@@ -50,6 +50,7 @@ export class SleepLogService {
     this.sessionService.sessionObservable
       .pipe(
         filter(session => !!session && !!session.accessToken),
+        take(1),
         tap(({ accessToken }) =>
           this.auth0Service.webAuth.client.userInfo(
             accessToken,
@@ -69,7 +70,6 @@ export class SleepLogService {
             },
           ),
         ),
-        take(1),
       )
       .subscribe();
   }


### PR DESCRIPTION
This PR introduces integration between Circadia study and BWH product - Sleep Log.
All requests are first issued to the GCP cloud function proxy which in turn makes request to Sleep Log API.
A simple link is displayed on participants dashboard which opens a new window with daily questionnaire.

Note: a cloud function used for this feature expects to receive Auth `clientId`. Since we plan to use this function locally AND on `dev` we have to pass `clientId` for `dev` env even if app is running locally.