### PR TITLE
DDP-7500:  Fix failed build for `ddp-atcp-auth`

### DIFF
--- a/ddp-workspace/projects/ddp-atcp/src/auth0/auth0-scripts/auth.ts
+++ b/ddp-workspace/projects/ddp-atcp/src/auth0/auth0-scripts/auth.ts
@@ -1,4 +1,4 @@
-import { FuncType } from 'ddp-sdk';
+export type FuncType<T> = (...args) => T;
 
 declare const auth0;
 

--- a/ddp-workspace/projects/ddp-atcp/src/auth0/auth0-scripts/forms.ts
+++ b/ddp-workspace/projects/ddp-atcp/src/auth0/auth0-scripts/forms.ts
@@ -1,5 +1,5 @@
 import {screensIds} from './ui-actions';
-import { FuncType } from 'ddp-sdk';
+import { FuncType } from './auth';
 
 declare const FormValidator;
 declare const $;

--- a/ddp-workspace/projects/ddp-atcp/src/auth0/auth0-scripts/ui-actions.ts
+++ b/ddp-workspace/projects/ddp-atcp/src/auth0/auth0-scripts/ui-actions.ts
@@ -1,4 +1,4 @@
-import { FuncType } from 'ddp-sdk';
+import { FuncType } from './auth';
 
 declare const $;
 

--- a/ddp-workspace/projects/ddp-sdk/src/public-api.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/public-api.ts
@@ -157,6 +157,10 @@ export * from './lib/components/activityForm/answers/activityBooleanAnswer.compo
 export * from './lib/components/activityForm/answers/activity-file-answer/activityFileAnswer.component';
 export * from './lib/components/activityForm/answers/activity-matrix-answer/activity-matrix-answer.component';
 export * from './lib/components/activityForm/answers/activity-instance-select-answer/activity-instance-select-answer.component';
+// eslint-disable-next-line max-len
+export * from './lib/components/activityForm/answers/activity-matrix-answer/activity-matrix-answer-dialog/activity-matrix-answer-dialog.component';
+// eslint-disable-next-line max-len
+export * from './lib/components/activityForm/answers/activity-matrix-answer/activity-matrix-answer-table/activity-matrix-answer-table.component';
 
 export * from './lib/components/activityForm/activity-blocks/activityQuestion.component';
 export * from './lib/components/activityForm/activity-blocks/modalActivityBlock/modalActivityBlock.component';


### PR DESCRIPTION
Fixed the failed build after running `ng build ddp-atcp-auth`, see an error below:

![error_atcp-auth](https://user-images.githubusercontent.com/7396837/151838866-9cb8d509-8eb1-4519-9f98-ec953220f8e2.png)

It is quite tricky. I guess the problem was in interconnection of two our Angular libraries: `ddp-sdk` and `ddp-atcp-auth`
 (found [an article](https://hackmd.io/@alx/SycgothIV)  - about how the compiler should import from workspace libraries)
