### PR TITLE
[PANCAN] Tweak ddp-pancan styles

### DIFF
--- a/ddp-workspace/angular.json
+++ b/ddp-workspace/angular.json
@@ -13,7 +13,10 @@
           "builder": "@angular-devkit/build-angular:ng-packagr",
           "options": {
             "tsConfig": "projects/ddp-sdk/tsconfig.lib.json",
-            "project": "projects/ddp-sdk/ng-package.json"
+            "project": "projects/ddp-sdk/ng-package.json",
+            "allowedCommonJsDependencies": [
+              "stackdriver-errors-js"
+            ]
           },
           "configurations": {
             "production": {
@@ -2491,6 +2494,9 @@
             ],
             "scripts": [
               "node_modules/stackdriver-errors-js/dist/stackdriver-errors-concat.min.js"
+            ],
+            "allowedCommonJsDependencies": [
+              "stackdriver-errors-js"
             ],
             "vendorChunk": true,
             "extractLicenses": false,

--- a/ddp-workspace/angular.json
+++ b/ddp-workspace/angular.json
@@ -13,10 +13,7 @@
           "builder": "@angular-devkit/build-angular:ng-packagr",
           "options": {
             "tsConfig": "projects/ddp-sdk/tsconfig.lib.json",
-            "project": "projects/ddp-sdk/ng-package.json",
-            "allowedCommonJsDependencies": [
-              "stackdriver-errors-js"
-            ]
+            "project": "projects/ddp-sdk/ng-package.json"
           },
           "configurations": {
             "production": {

--- a/ddp-workspace/projects/ddp-pancan/src/theme.scss
+++ b/ddp-workspace/projects/ddp-pancan/src/theme.scss
@@ -42,6 +42,20 @@ $md-primary: (
 $app-primary: mat.define-palette($md-primary, 500, 500, 500);
 $app-accent: mat.define-palette($md-primary, 900, 700, A500);
 
-$test-app-theme: mat.define-light-theme($app-primary, $app-accent);
+$test-app-theme: mat.define-light-theme((
+    color: (
+        primary: $app-primary,
+        accent: $app-accent,
+    )
+));
 
-@include mat.all-component-themes($test-app-theme);
+// for common features used across multiple components.
+@include mat.core-color($test-app-theme);
+// Individual component mixins (used in the app) only
+// instead of using all Angular Material components mixins.
+// in order not to produce unnecessary CSS.
+@include mat.button-color($test-app-theme);
+@include mat.icon-color($test-app-theme);
+@include mat.expansion-color($test-app-theme);
+@include mat.form-field-color($test-app-theme);
+@include mat.input-color($test-app-theme);


### PR DESCRIPTION
After Angular updating to v.13 we have some warnings during build time (for every project), like:
![image](https://user-images.githubusercontent.com/7396837/148811346-d7e9d54d-55c0-44cc-8208-09b52d5efedf.png)

![image](https://user-images.githubusercontent.com/7396837/148811386-860d8dba-1a2f-421e-9865-5302ee4930f8.png)

So in this PR I fixed them for `ddp-pancan` only:
- fixed a warning about CommonJs dependency
- fixed duplicated theming styles for ddp-pancan,
according to https://github.com/angular/components/blob/master/guides/duplicate-theming-styles.md.

(it makes sense to fix the warnings for all our projects, in my opinion).

Side-effect: decreased the ccs chunk size
_**Before:**_
![before_pancan](https://user-images.githubusercontent.com/7396837/147933814-23887acd-77ee-4222-8f20-ca049bb0c191.png)

_**After:**_
![after_pancan](https://user-images.githubusercontent.com/7396837/147933830-d69b4323-86f8-4936-bfe4-e53dc210138d.png)


