### PR TITLE
[PANCAN] Close header menu when window is resized

### DIFF
--- a/ddp-workspace/projects/ddp-pancan/src/app/components/header/header.component.ts
+++ b/ddp-workspace/projects/ddp-pancan/src/app/components/header/header.component.ts
@@ -37,4 +37,8 @@ export class HeaderComponent implements OnInit {
             || this.document.body.scrollTop || 0;
         this.isPageScrolled = !!scrolledPixels;
     }
+
+    @HostListener('window: resize') public onWindowResize(): void {
+        this.isPanelOpened = false;
+    }
 }


### PR DESCRIPTION
Fix a bug when a mobile header menu keeps opened by window resizing.