### PR TITLE
DDP-6752: *NEW* [Pancan] picklist autocomplete : treat the "-", '/' characters as a space.

### DIFF
--- a/ddp-workspace/projects/ddp-pancan/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-pancan/src/app/app.module.ts
@@ -91,7 +91,7 @@ sdkConfig.projectGcpId = DDP_ENV.projectGcpId;
 sdkConfig.doGcpErrorReporting = DDP_ENV.doGcpErrorReporting;
 sdkConfig.tooltipIconUrl = 'assets/images/info.png';
 sdkConfig.useStepsWithCircle = true;
-sdkConfig.picklistsWithNoSorting = ['PRIMARY_CANCER_SELF', 'PRIMARY_CANCER_CHILD'];
+sdkConfig.notSortedPicklistAutocompleteStableIds = ['PRIMARY_CANCER_SELF', 'PRIMARY_CANCER_CHILD'];
 
 export function translateFactory(translate: TranslateService,
     injector: Injector,

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activityPicklistAnswer.component.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activityPicklistAnswer.component.spec.ts
@@ -84,7 +84,7 @@ describe('ActivityPicklistAnswer', () => {
             providers: [
                 { provide: NGXTranslateService, useValue: ngxTranslateServiceSpy },
                 { provide: PicklistSortingPolicy, useValue: new PicklistSortingPolicy() },
-                { provide: 'ddp.config', useValue: { picklistsWithNoSorting: [] } }
+                { provide: 'ddp.config', useValue: { notSortedPicklistAutocompleteStableIds: [] } }
             ],
             declarations: [
                 TestHostComponent,

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.spec.ts
@@ -66,7 +66,12 @@ describe('AutocompleteActivityPicklistQuestion', () => {
             providers: [
                 { provide: NGXTranslateService, useValue: ngxTranslateServiceSpy },
                 { provide: PicklistSortingPolicy, useValue:  new PicklistSortingPolicy() },
-                { provide: 'ddp.config', useValue: { picklistsWithNoSorting: [] } }
+                { provide: 'ddp.config',
+                    useValue: {
+                        notSortedPicklistAutocompleteStableIds: [],
+                        picklistAutocompleteIgnoredSymbols: []
+                    }
+                }
             ],
             declarations: [AutocompleteActivityPicklistQuestion, SearchHighlightPipe]
         }).compileComponents();
@@ -289,7 +294,11 @@ describe('AutocompleteActivityPicklistQuestion sorting (with default ALPHABETICA
 
     let component: AutocompleteActivityPicklistQuestion;
     let fixture: ComponentFixture<AutocompleteActivityPicklistQuestion>;
-    const configServiceSpy = jasmine.createSpyObj('ddp.config', null, {picklistsWithNoSorting: []});
+    const configServiceSpy = jasmine.createSpyObj('ddp.config', null,
+        {
+            notSortedPicklistAutocompleteStableIds: [],
+            picklistAutocompleteIgnoredSymbols: []
+        });
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -321,7 +330,7 @@ describe('AutocompleteActivityPicklistQuestion sorting (with default ALPHABETICA
     });
 
     it('should keep  options as is (do not sort alphabetically)', () => {
-        Object.defineProperty(configServiceSpy , 'picklistsWithNoSorting', {
+        Object.defineProperty(configServiceSpy , 'notSortedPicklistAutocompleteStableIds', {
             value: ['stableId123']
         });
         component.block.stableId = 'stableId123';

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
@@ -62,14 +62,7 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
     }
 
     public ngOnInit(): void {
-        const answer = this.block.answer && this.block.answer[0];
-        if (answer) {
-            const value = answer.detail || [
-                ...this.block.picklistGroups.flatMap(group => group.options),
-                ...this.block.picklistOptions
-            ].find(option => option.stableId === answer.stableId);
-            this.inputFormControl.setValue(value);
-        }
+        this.initInputValue();
 
         const userQueryStream$ = this.inputFormControl.valueChanges.pipe(
             map(value => typeof value === 'string' ? value.trim() : value),
@@ -88,12 +81,13 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
             sortedPicklistOptions = this.block.picklistOptions;
         }
 
-        userQueryStream$.pipe(startWith('')).subscribe((value: string | ActivityPicklistOption) => {
-            const query = typeof value === 'string' ? value : value.optionLabel;
-            this.filteredGroups = this.filterOutEmptyGroups(query ? this.filterGroups(query, sortedPicklistGroups)
-                : sortedPicklistGroups.slice());
-            this.filteredOptions = query ? this.filterOptions(query, sortedPicklistOptions) : sortedPicklistOptions.slice();
-        });
+        userQueryStream$.pipe(startWith(''))
+            .subscribe((value: string | ActivityPicklistOption) => {
+                const query = typeof value === 'string' ? value : value.optionLabel;
+                this.filteredGroups = this.filterOutEmptyGroups(query ? this.filterGroups(query, sortedPicklistGroups)
+                    : sortedPicklistGroups.slice());
+                this.filteredOptions = query ? this.filterOptions(query, sortedPicklistOptions) : sortedPicklistOptions.slice();
+            });
 
         userQueryStream$.subscribe((value: string | ActivityPicklistOption) => {
             if (typeof value === 'string') {
@@ -122,6 +116,17 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
         super.ngOnDestroy();
         this.ngUnsubscribe.next();
         this.ngUnsubscribe.complete();
+    }
+
+    private initInputValue(): void {
+        const answer = this.block.answer && this.block.answer[0];
+        if (answer) {
+            const value = answer.detail || [
+                ...this.block.picklistGroups.flatMap(group => group.options),
+                ...this.block.picklistOptions
+            ].find(option => option.stableId === answer.stableId);
+            this.inputFormControl.setValue(value);
+        }
     }
 
     private handleStringValue(value: string): void {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
@@ -23,13 +23,13 @@ import { StringsHelper } from '../../../utility/stringsHelper';
 
         <mat-autocomplete #autoCompleteFromSource="matAutocomplete" class="autoCompletePanel" [displayWith]="displayAutoComplete">
             <mat-optgroup *ngFor="let group of filteredGroups">
-                <strong [innerHtml]="group.name | searchHighlight: autocompleteInput.value"></strong>
+                <strong [innerHtml]="group.name | searchHighlight: autocompleteInput.value : ignoredSymbolsInQuery"></strong>
                 <ng-container *ngTemplateOutlet="generalOptionsList; context: {list: group.options}"></ng-container>
             </mat-optgroup>
             <ng-container *ngTemplateOutlet="generalOptionsList; context: {list: filteredOptions}"></ng-container>
             <ng-template #generalOptionsList let-list="list">
                 <mat-option *ngFor="let suggestion of list" class="autoCompleteOption" [value]="suggestion">
-                    <span [innerHtml]="suggestion.optionLabel | searchHighlight: autocompleteInput.value"></span>
+                    <span [innerHtml]="suggestion.optionLabel | searchHighlight: autocompleteInput.value : ignoredSymbolsInQuery"></span>
                 </mat-option>
             </ng-template>
         </mat-autocomplete>
@@ -49,7 +49,7 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
     // options w/o a group
     filteredOptions: ActivityPicklistOption[] = [];
     inputFormControl = new FormControl();
-    private readonly ignoredSymbolsInQuery;
+    readonly ignoredSymbolsInQuery: string[];
     private readonly ngUnsubscribe = new Subject();
 
     constructor(

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
@@ -11,8 +11,6 @@ import { PicklistSortingPolicy } from '../../../services/picklistSortingPolicy.s
 import { ConfigurationService } from '../../../services/configuration.service';
 import { StringsHelper } from '../../../utility/stringsHelper';
 
-const SEARCH_IGNORED_SYMBOLS = ['-', '/', '(', ')'];
-
 @Component({
     selector: 'ddp-activity-autocomplete-picklist-question',
     template: `
@@ -51,6 +49,7 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
     // options w/o a group
     filteredOptions: ActivityPicklistOption[] = [];
     inputFormControl = new FormControl();
+    private readonly ignoredSymbolsInQuery;
     private readonly ngUnsubscribe = new Subject();
 
     constructor(
@@ -59,6 +58,7 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
         @Inject('ddp.config') public config: ConfigurationService
     ) {
         super(translate);
+        this.ignoredSymbolsInQuery = this.config.picklistAutocompleteIgnoredSymbols;
     }
 
     public ngOnInit(): void {
@@ -171,8 +171,8 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
     }
 
     private isMatched(text: string, query: string): boolean {
-        const normalizedText = StringsHelper.normalizeString(text, SEARCH_IGNORED_SYMBOLS);
-        const normalizedQuery = StringsHelper.normalizeString(query, SEARCH_IGNORED_SYMBOLS);
+        const normalizedText = StringsHelper.normalizeString(text, this.ignoredSymbolsInQuery);
+        const normalizedQuery = StringsHelper.normalizeString(query, this.ignoredSymbolsInQuery);
         return StringsHelper.isIncluded(normalizedText, normalizedQuery);
     }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
@@ -71,7 +71,7 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
             this.inputFormControl.setValue(value);
         }
 
-        const userQueryStream = this.inputFormControl.valueChanges.pipe(
+        const userQueryStream$ = this.inputFormControl.valueChanges.pipe(
             map(value => typeof value === 'string' ? value.trim() : value),
             distinctUntilChanged(),
             debounceTime(200),
@@ -88,14 +88,14 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
             sortedPicklistOptions = this.block.picklistOptions;
         }
 
-        userQueryStream.pipe(startWith('')).subscribe((value: string | ActivityPicklistOption) => {
+        userQueryStream$.pipe(startWith('')).subscribe((value: string | ActivityPicklistOption) => {
             const query = typeof value === 'string' ? value : value.optionLabel;
             this.filteredGroups = this.filterOutEmptyGroups(query ? this.filterGroups(query, sortedPicklistGroups)
                 : sortedPicklistGroups.slice());
             this.filteredOptions = query ? this.filterOptions(query, sortedPicklistOptions) : sortedPicklistOptions.slice();
         });
 
-        userQueryStream.subscribe((value: string | ActivityPicklistOption) => {
+        userQueryStream$.subscribe((value: string | ActivityPicklistOption) => {
             if (typeof value === 'string') {
                 if (value.length) {
                     this.handleStringValue(value);

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
@@ -62,6 +62,8 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
     }
 
     public ngOnInit(): void {
+        // reset the sort policy for picklists which don't need to have sorted options
+        this.sortPolicy = this.shouldBeSorted ? this.sortPolicy : new PicklistSortingPolicy();
         this.initInputValue();
 
         const userQueryStream$ = this.inputFormControl.valueChanges.pipe(
@@ -71,15 +73,8 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
             takeUntil(this.ngUnsubscribe)
         );
 
-        let sortedPicklistGroups;
-        let sortedPicklistOptions;
-        if (this.shouldBeSorted) {
-            sortedPicklistGroups = this.sortPolicy.sortPicklistGroups(this.block.picklistGroups);
-            sortedPicklistOptions = this.sortPolicy.sortPicklistOptions(this.block.picklistOptions);
-        } else {
-            sortedPicklistGroups = this.block.picklistGroups;
-            sortedPicklistOptions = this.block.picklistOptions;
-        }
+        const sortedPicklistGroups = this.sortPolicy.sortPicklistGroups(this.block.picklistGroups);
+        const sortedPicklistOptions = this.sortPolicy.sortPicklistOptions(this.block.picklistOptions);
 
         userQueryStream$.pipe(startWith(''))
             .subscribe((value: string | ActivityPicklistOption) => {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
@@ -159,7 +159,7 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
     }
 
     private get shouldBeSorted(): boolean {
-        return !this.config.picklistsWithNoSorting.includes(this.block.stableId);
+        return !this.config.notSortedPicklistAutocompleteStableIds.includes(this.block.stableId);
     }
 
     private filterOutEmptyGroups(groups: ActivityPicklistNormalizedGroup[]): ActivityPicklistNormalizedGroup[] {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/pipes/searchHighlight.pipe.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/pipes/searchHighlight.pipe.ts
@@ -1,13 +1,16 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import { StringsHelper } from '../utility/stringsHelper';
 
 @Pipe({
     name: 'searchHighlight'
 })
 export class SearchHighlightPipe implements PipeTransform {
-    transform(text: string, search: string): string {
+    transform(text: string, search: string, ignoredSymbols?: string[]): string {
+        const normalizedSearch = StringsHelper.normalizeString(search, ignoredSymbols || []);
+
         // copied from
         // https://stackoverflow.com/questions/49653410/mat-autocomplete-filter-to-hightlight-partial-string-matches#answer-49670236
-        const pattern = search
+        const pattern = normalizedSearch
             .replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')
             .split(' ')
             .filter(t => t.length > 0)

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/configuration.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/configuration.service.ts
@@ -74,4 +74,6 @@ export class ConfigurationService {
     prismRoute: string;
     // autocompletePicklists which don't need to be sorted
     notSortedPicklistAutocompleteStableIds: string[] = [];
+    // symbols which should be ignored in autocompletePicklist query (treat as a space)
+    picklistAutocompleteIgnoredSymbols: string[] = ['-', '/', '(', ')'];
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/configuration.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/configuration.service.ts
@@ -72,5 +72,6 @@ export class ConfigurationService {
     prismColumns: string[] = [];
     prismDashboardRoute: string;
     prismRoute: string;
-    picklistsWithNoSorting: string[] = [];
+    // autocompletePicklists which don't need to be sorted
+    notSortedPicklistAutocompleteStableIds: string[] = [];
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/picklistSortingPolicy.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/picklistSortingPolicy.service.ts
@@ -7,7 +7,6 @@ import { ActivityPicklistOption } from '../models/activity/activityPicklistOptio
 export class PicklistSortingPolicy {
     constructor(readonly mainSortOrder: SortOrder = SortOrder.NONE, readonly lastStableId?: string) {}
 
-
     public sortPicklistGroups(groups: ActivityPicklistNormalizedGroup[]): ActivityPicklistNormalizedGroup[] {
         const groupsCopy = groups.slice();
         if (this.mainSortOrder === SortOrder.ALPHABETICAL) {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/utility/stringsHelper.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/utility/stringsHelper.ts
@@ -1,5 +1,7 @@
 export class StringsHelper {
     static normalizeString(text: string, ignoredSymbols: string[], separator: string = ' '): string {
+        if (ignoredSymbols.length === 0) return text;
+
         return ignoredSymbols.reduce((acc, symbol) => {
             return acc.split(symbol)
                 .map(word => word.trim())

--- a/ddp-workspace/projects/ddp-sdk/src/lib/utility/stringsHelper.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/utility/stringsHelper.ts
@@ -1,0 +1,14 @@
+export class StringsHelper {
+    static normalizeString(text: string, ignoredSymbols: string[], separator: string = ' '): string {
+        return ignoredSymbols.reduce((acc, symbol) => {
+            return acc.split(symbol)
+                .map(word => word.trim())
+                .join(separator);
+        }, text.toLowerCase());
+    }
+
+    static isIncluded(text: string, query: string, separator: string = ' '): boolean {
+        return query.split(separator)
+            .every(word => text.includes(word));
+    }
+}


### PR DESCRIPTION
Another implementation approach.
Also fixed needed comments suggested in the [previous PR#842](https://github.com/broadinstitute/ddp-angular/pull/842)

The ticket: [DDP-6752](https://broadinstitute.atlassian.net/browse/DDP-6752)
Also see [the slack discussion](https://broadinstitute.slack.com/archives/C02AAP2AM98/p1628262486037600).

