### PR TITLE
DDP-7384: fix: validation excluding visible sections

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityForm.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/activityForm.ts
@@ -21,8 +21,12 @@ export class ActivityForm {
 
     public validate(validateOnlyVisibleSections?: boolean): boolean {
         let isValid = true;
-        const sectionsToValidate = this.getAllSections()
-            .filter(section => validateOnlyVisibleSections ? section.visible : section);
+
+        const sectionsToValidate = this.getAllSections().filter(
+            // section should be considered visible as long as `visible` prop isn't explicitly set to `false`
+            section => validateOnlyVisibleSections ? section.visible !== false : section
+        );
+
         for (const section of sectionsToValidate) {
             isValid = section.validate() && isValid;
         }


### PR DESCRIPTION
[DDP-7384](https://broadinstitute.atlassian.net/browse/DDP-7384?focusedCommentId=1303855) Comment bullet point 2

Lately added logic to only validate visible sections was missing an edge case where a section might not have `visible` prop set and should be still considered visible unless the prop is explicitly set to `false`.