### PR TITLE
[DDP-SDK] Fix `ddp-sdk` build

### DIFF
--- a/ddp-workspace/projects/ddp-pancan/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-pancan/src/app/app.module.ts
@@ -19,7 +19,9 @@ import {
     SortOrder,
     PicklistSortingPolicy,
     AnalyticsEventsService,
-    AnalyticsEvent
+    AnalyticsEvent,
+    PICKLIST_SORTING_POLICY_LAST_STABLE_ID,
+    PICKLIST_SORTING_POLICY_MAIN_SORT_ORDER
 } from 'ddp-sdk';
 
 import { ToolkitConfigurationService, ToolkitModule } from 'toolkit';
@@ -188,9 +190,14 @@ export function translateFactory(translate: TranslateService,
         },
         // Ensure that sorting of autocomplete picklist options is as specified
         {
-            provide: PicklistSortingPolicy,
-            useValue: new PicklistSortingPolicy(SortOrder.ALPHABETICAL, 'UNSURE')
-        }
+            provide: PICKLIST_SORTING_POLICY_MAIN_SORT_ORDER,
+            useValue: SortOrder.ALPHABETICAL
+        },
+        {
+            provide: PICKLIST_SORTING_POLICY_LAST_STABLE_ID,
+            useValue: 'UNSURE'
+        },
+        PicklistSortingPolicy
     ],
     bootstrap: [AppComponent]
 })

--- a/ddp-workspace/projects/ddp-sdk/src/lib/ddp.module.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/ddp.module.ts
@@ -207,7 +207,6 @@ import { FileAnswerMapperService } from './services/fileAnswerMapper.service';
 import { StickyScrollDirective } from './directives/sticky-scroll.directive';
 import { AutocompleteActivityPicklistQuestion } from './components/activityForm/picklist/autocompleteActivityPicklistQuestion.component';
 import { SearchHighlightPipe } from './pipes/searchHighlight.pipe';
