### PR TITLE
Pancan: styling support for composite grid questions

### DIFF
--- a/ddp-workspace/projects/ddp-pancan/src/styles/activities.scss
+++ b/ddp-workspace/projects/ddp-pancan/src/styles/activities.scss
@@ -512,6 +512,7 @@ select:disabled {
                                 .mat-radio-group {
                                     display: flex !important;
                                     flex-flow: row nowrap !important;
+                                    align-items: center;
 
                                     height: 100%;
 
@@ -528,6 +529,8 @@ select:disabled {
                                                 margin: 0;
 
                                                 .mat-radio-label-content {
+                                                    display: none;
+
                                                     padding: 0;
 
                                                     font-size: 1rem;
@@ -548,57 +551,31 @@ select:disabled {
                             align-self: flex-end;
                         }
 
-                        > div {
-                            ddp-activity-radiobuttons-picklist-question {
-                                > div {
-                                    .mat-radio-group {
-                                        .margin-5 {
-                                            .mat-radio-button {
-                                                height: 100%;
+                        .mat-radio-group {
+                            align-items: stretch;
 
-                                                .mat-radio-label {
-                                                    display: flex;
-                                                    flex-flow: column-reverse nowrap;
-                                                    align-items: center !important;
+                            .margin-5 {
+                                .mat-radio-button {
+                                    height: 100%;
 
-                                                    height: 100%;
+                                    .mat-radio-label {
+                                        display: flex;
+                                        flex-flow: column-reverse nowrap;
+                                        align-items: center !important;
 
-                                                    .mat-radio-container {
-                                                        margin-top: 2rem;
-                                                    }
+                                        height: 100%;
 
-                                                    .mat-radio-label-content {
-                                                        margin-bottom: auto;
-                                                        padding: 0 0.25rem;
-
-                                                        text-align: center;
-                                                    }
-                                                }
-                                            }
+                                        .mat-radio-container {
+                                            margin-top: 2rem;
                                         }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
 
-                &:not(:first-of-type) {
-                    ddp-activity-picklist-answer {
-                        > div {
-                            ddp-activity-radiobuttons-picklist-question {
-                                > div {
-                                    .mat-radio-group {
-                                        align-items: center;
+                                        .mat-radio-label-content {
+                                            display: block;
 
-                                        .margin-5 {
-                                            .mat-radio-button {
-                                                .mat-radio-label {
-                                                    .mat-radio-label-content {
-                                                        display: none;
-                                                    }
-                                                }
-                                            }
+                                            margin-bottom: auto;
+                                            padding: 0 0.25rem;
+
+                                            text-align: center;
                                         }
                                     }
                                 }

--- a/ddp-workspace/projects/ddp-pancan/src/styles/activities.scss
+++ b/ddp-workspace/projects/ddp-pancan/src/styles/activities.scss
@@ -473,7 +473,7 @@ select:disabled {
     }
 }
 
-@media (min-width: 768px) {
+@media (min-width: $tablet-breakpoint) {
     [class*="composite-answer"][class*="GRID"] {
         .ddp-answer-container {
             margin-bottom: 2.5rem;
@@ -489,13 +489,11 @@ select:disabled {
                     ddp-question-prompt {
                         width: 10rem;
 
-                        > div {
-                            .ddp-question-prompt {
-                                margin: 0;
+                        .ddp-question-prompt {
+                            margin: 0;
 
-                                font-size: 1rem;
-                                line-height: 1.35;
-                            }
+                            font-size: 1rem;
+                            line-height: 1.35;
                         }
                     }
 

--- a/ddp-workspace/projects/ddp-pancan/src/styles/activities.scss
+++ b/ddp-workspace/projects/ddp-pancan/src/styles/activities.scss
@@ -473,4 +473,142 @@ select:disabled {
     }
 }
 
+@media (min-width: 768px) {
+    [class*="composite-answer"][class*="GRID"] {
+        .ddp-answer-container {
+            margin-bottom: 2.5rem;
 
+            .ddp-answer-field {
+                display: block;
+
+                ddp-activity-picklist-answer {
+                    display: flex;
+
+                    padding: 1rem 0;
+
+                    ddp-question-prompt {
+                        width: 10rem;
+
+                        > div {
+                            .ddp-question-prompt {
+                                margin: 0;
+
+                                font-size: 1rem;
+                                line-height: 1.35;
+                            }
+                        }
+                    }
+
+                    > div {
+                        flex: 1;
+
+                        ddp-activity-radiobuttons-picklist-question {
+                            display: block;
+
+                            width: 100%;
+                            height: 100%;
+
+                            > div {
+                                height: 100%;
+
+                                .mat-radio-group {
+                                    display: flex !important;
+                                    flex-flow: row nowrap !important;
+
+                                    height: 100%;
+
+                                    .margin-5 {
+                                        flex: 1;
+
+                                        margin: 0;
+
+                                        .mat-radio-button {
+                                            .mat-radio-label {
+                                                display: flex;
+                                                justify-content: center;
+
+                                                margin: 0;
+
+                                                .mat-radio-label-content {
+                                                    padding: 0;
+
+                                                    font-size: 1rem;
+                                                    line-height: 1.35;
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                &:first-of-type {
+                    ddp-activity-picklist-answer {
+                        ddp-question-prompt {
+                            align-self: flex-end;
+                        }
+
+                        > div {
+                            ddp-activity-radiobuttons-picklist-question {
+                                > div {
+                                    .mat-radio-group {
+                                        .margin-5 {
+                                            .mat-radio-button {
+                                                height: 100%;
+
+                                                .mat-radio-label {
+                                                    display: flex;
+                                                    flex-flow: column-reverse nowrap;
+                                                    align-items: center !important;
+
+                                                    height: 100%;
+
+                                                    .mat-radio-container {
+                                                        margin-top: 2rem;
+                                                    }
+
+                                                    .mat-radio-label-content {
+                                                        margin-bottom: auto;
+                                                        padding: 0 0.25rem;
+
+                                                        text-align: center;
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                &:not(:first-of-type) {
+                    ddp-activity-picklist-answer {
+                        > div {
+                            ddp-activity-radiobuttons-picklist-question {
+                                > div {
+                                    .mat-radio-group {
+                                        align-items: center;
+
+                                        .margin-5 {
+                                            .mat-radio-button {
+                                                .mat-radio-label {
+                                                    .mat-radio-label-content {
+                                                        display: none;
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds styles to arrange radio picklist questions in a grid using composite question as a group.
On mobile questions are arranged like before in a list one by one.
<img src="https://user-images.githubusercontent.com/71830582/133983952-0aba31ba-1ca3-4db4-8b76-00d02db19aef.png" width="400" />
