### PR TITLE
DDP-7527: Change `deprecation` linter rule

### DIFF
--- a/ddp-workspace/.eslintrc.json
+++ b/ddp-workspace/.eslintrc.json
@@ -97,7 +97,7 @@
             "allowTemplateLiterals": true
           }
         ],
-        "deprecation/deprecation": "off", // Temporarily changed from 'warn' to 'off'
+        "deprecation/deprecation": "warn",
         "quote-props": [
           "error",
           "as-needed"


### PR DESCRIPTION
Enabled `deprecation` linter rule. 

**NOTE:**
The PR can be merged when other related PR (https://github.com/broadinstitute/ddp-angular/pull/1174, https://github.com/broadinstitute/ddp-angular/pull/1176, https://github.com/broadinstitute/ddp-angular/pull/1188, https://github.com/broadinstitute/ddp-angular/pull/1195 ) are already merged.