### PR TITLE
DDP-7307: Implement decimal data type

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-answer/activityAnswer.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-answer/activityAnswer.component.ts
@@ -3,7 +3,6 @@ import { AbstractActivityQuestionBlock } from '../../../../models/activity/abstr
 import { AnswerValue } from '../../../../models/activity/answerValue';
 import { QuestionType } from '../../../../models/activity/questionType';
 import { BlockType } from '../../../../models/activity/blockType';
-import { NumericType } from '../../../../models/activity/numericType';
 import { ActivityNumericQuestionBlock } from '../../../../models/activity/activityNumericQuestionBlock';
 
 @Component({
@@ -21,7 +20,7 @@ import { ActivityNumericQuestionBlock } from '../../../../models/activity/activi
                                       [readonly]="readonly"
                                       (valueChanged)="onChange($event)">
             </ddp-activity-text-answer>
-            <ddp-activity-numeric-answer *ngIf="isNumericQuestion(block)"
+            <ddp-activity-numeric-answer *ngIf="isNumericQuestion(block) || isDecimalQuestion(block)"
                                          [class]="'numeric-answer-' + block.stableId"
                                          [block]="block"
                                          [valueChangeStep]="numericValueStep"
@@ -94,9 +93,8 @@ export class ActivityAnswerComponent {
     @Output() componentBusy = new EventEmitter<boolean>();
 
     public get numericValueStep(): number {
-        if (this.isNumericQuestion(this.block)) {
-            const block = this.block as ActivityNumericQuestionBlock;
-            return (block.numericType === NumericType.Integer) ? 1 : Math.pow(10, -(block.scale));
+        if (this.isDecimalQuestion(this.block)) {
+            return Math.pow(10, -( (this.block as ActivityNumericQuestionBlock).scale) );
         }
     }
 
@@ -114,6 +112,10 @@ export class ActivityAnswerComponent {
 
     public isNumericQuestion(block: AbstractActivityQuestionBlock): boolean {
         return this.isQuestion(block) && block.questionType === QuestionType.Numeric;
+    }
+
+    public isDecimalQuestion(block: AbstractActivityQuestionBlock): boolean {
+        return this.isQuestion(block) && block.questionType === QuestionType.Decimal;
     }
 
     public isPicklistQuestion(block: AbstractActivityQuestionBlock): boolean {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-answer/activityAnswer.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-answer/activityAnswer.component.ts
@@ -3,7 +3,7 @@ import { AbstractActivityQuestionBlock } from '../../../../models/activity/abstr
 import { AnswerValue } from '../../../../models/activity/answerValue';
 import { QuestionType } from '../../../../models/activity/questionType';
 import { BlockType } from '../../../../models/activity/blockType';
-import { ActivityNumericQuestionBlock } from '../../../../models/activity/activityNumericQuestionBlock';
+import { ActivityDecimalQuestionBlock } from '../../../../models/activity/activityDecimalQuestionBlock';
 
 @Component({
     selector: 'ddp-activity-answer',
@@ -94,7 +94,7 @@ export class ActivityAnswerComponent {
 
     public get numericValueStep(): number {
         if (this.isDecimalQuestion(this.block)) {
-            return Math.pow(10, -( (this.block as ActivityNumericQuestionBlock).scale) );
+            return Math.pow(10, -( (this.block as ActivityDecimalQuestionBlock).scale) );
         }
     }
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-answer/activityAnswer.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-answer/activityAnswer.component.ts
@@ -3,7 +3,6 @@ import { AbstractActivityQuestionBlock } from '../../../../models/activity/abstr
 import { AnswerValue } from '../../../../models/activity/answerValue';
 import { QuestionType } from '../../../../models/activity/questionType';
 import { BlockType } from '../../../../models/activity/blockType';
-import { ActivityDecimalQuestionBlock } from '../../../../models/activity/activityDecimalQuestionBlock';
 
 @Component({
     selector: 'ddp-activity-answer',
@@ -23,7 +22,6 @@ import { ActivityDecimalQuestionBlock } from '../../../../models/activity/activi
             <ddp-activity-numeric-answer *ngIf="isNumericQuestion(block) || isDecimalQuestion(block)"
                                          [class]="'numeric-answer-' + block.stableId"
                                          [block]="block"
-                                         [valueChangeStep]="numericValueStep"
                                          [readonly]="readonly"
                                          (valueChanged)="onChange($event)">
             </ddp-activity-numeric-answer>
@@ -91,12 +89,6 @@ export class ActivityAnswerComponent {
     @Input() activityGuid: string;
     @Output() valueChanged: EventEmitter<AnswerValue> = new EventEmitter();
     @Output() componentBusy = new EventEmitter<boolean>();
-
-    public get numericValueStep(): number {
-        if (this.isDecimalQuestion(this.block)) {
-            return Math.pow(10, -( (this.block as ActivityDecimalQuestionBlock).scale) );
-        }
-    }
 
     public onChange(value: AnswerValue): void {
         this.valueChanged.emit(value);

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-answer/activityAnswer.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-answer/activityAnswer.component.ts
@@ -3,6 +3,8 @@ import { AbstractActivityQuestionBlock } from '../../../../models/activity/abstr
 import { AnswerValue } from '../../../../models/activity/answerValue';
 import { QuestionType } from '../../../../models/activity/questionType';
 import { BlockType } from '../../../../models/activity/blockType';
+import { NumericType } from '../../../../models/activity/numericType';
+import { ActivityNumericQuestionBlock } from '../../../../models/activity/activityNumericQuestionBlock';
 
 @Component({
     selector: 'ddp-activity-answer',
@@ -22,6 +24,7 @@ import { BlockType } from '../../../../models/activity/blockType';
             <ddp-activity-numeric-answer *ngIf="isNumericQuestion(block)"
                                          [class]="'numeric-answer-' + block.stableId"
                                          [block]="block"
+                                         [valueChangeStep]="numericValueStep"
                                          [readonly]="readonly"
                                          (valueChanged)="onChange($event)">
             </ddp-activity-numeric-answer>
@@ -89,6 +92,13 @@ export class ActivityAnswerComponent {
     @Input() activityGuid: string;
     @Output() valueChanged: EventEmitter<AnswerValue> = new EventEmitter();
     @Output() componentBusy = new EventEmitter<boolean>();
+
+    public get numericValueStep(): number {
+        if (this.isNumericQuestion(this.block)) {
+            const block = this.block as ActivityNumericQuestionBlock;
+            return (block.numericType === NumericType.Integer) ? 1 : Math.pow(10, -(block.scale));
+        }
+    }
 
     public onChange(value: AnswerValue): void {
         this.valueChanged.emit(value);

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.spec.ts
@@ -108,15 +108,17 @@ describe('ActivityNumericAnswer (Decimal answers)', () => {
 
         fixture = TestBed.createComponent(ActivityNumericAnswer);
         component = fixture.componentInstance;
-        component.block = questionBlock;
-        fixture.detectChanges();
     }));
 
     it('should create', () => {
+        component.block = questionBlock;
+        fixture.detectChanges();
         expect(component).toBeTruthy();
     });
 
     it('should init input', () => {
+        component.block = questionBlock;
+        fixture.detectChanges();
         const inputElement: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
         expect(inputElement.value).toBe('2.35');
         // TODO: fix commented tests below in scope of DDP-7573
@@ -125,7 +127,21 @@ describe('ActivityNumericAnswer (Decimal answers)', () => {
     });
 
     it('should update input', () => {
-        component.readonly = false;
+        component.block = {
+            answer: { value: 456, scale: 1 },
+            // min: {},
+            // max: {},
+            scale: 2,
+            questionType: QuestionType.Decimal
+        } as ActivityDecimalQuestionBlock;
+        fixture.detectChanges();
+        const inputElement: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
+        expect(inputElement.value).toBe('45.60');
+        // expect(inputElement.min).toBe();
+        // expect(inputElement.max).toBe();
+    });
+
+    it('should update input if answer is null', () => {
         component.block = {
             answer: null,
             // min: {},
@@ -136,6 +152,20 @@ describe('ActivityNumericAnswer (Decimal answers)', () => {
         fixture.detectChanges();
         const inputElement: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
         expect(inputElement.value).toBe('');
+        // expect(inputElement.min).toBe();
+        // expect(inputElement.max).toBe();
+    });
+
+    it('should update input with default question scale value (0)', () => {
+        component.block = {
+            answer: { value: 123, scale: 1 },
+            // min: {},
+            // max: {},
+            questionType: QuestionType.Decimal
+        } as ActivityDecimalQuestionBlock;
+        fixture.detectChanges();
+        const inputElement: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
+        expect(inputElement.value).toBe('12');
         // expect(inputElement.min).toBe();
         // expect(inputElement.max).toBe();
     });

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.spec.ts
@@ -170,7 +170,7 @@ describe('ActivityNumericAnswer (Decimal answers)', () => {
         // expect(inputElement.max).toBe();
     });
 
-    it('should emit valid numeric answer', () => {
+    it('should emit valid decimal answer', () => {
         component.block = {
             answer: null,
             scale: 2,

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.spec.ts
@@ -1,18 +1,21 @@
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { MatTooltipModule } from '@angular/material/tooltip';
 import { By } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatInputModule } from '@angular/material/input';
+
 import { QuestionPromptComponent } from './question-prompt/questionPrompt.component';
 import { TooltipComponent } from '../../tooltip.component';
 import { TranslateTestingModule } from '../../../testsupport/translateTestingModule';
 import { ActivityNumericQuestionBlock } from '../../../models/activity/activityNumericQuestionBlock';
 import { ActivityNumericAnswer } from './activityNumericAnswer.component';
-import { MatInputModule } from '@angular/material/input';
+import { NumericType } from 'ddp-sdk';
 
 describe('ActivityNumericAnswer', () => {
     const questionBlock = {
+        numericType: NumericType.Integer,
         answer: null,
         min: 1,
         max: 10
@@ -87,6 +90,7 @@ describe('ActivityNumericAnswer', () => {
 
     it('should emit valid answer', () => {
         component.block = {
+            numericType: NumericType.Integer,
             answer: null,
             min: 0,
             max: 10

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.spec.ts
@@ -1,40 +1,22 @@
-import { Component } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MatTooltipModule } from '@angular/material/tooltip';
+import { ReactiveFormsModule } from '@angular/forms';
 import { MatInputModule } from '@angular/material/input';
 
 import { QuestionPromptComponent } from './question-prompt/questionPrompt.component';
-import { TooltipComponent } from '../../tooltip.component';
-import { TranslateTestingModule } from '../../../testsupport/translateTestingModule';
 import { ActivityNumericQuestionBlock } from '../../../models/activity/activityNumericQuestionBlock';
 import { ActivityNumericAnswer } from './activityNumericAnswer.component';
 import { QuestionType } from '../../../models/activity/questionType';
+import { ActivityDecimalQuestionBlock } from '../../../models/activity/activityDecimalQuestionBlock';
 
-describe('ActivityNumericAnswer (Integer number answers)', () => {
+describe('ActivityNumericAnswer (Integer answers)', () => {
     const questionBlock = {
         answer: null,
         min: 1,
-        max: 10
+        max: 10,
+        questionType: QuestionType.Numeric
     } as ActivityNumericQuestionBlock;
-    const mode = false;
-
-    @Component({
-        template: `
-        <ddp-activity-numeric-answer [block]="block"
-                                     [readonly]="false"
-                                     (valueChanged)="changed($event)">
-        </ddp-activity-numeric-answer>`
-    })
-    class TestHostComponent {
-        block = questionBlock;
-        readonly = mode;
-
-        changed(value: any): void { }
-    }
-
     let component: ActivityNumericAnswer;
     let fixture: ComponentFixture<ActivityNumericAnswer>;
 
@@ -43,16 +25,11 @@ describe('ActivityNumericAnswer (Integer number answers)', () => {
             imports: [
                 MatInputModule,
                 BrowserAnimationsModule,
-                FormsModule,
-                ReactiveFormsModule,
-                MatTooltipModule,
-                TranslateTestingModule
+                ReactiveFormsModule
             ],
             declarations: [
-                TestHostComponent,
                 ActivityNumericAnswer,
-                QuestionPromptComponent,
-                TooltipComponent
+                QuestionPromptComponent
             ]
         }).compileComponents();
 
@@ -77,7 +54,8 @@ describe('ActivityNumericAnswer (Integer number answers)', () => {
         component.block = {
             answer: null,
             min: 0,
-            max: 11
+            max: 11,
+            questionType: QuestionType.Numeric
         } as ActivityNumericQuestionBlock;
         fixture.detectChanges();
         const inputElement: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
@@ -101,5 +79,80 @@ describe('ActivityNumericAnswer (Integer number answers)', () => {
         fixture.detectChanges();
         expect(component.block.answer).toBe(5);
         expect(component.valueChanged.emit).toHaveBeenCalledWith(5);
+    });
+});
+
+describe('ActivityNumericAnswer (Decimal answers)', () => {
+    const questionBlock = {
+        answer: { value: 235, scale: 2 },
+        min: null,
+        max: null,
+        scale: 2,
+        questionType: QuestionType.Decimal
+    } as ActivityDecimalQuestionBlock;
+    let component: ActivityNumericAnswer;
+    let fixture: ComponentFixture<ActivityNumericAnswer>;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                MatInputModule,
+                BrowserAnimationsModule,
+                ReactiveFormsModule
+            ],
+            declarations: [
+                ActivityNumericAnswer,
+                QuestionPromptComponent
+            ]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(ActivityNumericAnswer);
+        component = fixture.componentInstance;
+        component.block = questionBlock;
+        fixture.detectChanges();
+    }));
+
+    it('should create', () => {
+        expect(component).toBeTruthy();
+    });
+
+    it('should init input', () => {
+        const inputElement: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
+        expect(inputElement.value).toBe('2.35');
+        // TODO: fix commented tests below in scope of DDP-7573
+        // expect(inputElement.min).toBe(null);
+        // expect(inputElement.max).toBe(null);
+    });
+
+    it('should update input', () => {
+        component.readonly = false;
+        component.block = {
+            answer: null,
+            // min: {},
+            // max: {},
+            scale: 2,
+            questionType: QuestionType.Decimal
+        } as ActivityDecimalQuestionBlock;
+        fixture.detectChanges();
+        const inputElement: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
+        expect(inputElement.value).toBe('');
+        // expect(inputElement.min).toBe();
+        // expect(inputElement.max).toBe();
+    });
+
+    it('should emit valid numeric answer', () => {
+        component.block = {
+            answer: null,
+            scale: 2,
+            questionType: QuestionType.Decimal
+        } as ActivityDecimalQuestionBlock;
+        spyOn(component.valueChanged, 'emit');
+        fixture.detectChanges();
+        const inputElement: HTMLInputElement = fixture.debugElement.query(By.css('input')).nativeElement;
+        component.numericField.patchValue(5.27);
+        inputElement.dispatchEvent(new Event('blur'));
+        fixture.detectChanges();
+        expect(component.block.answer).toEqual({ value: 527, scale: 2 });
+        expect(component.valueChanged.emit).toHaveBeenCalledWith({ value: 527, scale: 2 });
     });
 });

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, DebugElement } from '@angular/core';
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -11,11 +11,10 @@ import { TooltipComponent } from '../../tooltip.component';
 import { TranslateTestingModule } from '../../../testsupport/translateTestingModule';
 import { ActivityNumericQuestionBlock } from '../../../models/activity/activityNumericQuestionBlock';
 import { ActivityNumericAnswer } from './activityNumericAnswer.component';
-import { NumericType } from 'ddp-sdk';
+import { QuestionType } from '../../../models/activity/questionType';
 
-describe('ActivityNumericAnswer', () => {
+describe('ActivityNumericAnswer (Integer number answers)', () => {
     const questionBlock = {
-        numericType: NumericType.Integer,
         answer: null,
         min: 1,
         max: 10
@@ -38,7 +37,6 @@ describe('ActivityNumericAnswer', () => {
 
     let component: ActivityNumericAnswer;
     let fixture: ComponentFixture<ActivityNumericAnswer>;
-    let debugElement: DebugElement;
 
   beforeEach(waitForAsync(() => {
         TestBed.configureTestingModule({
@@ -90,10 +88,10 @@ describe('ActivityNumericAnswer', () => {
 
     it('should emit valid answer', () => {
         component.block = {
-            numericType: NumericType.Integer,
             answer: null,
             min: 0,
-            max: 10
+            max: 10,
+            questionType: QuestionType.Numeric
         } as ActivityNumericQuestionBlock;
         spyOn(component.valueChanged, 'emit');
         fixture.detectChanges();

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.ts
@@ -43,8 +43,6 @@ export class ActivityNumericAnswer implements OnInit, OnChanges, OnDestroy {
     private subs: Subscription;
 
     public ngOnInit(): void {
-        console.log('question:', this.block);
-
         this.initForm();
 
         this.subs = this.numericField.valueChanges.subscribe((enteredValue: number) => {
@@ -110,12 +108,10 @@ export class ActivityNumericAnswer implements OnInit, OnChanges, OnDestroy {
 
     private formatDecimalAnswer(answerValue: string): DecimalAnswer {
         const [integerPart = '', decimalPart = ''] = answerValue.split('.');
-        const res = {
+        return {
             value: +integerPart.concat(decimalPart),
             scale: decimalPart.length
         };
-        console.log('Decimal to patch:', res);
-        return res;
     }
 
     private formatDecimalAnswerToDisplay(answer: NumericAnswerType): string {
@@ -130,10 +126,8 @@ export class ActivityNumericAnswer implements OnInit, OnChanges, OnDestroy {
         if (decimalPart.length < scale) {
             decimalPart += '0'.repeat(scale - decimalPart.length);
         }
-        const res = integerPart + (scale ? `.${decimalPart.slice(0, scale)}` : '');
 
-        console.log('Decimal to display:', res);
-        return res;
+        return integerPart + (scale ? `.${decimalPart.slice(0, scale)}` : '');
     }
 
     private mapDecimalAnswerToNumber(answer: DecimalAnswer ): number {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.ts
@@ -4,12 +4,10 @@ import { Subscription } from 'rxjs';
 import * as _ from 'underscore';
 import { ActivityNumericQuestionBlock } from '../../../models/activity/activityNumericQuestionBlock';
 import { QuestionType } from '../../../models/activity/questionType';
-import {
-    ActivityDecimalQuestionBlock,
-    DecimalAnswer,
-    NumericAnswerType
-} from '../../../models/activity/activityDecimalQuestionBlock';
+import { ActivityDecimalQuestionBlock } from '../../../models/activity/activityDecimalQuestionBlock';
 import { ActivityQuestionBlock } from '../../../models/activity/activityQuestionBlock';
+import { NumericAnswerType } from '../../../models/activity/numericAnswerType';
+import { DecimalAnswer } from '../../../models/activity/decimalAnswer';
 
 @Component({
     selector: 'ddp-activity-numeric-answer',

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.ts
@@ -1,8 +1,13 @@
 import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
 import { FormControl } from '@angular/forms';
-import { ActivityNumericQuestionBlock } from '../../../models/activity/activityNumericQuestionBlock';
-import * as _ from 'underscore';
 import { Subscription } from 'rxjs';
+import { ActivityNumericQuestionBlock } from '../../../models/activity/activityNumericQuestionBlock';
+import { NumericType } from '../../../models/activity/numericType';
+
+interface DecimalAnswer {
+    value: number;
+    scale: number;
+}
 
 @Component({
     selector: 'ddp-activity-numeric-answer',
@@ -15,6 +20,7 @@ import { Subscription } from 'rxjs';
                [formControl]="numericField"
                [min]="block.min"
                [max]="block.max"
+               [step]="valueChangeStep"
                [placeholder]="placeholder || block.placeholder"
                [attr.data-ddp-test]="'answer:' + block.stableId">
     </mat-form-field>
@@ -27,6 +33,7 @@ import { Subscription } from 'rxjs';
 })
 export class ActivityNumericAnswer implements OnInit, OnChanges, OnDestroy {
     @Input() block: ActivityNumericQuestionBlock;
+    @Input() valueChangeStep: number;
     @Input() placeholder: string;
     @Input() readonly: boolean;
     @Output() valueChanged: EventEmitter<number> = new EventEmitter();
@@ -34,12 +41,17 @@ export class ActivityNumericAnswer implements OnInit, OnChanges, OnDestroy {
     private subs: Subscription;
 
     public ngOnInit(): void {
+        console.log('question:', this.block);
+
         this.initForm();
-        this.subs = this.numericField.valueChanges.subscribe(enteredValue => {
-            const answer = enteredValue !== null ? parseInt(enteredValue, 10) : null;
-            this.block.answer = answer;
-            this.numericField.patchValue(answer === null ? '' : answer, {onlySelf: true, emitEvent: false});
-            this.valueChanged.emit(answer);
+
+        this.subs = this.numericField.valueChanges.subscribe((enteredValue: number) => {
+            const answerToDisplay: string = this.mapAnswerToDisplay(enteredValue);
+            const answerToPatch: number | DecimalAnswer = this.mapAnswerToPatchToServer(answerToDisplay);
+
+            this.numericField.patchValue(answerToDisplay, {onlySelf: true, emitEvent: false});
+            this.block.answer = answerToPatch as any;
+            this.valueChanged.emit(answerToPatch as any);
         });
     }
 
@@ -60,8 +72,71 @@ export class ActivityNumericAnswer implements OnInit, OnChanges, OnDestroy {
 
     private initForm(): void {
         this.numericField = new FormControl({
-            value: _.isNumber(this.block.answer) ? this.block.answer : '',
+            value: this.mapAnswerToDisplay(this.block.answer),
             disabled: this.readonly
         }, {updateOn: 'blur'});
     }
+
+    private get isIntegerQuestion(): boolean {
+        return this.block.numericType === NumericType.Integer;
+    }
+
+    // e.g. .71 => '0.710' (scale = 3)
+    private mapAnswerToDisplay(patchAnswer: number | null): string {
+        if (patchAnswer == null) {
+            return '';
+        }
+
+        return this.isIntegerQuestion ?
+            patchAnswer.toString() :
+            this.formatDecimalAnswerToDisplay(patchAnswer);
+    }
+
+    // e.g. '0.710' => {  // a decimal floating-point value represented by (value * 10^-scale)
+    //   "value": 710,  // the significand of a decimal number
+    //   "scale": 3     // the exponent of a decimal number
+    // }
+    private mapAnswerToPatchToServer(answerValue: string): number | DecimalAnswer | null {
+        if (answerValue === null) {
+            return null;
+        }
+
+        return this.isIntegerQuestion ?
+            parseInt(answerValue, 10) :
+            this.formatDecimalAnswer(answerValue);
+    }
+
+    private formatDecimalAnswer(answerValue: string): DecimalAnswer {
+        const [integerPart = '', decimalPart = ''] = answerValue.split('.');
+        const res = {
+            value: +integerPart.concat(decimalPart),
+            scale: decimalPart.length
+        };
+        console.log('Decimal to patch:', res);
+        return res;
+    }
+
+    private formatDecimalAnswerToDisplay(enteredValue: number): string {
+        const precise: number = this.block.precision;
+        const scale: number = this.block.scale;
+        const hideLeadingZero: boolean = this.block.hideLeadingZero || false;
+
+        let [
+            integerPart = hideLeadingZero ? '' : '0',
+            decimalPart = '0'.repeat(scale)
+        ] = String(enteredValue).split('.');
+
+        if (precise && !!Number(integerPart)) {
+            integerPart = integerPart.slice(0, precise);
+        }
+
+        if (decimalPart.length < scale) {
+            decimalPart += '0'.repeat(scale - decimalPart.length);
+        }
+        const res = (`${integerPart}.${decimalPart.slice(0, scale)}`);
+
+        console.log('Decimal to display:', res);
+        return res;
+    }
+
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.ts
@@ -8,6 +8,7 @@ import { ActivityDecimalQuestionBlock } from '../../../models/activity/activityD
 import { ActivityQuestionBlock } from '../../../models/activity/activityQuestionBlock';
 import { NumericAnswerType } from '../../../models/activity/numericAnswerType';
 import { DecimalAnswer } from '../../../models/activity/decimalAnswer';
+import { AbstractActivityQuestionBlock } from '../../../models/activity/abstractActivityQuestionBlock';
 
 @Component({
     selector: 'ddp-activity-numeric-answer',
@@ -33,7 +34,6 @@ import { DecimalAnswer } from '../../../models/activity/decimalAnswer';
 })
 export class ActivityNumericAnswer implements OnInit, OnChanges, OnDestroy {
     @Input() block: ActivityNumericQuestionBlock | ActivityDecimalQuestionBlock;
-    @Input() valueChangeStep = 1;
     @Input() placeholder: string;
     @Input() readonly: boolean;
     @Output() valueChanged: EventEmitter<NumericAnswerType> = new EventEmitter();
@@ -66,6 +66,10 @@ export class ActivityNumericAnswer implements OnInit, OnChanges, OnDestroy {
                 this.readonly ? this.numericField.disable({ emitEvent: false }) : this.numericField.enable({ emitEvent: false });
             }
         }
+    }
+
+    public get valueChangeStep(): number {
+        return this.isDecimalQuestion(this.block) ? Math.pow(10, -((this.block as ActivityDecimalQuestionBlock).scale)) : 1;
     }
 
     private initForm(): void {
@@ -130,5 +134,9 @@ export class ActivityNumericAnswer implements OnInit, OnChanges, OnDestroy {
 
     private mapDecimalAnswerToNumber(answer: DecimalAnswer ): number {
         return answer.value * Math.pow(10, -(answer.scale || 0));
+    }
+
+    private isDecimalQuestion(block: AbstractActivityQuestionBlock): boolean {
+        return block.questionType === QuestionType.Decimal;
     }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.ts
@@ -130,7 +130,7 @@ export class ActivityNumericAnswer implements OnInit, OnChanges, OnDestroy {
         if (decimalPart.length < scale) {
             decimalPart += '0'.repeat(scale - decimalPart.length);
         }
-        const res = (`${integerPart}.${decimalPart.slice(0, scale)}`);
+        const res = integerPart + (scale ? `.${decimalPart.slice(0, scale)}` : '');
 
         console.log('Decimal to display:', res);
         return res;

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.ts
@@ -112,18 +112,13 @@ export class ActivityNumericAnswer implements OnInit, OnChanges, OnDestroy {
     }
 
     private formatDecimalAnswerToDisplay(enteredValue: number): string {
-        const precise: number = this.block.precision;
         const scale: number = this.block.scale;
-        const hideLeadingZero: boolean = this.block.hideLeadingZero || false;
 
         let [
-            integerPart = hideLeadingZero ? '' : '0',
+            // eslint-disable-next-line prefer-const
+            integerPart = '0',
             decimalPart = '0'.repeat(scale)
         ] = String(enteredValue).split('.');
-
-        if (precise && !!Number(integerPart)) {
-            integerPart = integerPart.slice(0, precise);
-        }
 
         if (decimalPart.length < scale) {
             decimalPart += '0'.repeat(scale - decimalPart.length);

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityDecimalQuestionBlock.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityDecimalQuestionBlock.ts
@@ -10,7 +10,7 @@ export type NumericAnswerType = number | DecimalAnswer;
 export class ActivityDecimalQuestionBlock extends ActivityQuestionBlock<DecimalAnswer> {
     public min: DecimalAnswer | null = null;
     public max: DecimalAnswer | null = null;
-    public scale: number = 2; // for decimal answers - the maximum number of allowed decimal digits. Default value = 2
+    public scale = 2; // for decimal answers - the maximum number of allowed decimal digits. Default value = 2
 
     constructor() {
         super();

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityDecimalQuestionBlock.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityDecimalQuestionBlock.ts
@@ -10,7 +10,7 @@ export type NumericAnswerType = number | DecimalAnswer;
 export class ActivityDecimalQuestionBlock extends ActivityQuestionBlock<DecimalAnswer> {
     public min: DecimalAnswer | null = null;
     public max: DecimalAnswer | null = null;
-    public scale = 2; // for decimal answers - the maximum number of allowed decimal digits. Default value = 2
+    public scale = 0; // for decimal answers - the maximum number of allowed decimal digits. Default value = 0
 
     constructor() {
         super();

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityDecimalQuestionBlock.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityDecimalQuestionBlock.ts
@@ -1,0 +1,27 @@
+import { ActivityQuestionBlock } from './activityQuestionBlock';
+import { QuestionType } from './questionType';
+
+export interface DecimalAnswer {
+    value: number;
+    scale: number;
+}
+export type NumericAnswerType = number | DecimalAnswer;
+
+export class ActivityDecimalQuestionBlock extends ActivityQuestionBlock<DecimalAnswer> {
+    public min: DecimalAnswer | null = null;
+    public max: DecimalAnswer | null = null;
+    public scale: number = 2; // for decimal answers - the maximum number of allowed decimal digits. Default value = 2
+
+    constructor() {
+        super();
+    }
+
+    public get questionType(): QuestionType {
+        return QuestionType.Decimal;
+    }
+
+    public hasAnswer(): boolean {
+        // TODO: tweak it for `REQUIRED` validation rule
+        return this.answer != null;
+    }
+}

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityDecimalQuestionBlock.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityDecimalQuestionBlock.ts
@@ -1,11 +1,6 @@
 import { ActivityQuestionBlock } from './activityQuestionBlock';
 import { QuestionType } from './questionType';
-
-export interface DecimalAnswer {
-    value: number;
-    scale: number;
-}
-export type NumericAnswerType = number | DecimalAnswer;
+import { DecimalAnswer } from './decimalAnswer';
 
 export class ActivityDecimalQuestionBlock extends ActivityQuestionBlock<DecimalAnswer> {
     public min: DecimalAnswer | null = null;

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityNumericQuestionBlock.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityNumericQuestionBlock.ts
@@ -10,9 +10,7 @@ export type NumericAnswerType = number | DecimalAnswer;
 export class ActivityNumericQuestionBlock extends ActivityQuestionBlock<NumericAnswerType> {
     public min: number | null = null;
     public max: number | null = null;
-    public precision: number; // for decimal answers - the maximum number of allowed significant digits
     public scale: number; // for decimal answers - the maximum number of allowed decimal digits
-    public hideLeadingZero: boolean; // for decimal answers - if we need to hide the leading zero if value is in the range `1 < 0 < -1`
 
     constructor(private isDecimal: boolean = false) {
         super();

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityNumericQuestionBlock.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityNumericQuestionBlock.ts
@@ -6,6 +6,9 @@ export class ActivityNumericQuestionBlock extends ActivityQuestionBlock<number> 
     public numericType: NumericType;
     public min: number | null = null;
     public max: number | null = null;
+    public precision: number; // for decimal answers - the maximum number of allowed significant digits
+    public scale: number; // for decimal answers - the maximum number of allowed decimal digits
+    public hideLeadingZero: boolean; // for decimal answers - if we need to hide the leading zero if value is in the range `1 < 0 < -1`
 
     constructor() {
         super();

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityNumericQuestionBlock.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityNumericQuestionBlock.ts
@@ -1,23 +1,16 @@
 import { ActivityQuestionBlock } from './activityQuestionBlock';
 import { QuestionType } from './questionType';
 
-export interface DecimalAnswer {
-    value: number;
-    scale: number;
-}
-export type NumericAnswerType = number | DecimalAnswer;
-
-export class ActivityNumericQuestionBlock extends ActivityQuestionBlock<NumericAnswerType> {
+export class ActivityNumericQuestionBlock extends ActivityQuestionBlock<number> {
     public min: number | null = null;
     public max: number | null = null;
-    public scale: number; // for decimal answers - the maximum number of allowed decimal digits
 
-    constructor(private isDecimal: boolean = false) {
+    constructor() {
         super();
     }
 
     public get questionType(): QuestionType {
-        return this.isDecimal ? QuestionType.Decimal : QuestionType.Numeric;
+        return QuestionType.Numeric;
     }
 
     public hasAnswer(): boolean {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityNumericQuestionBlock.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityNumericQuestionBlock.ts
@@ -1,21 +1,25 @@
-import { NumericType } from './numericType';
 import { ActivityQuestionBlock } from './activityQuestionBlock';
 import { QuestionType } from './questionType';
 
-export class ActivityNumericQuestionBlock extends ActivityQuestionBlock<number> {
-    public numericType: NumericType;
+export interface DecimalAnswer {
+    value: number;
+    scale: number;
+}
+export type NumericAnswerType = number | DecimalAnswer;
+
+export class ActivityNumericQuestionBlock extends ActivityQuestionBlock<NumericAnswerType> {
     public min: number | null = null;
     public max: number | null = null;
     public precision: number; // for decimal answers - the maximum number of allowed significant digits
     public scale: number; // for decimal answers - the maximum number of allowed decimal digits
     public hideLeadingZero: boolean; // for decimal answers - if we need to hide the leading zero if value is in the range `1 < 0 < -1`
 
-    constructor() {
+    constructor(private isDecimal: boolean = false) {
         super();
     }
 
     public get questionType(): QuestionType {
-        return QuestionType.Numeric;
+        return this.isDecimal ? QuestionType.Decimal : QuestionType.Numeric;
     }
 
     public hasAnswer(): boolean {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/answerValue.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/answerValue.ts
@@ -1,7 +1,7 @@
 import { DatePickerValue } from '../datePickerValue';
 import { ActivityPicklistAnswerDto } from './activityPicklistAnswerDto';
 import { ActivityMatrixAnswerDto } from './activityMatrixAnswerDto';
-import { NumericAnswerType } from './activityDecimalQuestionBlock';
+import { NumericAnswerType } from './numericAnswerType';
 
 export type AnswerValue =
   | boolean

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/answerValue.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/answerValue.ts
@@ -1,13 +1,14 @@
 import { DatePickerValue } from '../datePickerValue';
 import { ActivityPicklistAnswerDto } from './activityPicklistAnswerDto';
 import { ActivityMatrixAnswerDto } from './activityMatrixAnswerDto';
+import { NumericAnswerType } from './activityNumericQuestionBlock';
 
 export type AnswerValue =
   | boolean
   | string
   | Array<ActivityPicklistAnswerDto>
   | DatePickerValue
-  | number
+  | NumericAnswerType
   | null
   | any[][]
   | ActivityMatrixAnswerDto[];

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/answerValue.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/answerValue.ts
@@ -1,7 +1,7 @@
 import { DatePickerValue } from '../datePickerValue';
 import { ActivityPicklistAnswerDto } from './activityPicklistAnswerDto';
 import { ActivityMatrixAnswerDto } from './activityMatrixAnswerDto';
-import { NumericAnswerType } from './activityNumericQuestionBlock';
+import { NumericAnswerType } from './activityDecimalQuestionBlock';
 
 export type AnswerValue =
   | boolean

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/decimalAnswer.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/decimalAnswer.ts
@@ -1,0 +1,4 @@
+export interface DecimalAnswer {
+    value: number;
+    scale: number;
+}

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/numericAnswerType.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/numericAnswerType.ts
@@ -1,0 +1,3 @@
+import { DecimalAnswer } from './decimalAnswer';
+
+export type NumericAnswerType = number | DecimalAnswer;

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/numericType.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/numericType.ts
@@ -1,4 +1,0 @@
-export enum NumericType {
-    Integer = 'INTEGER',
-    Decimal = 'DECIMAL'
-}

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/numericType.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/numericType.ts
@@ -1,3 +1,4 @@
 export enum NumericType {
-    Integer = 'INTEGER'
+    Integer = 'INTEGER',
+    Decimal = 'DECIMAL'
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/questionType.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/questionType.ts
@@ -7,6 +7,7 @@ export enum QuestionType {
     Composite = 'COMPOSITE',
     Agreement = 'AGREEMENT',
     Numeric = 'NUMERIC',
+    Decimal = 'DECIMAL',
     File = 'FILE',
     Matrix = 'MATRIX',
     ActivityInstanceSelect = 'ACTIVITY_INSTANCE_SELECT',

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityQuestionConverter.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityQuestionConverter.service.ts
@@ -146,6 +146,10 @@ export class ActivityQuestionConverter {
                 func: (questionJson) => this.getNumericBlock(questionJson)
             },
             {
+                type: QuestionType.Decimal,
+                func: (questionJson) => this.getNumericBlock(questionJson, true)
+            },
+            {
                 type: QuestionType.Picklist,
                 func: (questionJson) => this.getPicklistBlock(questionJson)
             },
@@ -208,10 +212,9 @@ export class ActivityQuestionConverter {
         return textBlock;
     }
 
-    private getNumericBlock(questionJson: any): ActivityNumericQuestionBlock {
-        const numericBlock = new ActivityNumericQuestionBlock();
+    private getNumericBlock(questionJson: any, isDecimal?: boolean): ActivityNumericQuestionBlock {
+        const numericBlock = new ActivityNumericQuestionBlock(isDecimal);
         numericBlock.placeholder = questionJson.placeholderText;
-        numericBlock.numericType = questionJson.numericType;
         questionJson.validations.forEach(validation => {
             if (_.isNumber(validation.min)) {
                 numericBlock.min = validation.min;

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityQuestionConverter.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityQuestionConverter.service.ts
@@ -227,8 +227,9 @@ export class ActivityQuestionConverter {
     private getDecimalBlock(questionJson: any): ActivityDecimalQuestionBlock {
         const decimalBlock = new ActivityDecimalQuestionBlock();
         decimalBlock.placeholder = questionJson.placeholderText;
-        decimalBlock.scale = questionJson.scale;
-
+        if (questionJson.scale) {
+            decimalBlock.scale = questionJson.scale;
+        }
         // TODO: add min/max from ValidationRuleType.DecimalRange (in scope of DDP-7573)
         return decimalBlock;
     }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityQuestionConverter.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityQuestionConverter.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { LoggingService } from '../logging.service';
 import { ActivitySuggestionBuilder } from './activitySuggestionBuilder.service';
-import { ActivityValidatorBuilder, ValidationRuleType } from './activityValidatorBuilder.service';
+import { ActivityValidatorBuilder } from './activityValidatorBuilder.service';
 import { ActivityRule } from '../../models/activity/activityRule';
 import { ActivityBooleanQuestionBlock } from '../../models/activity/activityBooleanQuestionBlock';
 import { ActivityAgreementQuestionBlock } from '../../models/activity/activityAgreementQuestionBlock';
@@ -24,6 +24,7 @@ import * as _ from 'underscore';
 import { PicklistRenderMode } from '../../models/activity/picklistRenderMode';
 import { ActivityInstanceSelectQuestionBlock } from '../../models/activity/activityInstanceSelectQuestionBlock';
 import { ActivityDecimalQuestionBlock } from '../../models/activity/activityDecimalQuestionBlock';
+import { ValidationRuleType } from './validationRuleType';
 
 const DETAIL_MAXLENGTH = 500;
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityValidatorBuilder.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityValidatorBuilder.service.ts
@@ -28,6 +28,21 @@ import { ActivityPicklistQuestionBlock } from '../../models/activity/activityPic
 import { ActivityStrictMatchValidationRule } from './validators/activityStrictMatchValidationRule';
 import { ActivityUniqueValidationRule } from './validators/activityUniqueValidationRule';
 
+export enum ValidationRuleType {
+    Required = 'REQUIRED',
+    Complete = 'COMPLETE',
+    Length = 'LENGTH',
+    Regex = 'REGEX',
+    NumOptionsSelected = 'NUM_OPTIONS_SELECTED',
+    YearRequired = 'YEAR_REQUIRED',
+    MonthRequired = 'MONTH_REQUIRED',
+    DayRequired = 'DAY_REQUIRED',
+    DateRange = 'DATE_RANGE',
+    AgeRange = 'AGE_RANGE',
+    IntRange = 'INT_RANGE',
+    Unique = 'UNIQUE'
+}
+
 @Injectable()
 export class ActivityValidatorBuilder {
     private rules: Array<ValidationRuleFactoryMapping>;
@@ -37,20 +52,20 @@ export class ActivityValidatorBuilder {
         private dateService: DateService,
         private logger: LoggingService) {
         this.rules = [
-            { type: 'REQUIRED', factory: (x, y) => new ActivityRequiredValidationRule(y) },
-            { type: 'COMPLETE', factory: (x, y) => new ActivityCompleteValidationRule(y) },
-            { type: 'LENGTH', factory: (x, y) => this.buildLengthValidator(x, y) },
-            { type: 'REGEX', factory: (x, y) => new ActivityRegexValidationRule(y, x.regexPattern) },
-            { type: 'NUM_OPTIONS_SELECTED',
+            { type: ValidationRuleType.Required, factory: (x, y) => new ActivityRequiredValidationRule(y) },
+            { type: ValidationRuleType.Complete, factory: (x, y) => new ActivityCompleteValidationRule(y) },
+            { type: ValidationRuleType.Length, factory: (x, y) => this.buildLengthValidator(x, y) },
+            { type: ValidationRuleType.Regex, factory: (x, y) => new ActivityRegexValidationRule(y, x.regexPattern) },
+            { type: ValidationRuleType.NumOptionsSelected,
               factory: (x, y) => new ActivityOptionsAmountValidationRule(y, x.minSelections, x.maxSelections)
             },
-            { type: 'YEAR_REQUIRED', factory: (x, y) => new ActivityYearRequiredDateValidationRule(y) },
-            { type: 'MONTH_REQUIRED', factory: (x, y) => new ActivityMonthRequiredDateValidationRule(y) },
-            { type: 'DAY_REQUIRED', factory: (x, y) => new ActivityDayRequiredDateValidationRule(y) },
-            { type: 'DATE_RANGE', factory: (x, y) => this.buildDateRangeValidator(x, y) },
-            { type: 'AGE_RANGE', factory: (x, y) => this.buildAgeRangeValidator(x, y) },
-            { type: 'INT_RANGE', factory: (x, y) => this.buildNumericRangeValidator(x, y) },
-            { type: 'UNIQUE', factory: (x, y) => new ActivityUniqueValidationRule(y) },
+            { type: ValidationRuleType.YearRequired, factory: (x, y) => new ActivityYearRequiredDateValidationRule(y) },
+            { type: ValidationRuleType.MonthRequired, factory: (x, y) => new ActivityMonthRequiredDateValidationRule(y) },
+            { type: ValidationRuleType.DayRequired, factory: (x, y) => new ActivityDayRequiredDateValidationRule(y) },
+            { type: ValidationRuleType.DateRange, factory: (x, y) => this.buildDateRangeValidator(x, y) },
+            { type: ValidationRuleType.AgeRange, factory: (x, y) => this.buildAgeRangeValidator(x, y) },
+            { type: ValidationRuleType.IntRange, factory: (x, y) => this.buildNumericRangeValidator(x, y) },
+            { type: ValidationRuleType.Unique, factory: (x, y) => new ActivityUniqueValidationRule(y) },
         ];
     }
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityValidatorBuilder.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityValidatorBuilder.service.ts
@@ -27,21 +27,7 @@ import { PicklistRenderMode } from '../../models/activity/picklistRenderMode';
 import { ActivityPicklistQuestionBlock } from '../../models/activity/activityPicklistQuestionBlock';
 import { ActivityStrictMatchValidationRule } from './validators/activityStrictMatchValidationRule';
 import { ActivityUniqueValidationRule } from './validators/activityUniqueValidationRule';
-
-export enum ValidationRuleType {
-    Required = 'REQUIRED',
-    Complete = 'COMPLETE',
-    Length = 'LENGTH',
-    Regex = 'REGEX',
-    NumOptionsSelected = 'NUM_OPTIONS_SELECTED',
-    YearRequired = 'YEAR_REQUIRED',
-    MonthRequired = 'MONTH_REQUIRED',
-    DayRequired = 'DAY_REQUIRED',
-    DateRange = 'DATE_RANGE',
-    AgeRange = 'AGE_RANGE',
-    IntRange = 'INT_RANGE',
-    Unique = 'UNIQUE'
-}
+import { ValidationRuleType } from './validationRuleType';
 
 @Injectable()
 export class ActivityValidatorBuilder {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validationRuleType.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validationRuleType.ts
@@ -1,0 +1,14 @@
+export enum ValidationRuleType {
+    Required = 'REQUIRED',
+    Complete = 'COMPLETE',
+    Length = 'LENGTH',
+    Regex = 'REGEX',
+    NumOptionsSelected = 'NUM_OPTIONS_SELECTED',
+    YearRequired = 'YEAR_REQUIRED',
+    MonthRequired = 'MONTH_REQUIRED',
+    DayRequired = 'DAY_REQUIRED',
+    DateRange = 'DATE_RANGE',
+    AgeRange = 'AGE_RANGE',
+    IntRange = 'INT_RANGE',
+    Unique = 'UNIQUE'
+}

--- a/ddp-workspace/projects/ddp-sdk/src/public-api.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/public-api.ts
@@ -32,7 +32,6 @@ export * from './lib/models/activity/activityGroupBlock';
 export * from './lib/models/activity/activityContentBlock';
 export * from './lib/models/activity/conditionalBlock';
 export * from './lib/models/activity/MailAddressBlock';
-export * from './lib/models/activity/numericType';
 export * from './lib/models/activity/textSuggestion';
 export * from './lib/models/activity/activityForm';
 export * from './lib/models/activity/createActivityInstanceResponse';

--- a/ddp-workspace/projects/study-builder-ui/src/app/model/core/numericQuestionDef.ts
+++ b/ddp-workspace/projects/study-builder-ui/src/app/model/core/numericQuestionDef.ts
@@ -1,9 +1,7 @@
 import { Template } from './template';
-import { NumericType } from './numericType';
 import { AbstractQuestionDef } from './abstractQuestionDef';
 
 export interface NumericQuestionDef extends AbstractQuestionDef {
-  numericType: NumericType;
   placeholderTemplate: Template;
   questionType: 'NUMERIC';
 }

--- a/ddp-workspace/projects/study-builder-ui/src/app/model/core/numericType.ts
+++ b/ddp-workspace/projects/study-builder-ui/src/app/model/core/numericType.ts
@@ -1,1 +1,0 @@
-export type NumericType = 'INTEGER';


### PR DESCRIPTION
Implemented UI (Angular) part of decimal data type [(DDP-7184 epic)](https://broadinstitute.atlassian.net/browse/DDP-7184).

**_Notes:_** 
 - used separate data models (**NUMERIC** - ActivityNumericQuestionBlock/ **DECIMAL** - ActivityDecimalQuestionBlock) as to apply **"REQUIRED"** validator in a generic way (will be tweaked in DDP-7573)
 - used the same component ActivityNumericAnswer for both **NUMERIC** / **DECIMAL** answers
     in order to avoid lots of duplication (logic / styles)
- set `valueChangeStep` property calculated from a question scale. It is used as an input step (the input value can be changed by ArrowUp/ArrowDown)
- default value for a question scale ("_the number of digits allowed to the right of the decimal point_") is 0 (zero). In this case the input value does not have any decimal part (the number is integer). _**See the first screenshot below.**_

**_Screenshots:_**

1) Display a saved decimal answer (question scale is not defined in the server response)
![q1](https://user-images.githubusercontent.com/7396837/154140728-8a38dff7-7ea0-40b0-b7ee-351a84ee796b.png)

2) Patch a decimal answer (question scale = 2, cut all extra digits from the right, e.g. `3.141516` => `3.14` )
![q2](https://user-images.githubusercontent.com/7396837/154140747-ded74f26-930c-4c85-a269-d0626aef84a8.png)
