### PR TITLE
DDP-7115: Add a new api call in order to run tests in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -538,6 +538,13 @@ jobs:
       - deploy-stored-build:
           study_key: << parameters.study_key >>
 
+  app-run-tests-job:
+    working_directory: *ng_workspace_path
+    executor:
+      name: build-executor
+    steps:
+      - run-tests
+
 parameters:
   study_key:
     type: string
@@ -547,7 +554,7 @@ parameters:
     default: "UNKNOWN"
   api_call:
     type: enum
-    enum: ["build-and-store","deploy","UNKNOWN"]
+    enum: ["build-and-store","deploy", "run-tests", "UNKNOWN"]
     default: "UNKNOWN"
   deploy_env:
     type: enum
@@ -561,7 +568,7 @@ workflows:
   version: 2
 
   api-build-and-store-workflow:
-    description: "Build study specified in api call"
+    # Build study specified in api call
     when:
       and:
         - equal: ["build-and-store", << pipeline.parameters.api_call >>]
@@ -571,7 +578,7 @@ workflows:
       - app-build-and-store-job
 
   api-deploy-workflow:
-    description: "Deploy a study build to environment specified in api call"
+    # Deploy a study build to environment specified in api call
     when:
       and:
         - equal: ["deploy", << pipeline.parameters.api_call >>]
@@ -583,6 +590,16 @@ workflows:
     jobs:
       - deploy-stored-build-job:
           study_key: << pipeline.parameters.study_key >>
+
+  api-run-tests-workflow:
+    # Run tests for study specified in api call (also tests for sdk and toolkit)
+      when:
+        and:
+          - equal: ["run-tests", << pipeline.parameters.api_call >>]
+          - not:
+              equal: ["UNKNOWN", << pipeline.parameters.study_key >>]
+      jobs:
+        - app-run-tests-job
 
   build-and-deploy-all-apps-workflow:
     unless: << pipeline.parameters.do-builds >>

--- a/build-utils/run_ci.sh
+++ b/build-utils/run_ci.sh
@@ -20,6 +20,8 @@ if [[ -z $COMMAND || -z $STUDY_KEY || -z $BRANCH || ($COMMAND == "deploy" && -z 
   echo "        Create build of given study and store for later use"
   echo "    deploy"
   echo "        Deploy saved build of corresponding to given branch to specified TARGET_ENV"
+  echo "    run-tests"
+  echo "        Run tests for given study and given branch"
   exit 1
 fi
 


### PR DESCRIPTION
Modified a script that can be used by developers to trigger the execution of all Angular tests in their PR branch
(for the pointed project/study (**`study_key`**) and also **`ddp-sdk`** and **`toolkit`** as common libraries).

To run test use the following command (from `ddp-angular` folder): 

 ### ` ./build-utils/run_ci.sh run-tests [study_key] [branch_name] [target_env] `

  e.g.: 
### ` ./build-utils/run_ci.sh run-tests pancan develop dev `

---
**_Note:_**
If we are going to set "**_all tests have passed_**" as a required rule before a PR merge 
we should remove/comment out flacky tests.
