### PR TITLE
[DSS] Update `karma` library version

### DIFF
--- a/ddp-workspace/package-lock.json
+++ b/ddp-workspace/package-lock.json
@@ -76,7 +76,7 @@
         "jasmine-core": "~3.10.1",
         "jasmine-marbles": "^0.9.1",
         "jasmine-spec-reporter": "~5.0.0",
-        "karma": "^6.3.9",
+        "karma": "^6.3.12",
         "karma-chrome-launcher": "~3.1.0",
         "karma-coverage-istanbul-reporter": "3.0.3",
         "karma-jasmine": "~4.0.0",
@@ -10241,15 +10241,15 @@
       }
     },
     "node_modules/karma": {
-      "version": "6.3.10",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.10.tgz",
-      "integrity": "sha512-Ofv+sgrkT8Czo6bzzQCvrwVyRSG8/3e7RbawEuxjfsINony+IR/S2csNRUFgPNfmWvju+dqi/MzQGOJ2LnlmfQ==",
+      "version": "6.3.12",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.12.tgz",
+      "integrity": "sha512-qwIG+oB2YmHx4hjvYSRMNzL3YWAJ9baHaLAxiP7biFNkfpwYTUTtPck0joFpucalNLzMr+7z/FX1uY/kl8DV9A==",
       "dev": true,
       "dependencies": {
         "body-parser": "^1.19.0",
         "braces": "^3.0.2",
         "chokidar": "^3.5.1",
-        "colors": "^1.4.0",
+        "colors": "1.4.0",
         "connect": "^3.7.0",
         "di": "^0.0.1",
         "dom-serialize": "^2.2.1",
@@ -25588,15 +25588,15 @@
       }
     },
     "karma": {
-      "version": "6.3.10",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.10.tgz",
-      "integrity": "sha512-Ofv+sgrkT8Czo6bzzQCvrwVyRSG8/3e7RbawEuxjfsINony+IR/S2csNRUFgPNfmWvju+dqi/MzQGOJ2LnlmfQ==",
+      "version": "6.3.12",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.12.tgz",
+      "integrity": "sha512-qwIG+oB2YmHx4hjvYSRMNzL3YWAJ9baHaLAxiP7biFNkfpwYTUTtPck0joFpucalNLzMr+7z/FX1uY/kl8DV9A==",
       "dev": true,
       "requires": {
         "body-parser": "^1.19.0",
         "braces": "^3.0.2",
         "chokidar": "^3.5.1",
-        "colors": "^1.4.0",
+        "colors": "1.4.0",
         "connect": "^3.7.0",
         "di": "^0.0.1",
         "dom-serialize": "^2.2.1",

--- a/ddp-workspace/package.json
+++ b/ddp-workspace/package.json
@@ -84,7 +84,7 @@
     "jasmine-core": "~3.10.1",
     "jasmine-marbles": "^0.9.1",
     "jasmine-spec-reporter": "~5.0.0",
-    "karma": "^6.3.9",
+    "karma": "^6.3.12",
     "karma-chrome-launcher": "~3.1.0",
     "karma-coverage-istanbul-reporter": "3.0.3",
     "karma-jasmine": "~4.0.0",


### PR DESCRIPTION
Updated `karma` version in order to get rid of an error (during unit-tests launch):

_**"(node:14940) [log4js-node-DEP0004] 
DeprecationWarning: Pattern %d{DATE} is deprecated due to the confusion it causes when used. 
Please use %d{DATETIME} instead."**_

([heads up](https://stackoverflow.com/questions/70841924/log4js-node-dep0004-deprecation-warning-in-angular-12-karma-unit-tests/70842002))