### PR TITLE
DDP-7761/hit-return

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-text-input/activityTextInput.component.html
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-text-input/activityTextInput.component.html
@@ -7,6 +7,7 @@
 
     <input
       matInput
+      (keydown.enter)="onEnter($event)"
       type="text"
       [formControl]="formGroup.get(controlName)"
       [minlength]="block.minLength"

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-text-input/activityTextInput.component.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-text-input/activityTextInput.component.spec.ts
@@ -43,6 +43,9 @@ describe('ActivityTextInput', () => {
           BrowserAnimationsModule,
           TranslateTestingModule,
         ],
+        providers: [
+            { provide: 'ddp.config', useValue: {} },
+        ]
       }).compileComponents();
     }),
   );

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-text-input/activityTextInput.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-text-input/activityTextInput.component.ts
@@ -15,7 +15,7 @@ import { debounceTime, map, switchMap } from 'rxjs/operators';
 
 import { ActivityTextQuestionBlock } from '../../../../models/activity/activityTextQuestionBlock';
 import { TextSuggestion } from '../../../../models/activity/textSuggestion';
-import { ConfigurationService } from "../../../../services/configuration.service";
+import { ConfigurationService } from '../../../../services/configuration.service';
 
 @Component({
   selector: 'ddp-activity-text-input',
@@ -106,12 +106,12 @@ export class ActivityTextInput implements OnInit, OnChanges, OnDestroy {
     return taggedValue;
   }
 
-  onEnter(event: Event) {
+  onEnter(event: Event): void {
     event.preventDefault();
     this.configuration.moveToNextFieldWhileInTextInput && this.prepareElementsToMove(event);
   }
 
-  private prepareElementsToMove(event: Event) {
+  private prepareElementsToMove(event: Event): void {
       const elementsArray: Element[] = Array.from(document.querySelectorAll(['input', 'mat-select', 'select', 'textarea'].join(',')))
           .filter(input => input.id && (input as HTMLElement)?.style.display !== 'none');
       const elementsObjects: Map<Element, number> = new Map(elementsArray.map((input, i) => [input, i]));

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/configuration.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/configuration.service.ts
@@ -34,6 +34,8 @@ export class ConfigurationService {
     studyGuid: string;
     // Validate only visible sections
     validateOnlyVisibleSections = false;
+    // Move to the next field while pressing 'return' key in 'activityTextInput' element
+    moveToNextFieldWhileInTextInput = false;
     // country code if limiting app to just one country
     supportedCountry: string | null = null;
     // whether dashboard status should display a count of questions

--- a/ddp-workspace/projects/ddp-singular/src/app/config/sdk.provider.ts
+++ b/ddp-workspace/projects/ddp-singular/src/app/config/sdk.provider.ts
@@ -31,6 +31,7 @@ configurationService.auth0SilentRenewUrl = DDP_ENV.auth0SilentRenewUrl;
 configurationService.auth0CodeRedirect = location.origin + base + 'auth';
 configurationService.errorReportingApiKey = DDP_ENV.errorReportingApiKey;
 configurationService.localRegistrationUrl = configurationService.backendUrl + '/pepper/v1/register';
+configurationService.moveToNextFieldWhileInTextInput = true;
 configurationService.mailAddressFormErrorFormatter = (formControlName, fieldLabel, error) => {
   if (formControlName === 'state') {
     return `SDK.MailAddress.FormError.${fieldLabel.toLowerCase()}.${error}`;


### PR DESCRIPTION
The reason, why it was navigating to the dashboard when the 'return' key was pressed was the HTML input element that is written in the ActivityTextInput component. As this problem was occurring globally (in the other studies as well), I have prevented the default behavior of enter key event in this particular component only. 

As required, I have also implemented functionality that will ensure that pressing the 'return' key will take the user to the next field, But it works only in the ActivityTextInput component as I didn't want to totally prevent the default behavior of enter key, while it's necessary for such HTML elements, like 'textarea', 'select' and etc. Also, this last functionality is optional for each study, at the moment only Singular study will use that.

# Ticket: https://broadinstitute.atlassian.net/browse/DDP-7761