-import { PicklistSortingPolicy } from './services/picklistSortingPolicy.service';
 import { FuncType } from './models/funcType';
 
 export function jwtOptionsFactory(sessionService: SessionMementoService): object {
@@ -335,12 +334,6 @@ export function createTranslateLoader(http: HttpClient): TranslateHttpLoader {
         InvitationPipe,
         FileAnswerMapperService,
         ParticipantsSearchServiceAgent,
-        // Angular Injection does not like that we have optional arguments in constructor
-        // Need to create our default instance ourselves
-        {
-            provide: PicklistSortingPolicy,
-            useValue: new PicklistSortingPolicy()
-        },
         {
             provide: HTTP_INTERCEPTORS,
             useClass: AuthInterceptor,

--- a/ddp-workspace/projects/ddp-sdk/src/lib/directives/addressGoogleAutocomplete.directive.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/directives/addressGoogleAutocomplete.directive.ts
@@ -1,17 +1,19 @@
 /// <reference types="@types/googlemaps" />
 import { Directive, ElementRef, EventEmitter, Inject, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
-import { ScriptLoaderService } from '../services/scriptLoader.service';
-import { Address } from '../models/address';
-import { ConfigurationService } from '../services/configuration.service';
 import { concat, Observable, Subject } from 'rxjs';
 import { share, skip, takeUntil } from 'rxjs/operators';
-import { LoggingService } from '../services/logging.service';
 import * as _ from 'underscore';
+
+import { ScriptLoaderService } from '../services/scriptLoader.service';
+import { ConfigurationService } from '../services/configuration.service';
+import { LoggingService } from '../services/logging.service';
+import { Address } from '../models/address';
+import { FuncType } from '../models/funcType';
+
 import Autocomplete = google.maps.places.Autocomplete;
 import PlaceResult = google.maps.places.PlaceResult;
 import AutocompleteOptions = google.maps.places.AutocompleteOptions;
 import ComponentRestrictions = google.maps.places.ComponentRestrictions;
-import { FuncType } from 'ddp-sdk';
 
 @Directive({
     selector: '[addressgoogleautocomplete]'

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityValidatorBuilder.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityValidatorBuilder.service.ts
@@ -24,7 +24,7 @@ import * as _ from 'underscore';
 import { ActivityFileValidationRule } from './validators/activityFileValidationRule';
 import { ActivityFileQuestionBlock } from '../../models/activity/activityFileQuestionBlock';
 import { PicklistRenderMode } from '../../models/activity/picklistRenderMode';
-import { ActivityPicklistQuestionBlock } from 'ddp-sdk';
+import { ActivityPicklistQuestionBlock } from '../../models/activity/activityPicklistQuestionBlock';
 import { ActivityStrictMatchValidationRule } from './validators/activityStrictMatchValidationRule';
 import { ActivityUniqueValidationRule } from './validators/activityUniqueValidationRule';
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/activityUniqueValidationRule.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/activityUniqueValidationRule.ts
@@ -1,7 +1,10 @@
-import { ActivityQuestionBlock } from '../../../models/activity/activityQuestionBlock';
 import { ActivityAbstractValidationRule } from './activityAbstractValidationRule';
+import { ActivityQuestionBlock } from '../../../models/activity/activityQuestionBlock';
 import { QuestionType } from '../../../models/activity/questionType';
-import { ActivityCompositeQuestionBlock, AnswerContainer } from 'ddp-sdk';
+import {
+    ActivityCompositeQuestionBlock,
+    AnswerContainer
+} from '../../../models/activity/activityCompositeQuestionBlock';
 
 export class ActivityUniqueValidationRule extends ActivityAbstractValidationRule {
     constructor(question: ActivityQuestionBlock<any>) {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/picklistSortingPolicy.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/picklistSortingPolicy.service.ts
@@ -1,12 +1,28 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable, InjectionToken } from '@angular/core';
 import { ActivityPicklistNormalizedGroup } from '../models/activity/activityPicklistNormalizedGroup';
 import { SortOrder } from './sortOrder';
 import { ActivityPicklistOption } from '../models/activity/activityPicklistOption';
 import { FuncType } from '../models/funcType';
 
+export const PICKLIST_SORTING_POLICY_MAIN_SORT_ORDER = new InjectionToken<string>(
+    'mainSortOrder for PicklistSortingPolicy configuration', {
+        factory: () => SortOrder.NONE // default value for DI
+    }
+);
+export const PICKLIST_SORTING_POLICY_LAST_STABLE_ID = new InjectionToken<string>(
+    'lastStableId (optional) for PicklistSortingPolicy configuration', {
+        factory: () => undefined // default value for DI
+    }
+);
+
 @Injectable()
 export class PicklistSortingPolicy {
-    constructor(readonly mainSortOrder: SortOrder = SortOrder.NONE, readonly lastStableId?: string) {}
+    constructor(
+        @Inject(PICKLIST_SORTING_POLICY_MAIN_SORT_ORDER)
+            readonly mainSortOrder: SortOrder = SortOrder.NONE, // default value for new PicklistSortingPolicy()
+        @Inject(PICKLIST_SORTING_POLICY_LAST_STABLE_ID) readonly lastStableId?: string
+    ) {
+    }
 
     public sortPicklistGroups(groups: ActivityPicklistNormalizedGroup[]): ActivityPicklistNormalizedGroup[] {
         const groupsCopy = groups.slice();

--- a/ddp-workspace/projects/ddp-sdk/src/public-api.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/public-api.ts
@@ -135,6 +135,7 @@ export * from './lib/components/activityForm/picklist/radiobuttonsActivityPickli
 export * from './lib/components/activityForm/picklist/checkboxesActivityPicklistQuestion.component';
 export * from './lib/components/activityForm/picklist/dropdownActivityPicklistQuestion.component';
 export * from './lib/components/activityForm/picklist/activityPicklistAnswer.component';
+export * from './lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component';
 export * from './lib/components/activityForm/answers/question-prompt/questionPrompt.component';
 export * from './lib/components/activityForm/activity-blocks/conditionalBlock.component';
 export * from './lib/components/activityForm/activity-blocks/groupBlockList.component';
@@ -169,14 +170,17 @@ export * from './lib/components/networkSniffer.component';
 export * from './lib/components/user/participantProfile.component';
 export * from './lib/components/progress-indicator/progress-indicator.component';
 export * from './lib/components/confirmDialog/confirmDialog.component';
+export * from './lib/components/prism/prism.component';
 
 export * from './lib/directives/upperCaseInputDirective.directive';
 export * from './lib/directives/routeTransformer.directive';
 export * from './lib/directives/lazyLoadResources.directive';
 export * from './lib/directives/invitationCodeFormatter.directive';
+export * from './lib/directives/sticky-scroll.directive';
 
 export * from './lib/pipes/invitationFormatter.pipe';
 export * from './lib/pipes/fileSizeFormatter.pipe';
+export * from './lib/pipes/searchHighlight.pipe';
 
 export * from './lib/guards/auth.guard';
 export * from './lib/guards/adminAuth.guard';


### PR DESCRIPTION
There are some issues during the `ddp-sdk` build.

Done in the PR: 
- fixed several circular dependencies in `sdk`
- added missed classes in `public-api.ts`
- refactored providing of `PicklistSortingPolicy` service