### PR TITLE
DDP-7649 | fix reload filter

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -1036,14 +1036,14 @@ export class ParticipantListComponent implements OnInit {
     }
   }
 
-  private setSavedFilterColumnsIfSelected() {
+  private setSavedFilterColumnsIfSelected(): void {
     const selectedSavedFilter = this.savedFilters.find(sf => sf.selected);
     if (selectedSavedFilter) {
       this.selectedColumns = selectedSavedFilter.columns;
     }
   }
 
-  private setQuickFilterColumnsIfSelected() {
+  private setQuickFilterColumnsIfSelected(): void {
     const selectedQuickFilter = this.quickFilters.find(qf => qf.selected);
     if (selectedQuickFilter) {
       this.selectedColumns = selectedQuickFilter.columns;
@@ -1138,9 +1138,6 @@ export class ParticipantListComponent implements OnInit {
     } else {
       this.selectedColumns[ parent ].push(column);
     }
-    // if (this.isDataOfViewFilterExists()) {
-    //   this.viewFilter.columns.data.push(column);
-    // }
   }
 
   private isDataOfViewFilterExists(): boolean {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -1022,13 +1022,31 @@ export class ParticipantListComponent implements OnInit {
   }
 
   private setDefaultColumns(): void {
-    if (this.isQuickFilterSelected() || this.isSavedFilterSelected()) {
+    if (this.isQuickFilterSelected()) {
+      this.setQuickFilterColumnsIfSelected();
+      return;
+    } else if (this.isSavedFilterSelected()) {
+      this.setSavedFilterColumnsIfSelected();
       return;
     }
     const filteredColumns = this.extractDefaultColumns(this.selectedColumns);
     Object.assign(this.selectedColumns, filteredColumns);
     if (this.isDataOfViewFilterExists()) {
       this.viewFilter.columns = this.extractDefaultColumns(this.viewFilter.columns);
+    }
+  }
+
+  private setSavedFilterColumnsIfSelected() {
+    const selectedSavedFilter = this.savedFilters.find(sf => sf.selected);
+    if (selectedSavedFilter) {
+      this.selectedColumns = selectedSavedFilter.columns;
+    }
+  }
+
+  private setQuickFilterColumnsIfSelected() {
+    const selectedQuickFilter = this.quickFilters.find(qf => qf.selected);
+    if (selectedQuickFilter) {
+      this.selectedColumns = selectedQuickFilter.columns;
     }
   }
 
@@ -1120,9 +1138,9 @@ export class ParticipantListComponent implements OnInit {
     } else {
       this.selectedColumns[ parent ].push(column);
     }
-    if (this.isDataOfViewFilterExists()) {
-      this.viewFilter.columns.data.push(column);
-    }
+    // if (this.isDataOfViewFilterExists()) {
+    //   this.viewFilter.columns.data.push(column);
+    // }
   }
 
   private isDataOfViewFilterExists(): boolean {


### PR DESCRIPTION
Ticket: https://broadinstitute.atlassian.net/browse/DDP-7649

**Things have done:**

- remove code which was adding column into view filter, which was causing keeping selected column even if reload with default filter was clicked.
- add two methods to replace selected columns if quick or saved filter is chosen.