### PR TITLE
DDP-7072: FIx a bug when a user can register without entering diagnosis

### DIFF
--- a/ddp-workspace/angular.json
+++ b/ddp-workspace/angular.json
@@ -2825,7 +2825,7 @@
               "projects/study-builder-ui/e2e/tsconfig.json"
             ],
             "exclude": [
-              "**/node_modules/**"
+              "**"
             ]
           }
         },
@@ -2842,7 +2842,7 @@
           }
         }
       }
-    },
+    }
   },
   "defaultProject": "ddp-sdk",
   "schematics": {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityQuestion.component.ts
@@ -78,6 +78,7 @@ export class ActivityQuestionComponent implements OnInit, OnDestroy {
         ]).pipe(
             // not displaying any local validations until a validation is requested
             // except some unique cases
+            // TODO: try to fix/refactor the local validation globally as to avoid exceptions
             filter(([enteredValue, validationRequested]) => {
                 return (enteredValue && this.isExceptionToEnforceLocalValidation(this.block))
                     || !!validationRequested;

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityQuestion.component.ts
@@ -77,7 +77,7 @@ export class ActivityQuestionComponent implements OnInit, OnDestroy {
             this.validationRequested$
         ]).pipe(
             // not displaying any local validations until a validation is requested
-            // except some uniq cases
+            // except some unique cases
             filter(([enteredValue, validationRequested]) => {
                 return (enteredValue && this.isExceptionToEnforceLocalValidation(this.block))
                     || !!validationRequested;

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.spec.ts
@@ -237,14 +237,14 @@ describe('AutocompleteActivityPicklistQuestion', () => {
         expect(valueChangedSpy).not.toHaveBeenCalled();
     }));
 
-    it('should emit valueChanged with empty array if user resets the input', fakeAsync(() => {
+    it('should emit valueChanged with null if user resets the input', fakeAsync(() => {
         const valueChangedSpy = spyOn(component.valueChanged, 'emit');
         component.inputFormControl.setValue('');
         fixture.detectChanges();
         tick(200);
 
-        expect(component.block.answer).toEqual([]);
-        expect(valueChangedSpy).toHaveBeenCalledWith([]);
+        expect(component.block.answer).toEqual(null);
+        expect(valueChangedSpy).toHaveBeenCalledWith(null);
     }));
 
     it('should display suggested option correctly', () => {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
@@ -89,7 +89,8 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
                 if (value.length) {
                     this.handleStringValue(value);
                 } else {
-                    this.updateAnswer();
+                    this.block.answer = null;
+                    this.valueChanged.emit(null);
                 }
             } else {
                 this.updateAnswer(value.stableId);

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/activityRequiredValidationRule.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/activityRequiredValidationRule.spec.ts
@@ -5,6 +5,7 @@ import { ActivityDateQuestionBlock } from '../../../models/activity/activityDate
 import { ActivityAgreementQuestionBlock } from '../../../models/activity/activityAgreementQuestionBlock';
 import { ActivityQuestionBlock } from '../../../models/activity/activityQuestionBlock';
 import { ActivityRequiredValidationRule } from './activityRequiredValidationRule';
+import { ActivityCompositeQuestionBlock } from '../../../models/activity/activityCompositeQuestionBlock';
 
 let validator: ActivityRequiredValidationRule;
 const MESSAGE = 'This question is required!';
@@ -101,5 +102,37 @@ describe('ActivityRequiredValidationRule', () => {
         expect(validator.result).toBe(MESSAGE);
         question.answer = 'TEST';
         expect(validator.recalculate()).toBeTruthy();
+    });
+
+    it('should test required rule for Composite question', () => {
+        const question = new ActivityCompositeQuestionBlock();
+        question.answer = null;
+        validator = new ActivityRequiredValidationRule(question);
+        validator.message = MESSAGE;
+        expect(validator.recalculate()).toBeFalsy();
+        expect(validator.result).toBe(MESSAGE);
+
+        question.answer = [[
+            {
+                stableId: 'PRIMARY_CANCER_SELF',
+                value: null
+            }
+        ]];
+        expect(validator.recalculate()).toBeFalsy();
+        expect(validator.result).toBe(MESSAGE);
+
+        question.answer = [[
+            {
+                stableId: 'PRIMARY_CANCER_SELF',
+                value: [
+                    {
+                        stableId: 'OTHER_CANCER',
+                        detail: 'some custom value'
+                    }
+                ]
+            }
+        ]];
+        expect(validator.recalculate()).toBeTruthy();
+        expect(validator.result).toBeNull();
     });
 });

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/activityRequiredValidationRule.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/activityRequiredValidationRule.ts
@@ -33,6 +33,9 @@ export class ActivityRequiredValidationRule extends ActivityAbstractValidationRu
         } else if (this.question.questionType === QuestionType.Picklist) {
             const value = this.question.answer as Array<ActivityPicklistAnswerDto>;
             valid = value.length > 0;
+        } else if (this.question.questionType === QuestionType.Composite) {
+            const answers = this.question.answer as Array<any>;
+            valid = answers?.length && answers.flatMap(x => x).every(answer => answer.value);
         } else if (this.question.questionType === QuestionType.Text) {
             const value = this.question.answer as string;
             valid = value.trim().length > 0;


### PR DESCRIPTION
**_The idea_** - not validate composite question answers with null values.
And set null values explicitly if it is needed,
 e.g. in case when a user can enter/press the spacebar in the diagnosis field and it is accepted as input
(Pancan - Prequal)