### PR TITLE
DDP-7406: fix:  hide autocomplete options on scroll

### DIFF
--- a/ddp-workspace/package-lock.json
+++ b/ddp-workspace/package-lock.json
@@ -31,6 +31,7 @@
         "assert": "^2.0.0",
         "auth0-js": "9.14.0",
         "auth0-lock": "^11.30.6",
+        "autobind-decorator": "^2.4.0",
         "bootstrap": "3.4.1",
         "core-js": "^3.18.3",
         "file-saver": "^2.0.5",
@@ -5146,6 +5147,15 @@
       "integrity": "sha512-ZshousKt+Wfv/iIBS3oQfOsH8NBF9IbL15qd2Qur8YfiQrRjrAT0T7VaesnrytYEHEXkUbHcdxWEAlyr16w20A==",
       "dependencies": {
         "password-sheriff": "^1.1.0"
+      }
+    },
+    "node_modules/autobind-decorator": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/autobind-decorator/-/autobind-decorator-2.4.0.tgz",
+      "integrity": "sha512-OGYhWUO72V6DafbF8PM8rm3EPbfuyMZcJhtm5/n26IDwO18pohE4eNazLoCGhPiXOCD0gEGmrbU3849QvM8bbw==",
+      "engines": {
+        "node": ">=8.10",
+        "npm": ">=6.4.1"
       }
     },
     "node_modules/autoprefixer": {
@@ -21215,6 +21225,11 @@
       "requires": {
         "password-sheriff": "^1.1.0"
       }
+    },
+    "autobind-decorator": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/autobind-decorator/-/autobind-decorator-2.4.0.tgz",
+      "integrity": "sha512-OGYhWUO72V6DafbF8PM8rm3EPbfuyMZcJhtm5/n26IDwO18pohE4eNazLoCGhPiXOCD0gEGmrbU3849QvM8bbw=="
     },
     "autoprefixer": {
       "version": "10.4.2",

--- a/ddp-workspace/package.json
+++ b/ddp-workspace/package.json
@@ -40,6 +40,7 @@
     "assert": "^2.0.0",
     "auth0-js": "9.14.0",
     "auth0-lock": "^11.30.6",
+    "autobind-decorator": "^2.4.0",
     "bootstrap": "3.4.1",
     "core-js": "^3.18.3",
     "file-saver": "^2.0.5",

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
@@ -3,6 +3,7 @@ import { FormControl } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, map, startWith, takeUntil } from 'rxjs/operators';
 import { MatAutocomplete, MatAutocompleteTrigger } from '@angular/material/autocomplete';
+import { boundMethod } from 'autobind-decorator';
 
 import { BaseActivityPicklistQuestion } from './baseActivityPicklistQuestion.component';
 import { ActivityPicklistNormalizedGroup } from '../../../models/activity/activityPicklistNormalizedGroup';
@@ -20,7 +21,8 @@ import { StringsHelper } from '../../../utility/stringsHelper';
                #autocompleteInput
                [formControl]="inputFormControl"
                [placeholder]="block.picklistLabel"
-               [matAutocomplete]="autoCompleteFromSource" />
+               [matAutocomplete]="autoCompleteFromSource"
+               (click)="openAutocompleteOptions()" />
 
         <mat-autocomplete #autoCompleteFromSource="matAutocomplete" class="autoCompletePanel" [displayWith]="displayAutoComplete">
             <mat-optgroup *ngFor="let group of filteredGroups">
@@ -120,13 +122,20 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
         window.removeEventListener('scroll', this.onScroll, true);
     }
 
-    onScroll = (event): void => {
+    @boundMethod
+    public onScroll(event): void {
         const isAutoCompleteOptionsScrolling = event.target === this.autocompleteSource.panel?.nativeElement;
 
         if (this.autocompleteTrigger.panelOpen && !isAutoCompleteOptionsScrolling) {
             this.autocompleteTrigger.closePanel();
         }
-    };
+    }
+
+    public openAutocompleteOptions(): void {
+        if (!this.autocompleteTrigger.panelOpen) {
+            this.autocompleteTrigger.openPanel();
+        }
+    }
 
     private initInputValue(): void {
         const answer = this.block.answer && this.block.answer[0];

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/autocompleteActivityPicklistQuestion.component.ts
@@ -1,7 +1,8 @@
-import { Component, Inject, OnChanges, OnDestroy, OnInit, SimpleChanges } from '@angular/core';
+import { Component, Inject, OnChanges, OnDestroy, OnInit, SimpleChanges, ViewChild } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, map, startWith, takeUntil } from 'rxjs/operators';
+import { MatAutocomplete, MatAutocompleteTrigger } from '@angular/material/autocomplete';
 
 import { BaseActivityPicklistQuestion } from './baseActivityPicklistQuestion.component';
 import { ActivityPicklistNormalizedGroup } from '../../../models/activity/activityPicklistNormalizedGroup';
@@ -51,6 +52,8 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
     inputFormControl = new FormControl();
     readonly ignoredSymbolsInQuery: string[];
     private readonly ngUnsubscribe = new Subject<void>();
+    @ViewChild('autocompleteInput', { read: MatAutocompleteTrigger }) autocompleteTrigger: MatAutocompleteTrigger;
+    @ViewChild('autoCompleteFromSource') autocompleteSource: MatAutocomplete;
 
     constructor(
         translate: NGXTranslateService,
@@ -96,6 +99,8 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
                 this.updateAnswer(value.stableId);
             }
         });
+
+        window.addEventListener('scroll', this.onScroll, true);
     }
 
     public ngOnChanges(changes: SimpleChanges): void {
@@ -112,7 +117,16 @@ export class AutocompleteActivityPicklistQuestion extends BaseActivityPicklistQu
         super.ngOnDestroy();
         this.ngUnsubscribe.next();
         this.ngUnsubscribe.complete();
+        window.removeEventListener('scroll', this.onScroll, true);
     }
+
+    onScroll = (event): void => {
+        const isAutoCompleteOptionsScrolling = event.target === this.autocompleteSource.panel?.nativeElement;
+
+        if (this.autocompleteTrigger.panelOpen && !isAutoCompleteOptionsScrolling) {
+            this.autocompleteTrigger.closePanel();
+        }
+    };
 
     private initInputValue(): void {
         const answer = this.block.answer && this.block.answer[0];


### PR DESCRIPTION
It was requested that auto-complete dropdown options would disappear when a user scrolls up or down.

https://broadinstitute.atlassian.net/browse/DDP-7406