### PR TITLE
DDP-6924: Fix a bug when a composite list is not refreshed after some child deletion [Pancan]

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-composite-answer/activityCompositeAnswer.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-composite-answer/activityCompositeAnswer.component.ts
@@ -151,7 +151,9 @@ export class ActivityCompositeAnswer implements OnChanges {
 
     public removeRow(index: number): void {
         this.childQuestionBlocks.splice(index, 1);
-        this.valueChanged.emit(this.buildComponentAnswers());
+        const childAnswers = this.buildComponentAnswers();
+        this.block.setAnswer(childAnswers, false);
+        this.valueChanged.emit(childAnswers);
     }
 
     // We need this method because we want to include the prototype in the clone.


### PR DESCRIPTION
Note: the Not updating on the block data model caused the issue.