### PR TITLE
DDP-7115: [Part 2- fix] Add a new api call in order to run tests in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -543,6 +543,9 @@ jobs:
     executor:
       name: build-executor
     steps:
+      - setup-build-workspace
+      - setup-shared-env:
+          study_key: << pipeline.parameters.study_key >>
       - run-tests
 
 parameters:


### PR DESCRIPTION
Add missed steps for `app-run-tests-job` (previously implemented in [PR#1045](https://github.com/broadinstitute/ddp-angular/pull/1045)).