### PR TITLE
Fix validation & error message render for enabled / disabled blocks

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityQuestion.component.ts
@@ -22,7 +22,7 @@ import { ActivityValidationResult } from '../../../models/activity/activityValid
                 (valueChanged)="enteredValue$.next($event)"
                 (componentBusy)="componentBusy.next($event)">
             </ddp-activity-answer>
-            <ng-container *ngIf="block.shown">
+            <ng-container *ngIf="block.shown && block.enabled">
                 <div class="ddp-activity-validation" *ngIf="errorMessage$ | async as errorMsg">
                     <ddp-validation-message [message]="errorMsg" [translationParams]="errorMessageTranslationParams$ | async">
                     </ddp-validation-message>
@@ -115,6 +115,7 @@ export class ActivityQuestionComponent implements OnInit, OnDestroy {
     public setupSavingData(): void {
         this.enteredValue$.pipe(
             filter(() => this.block.canPatch()),
+            filter(() => this.block.enabled),
             tap(value =>
                 this.submissionManager.patchAnswer(
                     this.studyGuid,

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityQuestion.component.ts
@@ -115,7 +115,6 @@ export class ActivityQuestionComponent implements OnInit, OnDestroy {
     public setupSavingData(): void {
         this.enteredValue$.pipe(
             filter(() => this.block.canPatch()),
-            filter(() => this.block.enabled),
             tap(value =>
                 this.submissionManager.patchAnswer(
                     this.studyGuid,

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/abstractActivityQuestionBlock.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/abstractActivityQuestionBlock.ts
@@ -37,7 +37,7 @@ export abstract class AbstractActivityQuestionBlock extends ActivityBlock {
   public abstract get questionType(): QuestionType;
 
   public canPatch(): boolean {
-    return this.validators
+    return this.enabled && this.validators
       .filter(validator => !validator.allowSave)
       .reduce((accumulator, validator) => accumulator && validator.recalculate(), true);
   }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityBlock.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityBlock.ts
@@ -22,7 +22,7 @@ export abstract class ActivityBlock {
     }
 
     public validate(): boolean {
-        const result = this.validateInternally();
+        const result = this.enabled ? this.validateInternally() : true;
         this.valid = result;
         return result;
     }


### PR DESCRIPTION
- Do not run validation for blocks with `enabled = false`
- Do not send any `PATCH` requests for block with `enabled = false` if user has manually removed `disabled` attribute from input element
- Do not show any validation error messages for blocks with `enabled = false`