### PR TITLE
Fix default value for date question answer

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityDateAnswer.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityDateAnswer.component.ts
@@ -33,7 +33,7 @@ export class ActivityDateAnswer {
     constructor(private logger: LoggingService) { }
 
     public handleChange(value: DatePickerValue | null): void {
-        let dateValue: DatePickerValue | null = {
+        let dateValue: DatePickerValue = {
             month: null,
             day: null,
             year: null,

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityDateAnswer.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityDateAnswer.component.ts
@@ -33,7 +33,11 @@ export class ActivityDateAnswer {
     constructor(private logger: LoggingService) { }
 
     public handleChange(value: DatePickerValue | null): void {
-        let dateValue: DatePickerValue | null = null;
+        let dateValue: DatePickerValue | null = {
+            month: null,
+            day: null,
+            year: null,
+        };
 
         if (value !== null) {
             dateValue = {


### PR DESCRIPTION
Background: if user tried to clear out pre-populated value in date question or type something invalid, save request would fail with 400 and user would be redirected to `/error` page.
With this change a user can freely clear answers and get no error if a given answer is invalid but a red validation input underline.