### PR TITLE
Remove event emission when `readonly` is changed

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.ts
@@ -53,7 +53,7 @@ export class ActivityNumericAnswer implements OnInit, OnChanges, OnDestroy {
                 this.initForm();
             }
             if (propName === 'readonly' && !changes['readonly'].firstChange) {
-                this.readonly ? this.numericField.disable() : this.numericField.enable();
+                this.readonly ? this.numericField.disable({ emitEvent: false }) : this.numericField.enable({ emitEvent: false });
             }
         }
     }


### PR DESCRIPTION
Removed emission of event so that `valueChanges` observable subscriber would not be called when `readonly` prop has changed. It will remove any redundant `PATCH` requests when this numeric answer is enabled / disabled conditionally with new `enabled` feature.