### PR TITLE
DDP-7876: Equation rendering fix

### DIFF
--- a/ddp-workspace/projects/ddp-lms/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-lms/src/app/app.module.ts
@@ -79,20 +79,19 @@ const translateFactory =
 
       locationInitialized.then(() => {
         const locale = languageService.getAppLanguageCode();
-
         translateService.setDefaultLang(locale);
 
-        translateService.use(locale).subscribe(
-          () => {
+        translateService.use(locale).subscribe({
+          next: () => {
             loggingService.logEvent(LOG_SOURCE, `Successfully initialized '${locale}' language as default.`);
           },
-          err => {
+          error: err => {
             loggingService.logError(LOG_SOURCE, `Problem with '${locale}' language initialization:`, err);
           },
-          () => {
+          complete: () => {
             resolve(null);
           },
-        );
+        });
       });
     });
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-answer/activityAnswer.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-answer/activityAnswer.component.ts
@@ -77,7 +77,8 @@ import { BlockType } from '../../../../models/activity/blockType';
             </ddp-activity-instance-select-answer>
             <ddp-activity-equation-answer *ngIf="isCertainTypeOfQuestion(block, QuestionType.Equation)"
                                           [class]="'equation-answer-' + block.stableId"
-                                          [block]="block">
+                                          [block]="block"
+                                          (valueChanged)="onChange($event)">
             </ddp-activity-equation-answer>
             <span *ngIf="block.additionalInfoFooter"
                   [innerHTML]="block.additionalInfoFooter"

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-composite-answer/activityCompositeAnswer.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-composite-answer/activityCompositeAnswer.component.ts
@@ -139,7 +139,8 @@ export class ActivityCompositeAnswer implements OnChanges {
         this.block.setAnswer(childAnswers, false);
 
         // No point in emitting if the value is not valid. Not gonna patch it anyways
-        if (currentBlock.validate()) {
+        // Also don't emit values from questions that have read-only answers (e.g. Equation question)
+        if (currentBlock.validate() && currentBlock.generatesAnswers()) {
             const compositeAnswerValue: any[][] = this.childQuestionBlocks.map(childQuestionBlockRow =>
                 childQuestionBlockRow
                     // we don't patch an equation question answer because it is read-only

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-equation-answer/activityEquationAnswer.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-equation-answer/activityEquationAnswer.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
 
@@ -6,6 +6,7 @@ import { DecimalHelper } from '../../../../utility/decimalHelper';
 import { SubmissionManager } from '../../../../services/serviceAgents/submissionManager.service';
 import { ActivityEquationQuestionBlock } from '../../../../models/activity/activityEquationQuestionBlock';
 import { AnswerResponseEquation } from '../../../../models/activity/answerResponseEquation';
+import { DecimalAnswer } from '../../../../models/activity/decimalAnswer';
 
 @Component({
   selector: 'ddp-activity-equation-answer',
@@ -16,6 +17,7 @@ import { AnswerResponseEquation } from '../../../../models/activity/answerRespon
 })
 export class ActivityEquationAnswerComponent implements OnInit, OnDestroy {
     @Input() block: ActivityEquationQuestionBlock;
+    @Output() valueChanged: EventEmitter<DecimalAnswer[]> = new EventEmitter();
     private subscription: Subscription;
 
     constructor(private submissionManager: SubmissionManager) {
@@ -27,7 +29,15 @@ export class ActivityEquationAnswerComponent implements OnInit, OnDestroy {
                 (response.equations || []).filter(equation => this.block.stableId === equation.stableId)[0]
             )
         ).subscribe((equationToUpdate: AnswerResponseEquation) => {
-            equationToUpdate && this.block.setAnswer([equationToUpdate.values[this.block.compositeRowIndex || 0]], false);
+            if (equationToUpdate) {
+                const newValue = [equationToUpdate.values[this.block.compositeRowIndex || 0]];
+                this.block.setAnswer(newValue, false);
+
+                if (this.block.compositeRowIndex != null) {
+                    // if the equation is a child of a composite - update the composite answers state
+                    this.valueChanged.emit(newValue);
+                }
+            }
         });
     }
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/answerValue.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/activity/answerValue.ts
@@ -2,6 +2,7 @@ import { DatePickerValue } from '../datePickerValue';
 import { ActivityPicklistAnswerDto } from './activityPicklistAnswerDto';
 import { ActivityMatrixAnswerDto } from './activityMatrixAnswerDto';
 import { NumericAnswerType } from './numericAnswerType';
+import { DecimalAnswer } from './decimalAnswer';
 
 export type AnswerValue =
   | boolean
@@ -10,6 +11,7 @@ export type AnswerValue =
   | Array<ActivityPicklistAnswerDto>
   | DatePickerValue
   | NumericAnswerType
+  | DecimalAnswer[]
   | null
   | any[][]
   | ActivityMatrixAnswerDto[];


### PR DESCRIPTION
Noticed a bug with equation questions rendering.
**Flow to reproduce:** 
- a composite question has equation questions as children
- update an input value tat will lead to an equation answer update
- go through the activity by clicking Next/Back button
-  the composite answers don't update (should be updated with the changed equation value)

So, the fix is about emitting a changed equation value up to its parent composite question in order to update the composite answers state (but not emitting it further, because we should not patch equation answers).

See screen records: 
**1. Before the fix (the bug appears)**

https://user-images.githubusercontent.com/7396837/167403482-7e62bc12-3228-40df-9ce7-e0779901edca.mp4


**2. After the fix (the composite question answers are valid)** 


https://user-images.githubusercontent.com/7396837/167403498-65a3cd8d-1d21-4841-be1e-8fb2ffc7c657.mp4


