### PR TITLE
DDP-6918: Fix Autocomplete list scrolling [Pancan] 

### DIFF
--- a/ddp-workspace/projects/ddp-pancan/src/app/components/header/header.component.scss
+++ b/ddp-workspace/projects/ddp-pancan/src/app/components/header/header.component.scss
@@ -5,7 +5,7 @@
     top: 0;
     left: 0;
     width: 100%;
-    z-index: 2000;
+    z-index: 1000;
     height: $header-height;
     transition: all 200ms linear;
     background-color: white;

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
@@ -197,7 +197,7 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
 
     onAutocompleteClose(): void {
         // reset z-index for the autocomplete overlay to default value (1000)
-        // in order to other components, which used the common overlay container (i.g. language-selector),
+        // in order to other components, which used the common overlay container (e.g. language-selector),
         // would have the default behavior
         this.setStyleToElement(this.overlayContainer, 'zIndex', '1000');
     }


### PR DESCRIPTION
The previous fix [PR#869](https://github.com/broadinstitute/ddp-angular/pull/869) causes to another non caught bug. 
We put autocomplete scroll under app header by scrolling. However other components (e.g. language selector) uses the same overlay container and also appear under the header. 

_See screenshots:_ (currently on dev, after the previous fix)
![image](https://user-images.githubusercontent.com/7396837/132020331-23b8921a-d6ad-4f15-886e-2c8fb1202875.png)
![image](https://user-images.githubusercontent.com/7396837/132020407-b6a6277d-c21a-4f8e-9324-277d14acb008.png)

It is quite tough (if possible?) to tweak it by css. And it is a [known Angular materials issue](https://github.com/angular/components/issues/1432).

So it should be done in another way. 
The simplest one is just closing any autocomplete suggestions list like it was done firstly (0171b33b052ea6806f296abc3ff2a9f5b5fd7079). 
On the other hand it's not a user friendly behavior.
Thus I have fixed it a bit tricky, but it is working. 

_See screenshots after the fix:_
![image](https://user-images.githubusercontent.com/7396837/132021479-a87c8a97-0761-4b57-92df-42482d24088b.png)
![image](https://user-images.githubusercontent.com/7396837/132021539-f9bf4540-76dc-45f4-87db-1e20df77166d.png)

