### PR TITLE
[ATCP] Fix some paths for style imports

### DIFF
--- a/ddp-workspace/projects/ddp-atcp/src/app/components/header/header.scss
+++ b/ddp-workspace/projects/ddp-atcp/src/app/components/header/header.scss
@@ -1,4 +1,5 @@
-@use '@angular/material' as mat;
+@use '../../../../../../node_modules/@angular/material' as mat;
+
 @import "../../styles/mixins.scss";
 @import '../../styles/theme.scss';
 @import "../../styles/variables";

--- a/ddp-workspace/projects/ddp-atcp/src/app/styles/theme.scss
+++ b/ddp-workspace/projects/ddp-atcp/src/app/styles/theme.scss
@@ -1,4 +1,4 @@
-@use '@angular/material' as mat;
+@use '../../../../../node_modules/@angular/material' as mat;
 @import '../../../../../node_modules/@angular/material/theming';
 @import 'variables';
 


### PR DESCRIPTION
Fix a failed pipeline step [`build atcp auth0 styles`](https://app.circleci.com/pipelines/github/broadinstitute/ddp-angular/12440/workflows/0e03683a-aae1-4c2a-b192-f5253b8674c3/jobs/18440)

