### PR TITLE
add validation for initial request and display selected answer

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activity-picklist-remote-auto-complete-options.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activity-picklist-remote-auto-complete-options.component.ts
@@ -168,7 +168,7 @@ export class ActivityPicklistRemoteAutoCompleteOptionsComponent
         );
     }
 
-    onBlur(value: string, data: SplittedData) {
+    onBlur(value: string, data: SplittedData): void {
         const matchingOption = data.plOptions.find(pl => value.toLocaleLowerCase() === pl.optionLabel.toLocaleLowerCase());
         const plOption = matchingOption ? matchingOption : this.createNotListedOption(data.otherOption);
         this.onValueSelect(plOption);

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activity-picklist-remote-auto-complete-options.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activity-picklist-remote-auto-complete-options.component.ts
@@ -155,18 +155,6 @@ export class ActivityPicklistRemoteAutoCompleteOptionsComponent
         return '';
     }
 
-    validateIfMissingOptionShouldBeDisplayed(
-        picklistOptions: ActivityPicklistOption[]
-    ): boolean {
-        return (
-            this.searchValue$.value.length &&
-            !picklistOptions.filter((pl) =>
-                pl.optionLabel
-                    .toLocaleLowerCase()
-                    .includes(this.searchValue$.value.toLocaleLowerCase())
-            ).length
-        );
-    }
 
     onBlur(value: string, data: SplittedData): void {
         const matchingOption = data.plOptions.find(pl => value.toLocaleLowerCase() === pl.optionLabel.toLocaleLowerCase());

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activity-picklist-remote-auto-complete-options.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activity-picklist-remote-auto-complete-options.component.ts
@@ -28,6 +28,7 @@ import { BaseActivityPicklistQuestion } from './baseActivityPicklistQuestion.com
             [placeholder]="block.picklistLabel"
             [matAutocomplete]="autoCompleteFromSource"
             (keyup)="onInput($event.target.value)"
+            [(ngModel)]="block.answer[0].detail"
         />
 
         <mat-autocomplete
@@ -51,7 +52,7 @@ import { BaseActivityPicklistQuestion } from './baseActivityPicklistQuestion.com
                 ></span>
             </mat-option>
         </mat-autocomplete>
-    </mat-form-field>`,
+    </mat-form-field> `,
     styles: [
         `
             .full-width {
@@ -85,15 +86,17 @@ export class ActivityPicklistRemoteAutoCompleteOptionsComponent
 
     ngOnInit(): void {
         this.picklistOptions$ = this.searchValue$.pipe(
-            debounceTime(500),
+            debounceTime(1000),
             distinctUntilChanged(),
             switchMap((searchValue) =>
-                this.activityService.getPickListOptions(
-                    this.block.stableId,
-                    searchValue,
-                    this.studyGuid,
-                    this.activityGuid
-                )
+                searchValue.length > 0
+                    ? this.activityService.getPickListOptions(
+                          this.block.stableId,
+                          searchValue,
+                          this.studyGuid,
+                          this.activityGuid
+                      )
+                    : of({ results: [] })
             ),
             map((data) => data.results)
         );
@@ -107,11 +110,10 @@ export class ActivityPicklistRemoteAutoCompleteOptionsComponent
         return typeof option === 'string' ? option : option?.optionLabel || '';
     }
 
-    onValueSelect(
-        value: ActivityPicklistOption,
-        detail: string | null = null
-    ): void {
-        this.block.answer = value ? [{ stableId: value.stableId, detail }] : [];
+    onValueSelect(value: ActivityPicklistOption): void {
+        this.block.answer = value
+            ? [{ stableId: value.stableId, detail: value.optionLabel }]
+            : [];
         this.valueChanged.emit([...this.block.answer]);
     }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activity-picklist-remote-auto-complete-options.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activity-picklist-remote-auto-complete-options.component.ts
@@ -149,7 +149,7 @@ export class ActivityPicklistRemoteAutoCompleteOptionsComponent
     }
 
     getAnswer(): string {
-        if(this.block.answer[0]) {
+        if(this.block.answer && this.block.answer[0]) {
             return this.block.answer[0].detail ? this.block.answer[0].detail: this.block.picklistOptions[0].optionLabel;
         }
         return '';

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activity-picklist-remote-auto-complete-options.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activity-picklist-remote-auto-complete-options.component.ts
@@ -11,6 +11,7 @@ import {
 } from 'rxjs';
 import { ActivityPicklistNormalizedGroup } from '../../../models/activity/activityPicklistNormalizedGroup';
 import { ActivityPicklistOption } from '../../../models/activity/activityPicklistOption';
+import { ActivityPicklistQuestionBlock } from '../../../models/activity/activityPicklistQuestionBlock';
 import { NGXTranslateService } from '../../../services/internationalization/ngxTranslate.service';
 import { ActivityServiceAgent } from '../../../services/serviceAgents/activityServiceAgent.service';
 import { BaseActivityPicklistQuestion } from './baseActivityPicklistQuestion.component';
@@ -28,7 +29,7 @@ import { BaseActivityPicklistQuestion } from './baseActivityPicklistQuestion.com
             [placeholder]="block.picklistLabel"
             [matAutocomplete]="autoCompleteFromSource"
             (keyup)="onInput($event.target.value)"
-            [(ngModel)]="block.answer[0].detail"
+            [ngModel] = "block.picklistOptions[0].optionLabel"
         />
 
         <mat-autocomplete
@@ -52,7 +53,7 @@ import { BaseActivityPicklistQuestion } from './baseActivityPicklistQuestion.com
                 ></span>
             </mat-option>
         </mat-autocomplete>
-    </mat-form-field> `,
+    </mat-form-field>`,
     styles: [
         `
             .full-width {
@@ -89,14 +90,12 @@ export class ActivityPicklistRemoteAutoCompleteOptionsComponent
             debounceTime(1000),
             distinctUntilChanged(),
             switchMap((searchValue) =>
-                searchValue.length > 0
-                    ? this.activityService.getPickListOptions(
-                          this.block.stableId,
-                          searchValue,
-                          this.studyGuid,
-                          this.activityGuid
-                      )
-                    : of({ results: [] })
+                this.activityService.getPickListOptions(
+                    this.block.stableId,
+                    searchValue,
+                    this.studyGuid,
+                    this.activityGuid
+                )
             ),
             map((data) => data.results)
         );
@@ -110,10 +109,12 @@ export class ActivityPicklistRemoteAutoCompleteOptionsComponent
         return typeof option === 'string' ? option : option?.optionLabel || '';
     }
 
-    onValueSelect(value: ActivityPicklistOption): void {
-        this.block.answer = value
-            ? [{ stableId: value.stableId, detail: value.optionLabel }]
-            : [];
+    onValueSelect(
+        value: ActivityPicklistOption,
+        detail: string | null = null
+    ): void {
+        this.block.answer = value ? [{ stableId: value.stableId, detail }] : [];
         this.valueChanged.emit([...this.block.answer]);
     }
+
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activity-picklist-remote-auto-complete-options.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activity-picklist-remote-auto-complete-options.component.ts
@@ -88,7 +88,7 @@ export class ActivityPicklistRemoteAutoCompleteOptionsComponent
     ngOnInit(): void {
         const initSearchValue = this.getAnswer();
         this.searchValue$ = new BehaviorSubject(initSearchValue);
-
+        
         this.picklistOptions$ = this.searchValue$.pipe(
             debounceTime(500),
             distinctUntilChanged(),
@@ -163,13 +163,12 @@ export class ActivityPicklistRemoteAutoCompleteOptionsComponent
     }
 
     getAnswer(): string {
-        const option = this.block.picklistOptions.find(
-            (pl) => pl.stableId === this.block.answer[0].stableId
-        );
-        return this.block.answer
-            ? option.stableId === 'OTHER'
-                ? option.detailLabel
-                : option.optionLabel
+        return this.block.answer && this.block.answer[0]
+            ? this.block.answer[0].stableId !== 'OTHER'
+                ? this.block.picklistOptions.find(
+                      (pl) => pl.stableId === this.block.answer[0].stableId
+                  ).optionLabel
+                : this.block.answer[0].detail
             : '';
     }
 
@@ -179,7 +178,9 @@ export class ActivityPicklistRemoteAutoCompleteOptionsComponent
         return (
             this.searchValue$.value.length &&
             !picklistOptions.filter((pl) =>
-                pl.optionLabel.includes(this.searchValue$.value)
+                pl.optionLabel
+                    .toLocaleLowerCase()
+                    .includes(this.searchValue$.value.toLocaleLowerCase())
             ).length
         );
     }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activity-picklist-remote-auto-complete-options.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activity-picklist-remote-auto-complete-options.component.ts
@@ -88,7 +88,7 @@ export class ActivityPicklistRemoteAutoCompleteOptionsComponent
     ngOnInit(): void {
         const initSearchValue = this.getAnswer();
         this.searchValue$ = new BehaviorSubject(initSearchValue);
-        
+
         this.picklistOptions$ = this.searchValue$.pipe(
             debounceTime(500),
             distinctUntilChanged(),
@@ -119,7 +119,7 @@ export class ActivityPicklistRemoteAutoCompleteOptionsComponent
         };
     }
 
-    createNotListedOption(data: SplittedData) {
+    createNotListedOption(data: SplittedData): ActivityPicklistOption[] {
         const notListedOption = {
             ...data.otherOption,
             optionLabel: this.searchValue$.value.toLocaleUpperCase(),

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activity-picklist-remote-auto-complete-options.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activity-picklist-remote-auto-complete-options.component.ts
@@ -95,10 +95,10 @@ export class ActivityPicklistRemoteAutoCompleteOptionsComponent
             distinctUntilChanged(),
             switchMap((searchValue) =>
                 this.activityService.getPickListOptions(
-                    this.block.stableId,
-                    searchValue,
                     this.studyGuid,
-                    this.activityGuid
+                    this.activityGuid,
+                    this.block.stableId,
+                    searchValue
                 )
             ),
             map((data) => this.splitOtherOptionFromPLOptions(data.results)),

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activity-picklist-remote-auto-complete-options.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activity-picklist-remote-auto-complete-options.component.ts
@@ -29,7 +29,7 @@ import { BaseActivityPicklistQuestion } from './baseActivityPicklistQuestion.com
             [placeholder]="block.picklistLabel"
             [matAutocomplete]="autoCompleteFromSource"
             (keyup)="onInput($event.target.value)"
-            [ngModel] = "getInitialAnswerOptionLabel()"
+            [ngModel]="getInitialAnswerOptionLabel()"
         />
 
         <mat-autocomplete
@@ -90,12 +90,14 @@ export class ActivityPicklistRemoteAutoCompleteOptionsComponent
             debounceTime(1000),
             distinctUntilChanged(),
             switchMap((searchValue) =>
-                this.activityService.getPickListOptions(
-                    this.block.stableId,
-                    searchValue,
-                    this.studyGuid,
-                    this.activityGuid
-                )
+                searchValue.length > 0
+                    ? this.activityService.getPickListOptions(
+                          this.block.stableId,
+                          searchValue,
+                          this.studyGuid,
+                          this.activityGuid
+                      )
+                    : of({ results: [] })
             ),
             map((data) => data.results)
         );
@@ -118,9 +120,11 @@ export class ActivityPicklistRemoteAutoCompleteOptionsComponent
     }
 
     getInitialAnswerOptionLabel(): string {
-        if(this.block.selectMode === 'SINGLE') {
+        if (
+            this.block.selectMode === 'SINGLE' &&
+            this.block.picklistOptions.length
+        ) {
             return this.block.picklistOptions[0].optionLabel;
         }
     }
-
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activity-picklist-remote-auto-complete-options.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activity-picklist-remote-auto-complete-options.component.ts
@@ -12,9 +12,9 @@ import { NGXTranslateService } from '../../../services/internationalization/ngxT
 import { ActivityServiceAgent } from '../../../services/serviceAgents/activityServiceAgent.service';
 import { BaseActivityPicklistQuestion } from './baseActivityPicklistQuestion.component';
 
-interface SplittedData {
-    plOptions: ActivityPicklistOption[];
-    otherOption: ActivityPicklistOption;
+interface CategorizedPicklistOptions {
+    currentAutoCompleteOptions: ActivityPicklistOption[];
+    userEnteredStringOption: ActivityPicklistOption;
 }
 
 @Component({
@@ -75,7 +75,7 @@ export class ActivityPicklistRemoteAutoCompleteOptionsComponent
     @Input() activityGuid: string;
 
     searchValue$ = new BehaviorSubject('');
-    picklistOptions$: Observable<SplittedData>;
+    picklistOptions$: Observable<CategorizedPicklistOptions>;
 
     readonly ignoredSymbolsInQuery: string[];
 
@@ -108,10 +108,10 @@ export class ActivityPicklistRemoteAutoCompleteOptionsComponent
     }
     splitOtherOptionFromPLOptions(
         data: ActivityPicklistOption[]
-    ): SplittedData {
+    ): CategorizedPicklistOptions {
         return {
-            plOptions: data.filter((pl) => pl.allowDetails !== true),
-            otherOption: data.find((pl) => pl.allowDetails === true),
+            currentAutoCompleteOptions: data.filter((pl) => pl.allowDetails !== true),
+            userEnteredStringOption: data.find((pl) => pl.allowDetails === true),
         };
     }
 
@@ -156,9 +156,9 @@ export class ActivityPicklistRemoteAutoCompleteOptionsComponent
     }
 
 
-    onBlur(value: string, data: SplittedData): void {
-        const matchingOption = data.plOptions.find(pl => value.toLocaleLowerCase() === pl.optionLabel.toLocaleLowerCase());
-        const plOption = matchingOption ? matchingOption : this.createNotListedOption(data.otherOption);
+    onBlur(value: string, data: CategorizedPicklistOptions): void {
+        const matchingOption = data.currentAutoCompleteOptions.find(pl => value.toLocaleLowerCase() === pl.optionLabel.toLocaleLowerCase());
+        const plOption = matchingOption ? matchingOption : this.createNotListedOption(data.userEnteredStringOption);
         this.onValueSelect(plOption);
     }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activity-picklist-remote-auto-complete-options.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/activity-picklist-remote-auto-complete-options.component.ts
@@ -29,7 +29,7 @@ import { BaseActivityPicklistQuestion } from './baseActivityPicklistQuestion.com
             [placeholder]="block.picklistLabel"
             [matAutocomplete]="autoCompleteFromSource"
             (keyup)="onInput($event.target.value)"
-            [ngModel] = "block.picklistOptions[0].optionLabel"
+            [ngModel] = "getInitialAnswerOptionLabel()"
         />
 
         <mat-autocomplete
@@ -115,6 +115,12 @@ export class ActivityPicklistRemoteAutoCompleteOptionsComponent
     ): void {
         this.block.answer = value ? [{ stableId: value.stableId, detail }] : [];
         this.valueChanged.emit([...this.block.answer]);
+    }
+
+    getInitialAnswerOptionLabel(): string {
+        if(this.block.selectMode === 'SINGLE') {
+            return this.block.picklistOptions[0].optionLabel;
+        }
     }
 
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/activityServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/activityServiceAgent.service.ts
@@ -148,7 +148,7 @@ export class ActivityServiceAgent extends UserServiceAgent<any> {
     getPickListOptions(
         studyGuid: string,
         activityGuid: string,
-        stableId: string,
+        questionStableId: string,
         query: string = ''
     ): Observable<{ query: string; results: ActivityPicklistOption[] }> {
         const baseUrl = this.getBaseUrl(studyGuid, activityGuid);

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/activityServiceAgent.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/activityServiceAgent.service.ts
@@ -146,14 +146,14 @@ export class ActivityServiceAgent extends UserServiceAgent<any> {
     }
 
     getPickListOptions(
-        questionStableId: string,
-        query: string = '',
         studyGuid: string,
-        activityGuid: string
+        activityGuid: string,
+        stableId: string,
+        query: string = ''
     ): Observable<{ query: string; results: ActivityPicklistOption[] }> {
         const baseUrl = this.getBaseUrl(studyGuid, activityGuid);
         return this.getObservable(
-            `${baseUrl}/questions/${questionStableId}/options?q=${query}`,
+            `${baseUrl}/questions/${stableId}/options?q=${query}`,
             {},
             [404]
         );


### PR DESCRIPTION
Display selected answer on remote autocomplete picklist option.
Avoid backend request when query is empty.