### PR TITLE
[ATCP] DDP-7500: fix failed `atcp/atcp-auth` build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,6 +315,7 @@ commands:
           command: |
             set -u
             ng build ddp-atcp-auth
+            npm run convert-atcp-auth-build-to-UMD
       - run:
           name: build atcp auth0 styles
           command: |

--- a/ddp-workspace/package.json
+++ b/ddp-workspace/package.json
@@ -7,7 +7,8 @@
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "convert-atcp-auth-build-to-UMD": "rollup --config projects/ddp-atcp/src/auth0/auth0-scripts/rollup.config.js"
   },
   "private": true,
   "husky": {

--- a/ddp-workspace/projects/ddp-atcp/src/auth0/auth0-scripts/package.json
+++ b/ddp-workspace/projects/ddp-atcp/src/auth0/auth0-scripts/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ddp-atcp-auth",
   "version": "1.0.0",
+  "main": "./ddp-atcp-auth.umd.js",
   "peerDependencies": {
   }
 }

--- a/ddp-workspace/projects/ddp-atcp/src/auth0/auth0-scripts/rollup.config.js
+++ b/ddp-workspace/projects/ddp-atcp/src/auth0/auth0-scripts/rollup.config.js
@@ -1,0 +1,12 @@
+// transform an FESM2015 input file to UMD
+// because it requires in `ddp-study-server\study-builder\tenants\atcp\pages\login.html`
+// in <script> tag
+
+export default {
+    input: 'projects/ddp-atcp/src/auth0/compiled/auth0-scripts/fesm2015/ddp-atcp-auth.mjs',
+    output: {
+        file: 'projects/ddp-atcp/src/auth0/compiled/auth0-scripts/bundles/ddp-atcp-auth.umd.js',
+        format: 'umd',
+        name: 'ddp-atcp-auth'
+    }
+};

--- a/ddp-workspace/projects/ddp-atcp/src/auth0/auth0-scripts/rollup.config.js
+++ b/ddp-workspace/projects/ddp-atcp/src/auth0/auth0-scripts/rollup.config.js
@@ -1,5 +1,5 @@
 // transform an FESM2015 input file to UMD
-// because it requires in `ddp-study-server\study-builder\tenants\atcp\pages\login.html`
+// because it is required in `ddp-study-server\study-builder\tenants\atcp\pages\login.html`
 // in <script> tag
 
 export default {

--- a/ddp-workspace/projects/ddp-atcp/src/auth0/auth0-scripts/tsconfig.lib.prod.json
+++ b/ddp-workspace/projects/ddp-atcp/src/auth0/auth0-scripts/tsconfig.lib.prod.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.lib.json",
+    "compilerOptions": {
+        "declarationMap": false
+    },
+    "angularCompilerOptions": {
+        "compilationMode": "partial"
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
1) **Initial issue** - 
ATCP study: login page fails.  `ddp-atcp-auth.umd.js` file can't be downloaded (404). 
The file is used in `ddp-study-server\study-builder\tenants\atcp\pages\login.html` as a JS script (<script>).

![image](https://user-images.githubusercontent.com/7396837/152148077-79549d52-b21a-4007-b07a-00bf83abb7ce.png)

2) Seems like after Angular update to v.13 an Angular builder `ng-packagr` does not create a build/bundle in **umd** format by default at present, but only as ES modules. Moreover, I was not able to configure it (see [ng-packagr doc](https://github.com/ng-packagr/ng-packagr/blob/master/docs/DESIGN.md#:~:text=For%20example%2C%20the,JSON%20configuration%20property)).
Thus I decided to add[ an additional step to convert ](https://github.com/broadinstitute/ddp-angular/pull/1036/files#:~:text=npm%20run%20convert%2Datcp%2Dauth%2Dbuild%2Dto%2DUMD)the created (ES2015-module) build into umd one by using [Rollup library](https://www.npmjs.com/package/rollup) (the library is a peer dependency of ng-packagr).

3) Checked on dev env - it works properly.
![atcp_after](https://user-images.githubusercontent.com/7396837/152149894-ccdf500d-0c9f-47b7-aa27-42963fc530cd.png)

4) May be it makes sense to refactor the `ddp-atcp-auth` library in ES-modules style in future. 