### PR TITLE
Singular-Change activity creation to just editing an instance. Disable buttons

### DIFF
--- a/ddp-workspace/projects/ddp-singular/src/app/components/activities-list/activities-list.component.html
+++ b/ddp-workspace/projects/ddp-singular/src/app/components/activities-list/activities-list.component.html
@@ -56,20 +56,20 @@
           <ng-container *ngTemplateOutlet="hasPreviousInstance(activity) ? continue : start"></ng-container>
 
           <ng-template #start>
-            <button type="button" class="button button--primary button--sm" (click)="onStartClick(activity)">
+            <button type="button" class="button button--primary button--sm" (click)="onStartClick(activity)" [disabled]="disableButtons">
               {{ (isMedicalRecordFileUpload(activity) ? 'SDK.UploadButton' : 'SDK.StartButton') | translate }}
             </button>
           </ng-template>
 
           <ng-template #continue>
-            <button type="button" class="button button--primary button--sm" (click)="onContinueClick(activity)">
+            <button type="button" class="button button--primary button--sm" (click)="onContinueClick(activity)"  [disabled]="disableButtons">
               {{ (isMedicalRecordFileUpload(activity) ? 'SDK.UploadButton' : 'SDK.ContinueButton') | translate }}
             </button>
           </ng-template>
         </ng-container>
 
         <ng-container *ngSwitchCase="ActivityStatusCodes.IN_PROGRESS">
-          <button type="button" class="button button--primary button--sm" (click)="onContinueClick(activity)">
+          <button type="button" class="button button--primary button--sm" (click)="onContinueClick(activity)"  [disabled]="disableButtons">
             {{ (isMedicalRecordFileUpload(activity) ? 'SDK.UploadButton' : 'SDK.ContinueButton') | translate }}
           </button>
         </ng-container>
@@ -78,13 +78,13 @@
           <ng-container *ngTemplateOutlet="isActivityEditable(activity) ? update : view"></ng-container>
 
           <ng-template #update>
-            <button type="button" class="button button--outline button--sm fixed-button" (click)="onEditClick(activity)">
+            <button type="button" class="button button--outline button--sm fixed-button" (click)="onEditClick(activity)"  [disabled]="disableButtons">
               {{ (isMedicalRecordFileUpload(activity) ? 'SDK.UploadButton' : 'SDK.EditButton') | translate }}
             </button>
           </ng-template>
 
           <ng-template #view>
-            <button type="button" class="button button--outline button--sm fixed-button" (click)="onViewClick(activity)">
+            <button type="button" class="button button--outline button--sm fixed-button" (click)="onViewClick(activity)"  [disabled]="disableButtons">
               {{ 'SDK.ReviewButton' | translate }}
             </button>
           </ng-template>

--- a/ddp-workspace/projects/ddp-singular/src/app/components/activities-list/activities-list.component.ts
+++ b/ddp-workspace/projects/ddp-singular/src/app/components/activities-list/activities-list.component.ts
@@ -11,6 +11,7 @@ import { ActivityIcons } from '../../constants/activity-icons';
 })
 export class ActivitiesListComponent {
   @Input() activities: ActivityInstance[];
+  @Input() disableButtons = false;
   @Output() startActivity = new EventEmitter<ActivityInstance>();
   @Output() continueActivity = new EventEmitter<ActivityInstance>();
   @Output() editActivity = new EventEmitter<ActivityInstance>();

--- a/ddp-workspace/projects/ddp-singular/src/app/components/pages/participant-list/participant-list.component.html
+++ b/ddp-workspace/projects/ddp-singular/src/app/components/pages/participant-list/participant-list.component.html
@@ -104,6 +104,7 @@
         <div class="participant__content" *ngIf="isParticipantContentExpanded(participant)">
           <app-activities-list
             [activities]="participant.activities"
+            [disableButtons]="isPageBusy || isEnrollBtnDisabled || loading"
             (editActivity)="onEditActivity(participant.guid, $event)"
             (viewActivity)="onViewActivity(participant.guid, $event)"
             (startActivity)="onStartActivity(participant.guid, $event)"

--- a/ddp-workspace/projects/ddp-singular/src/app/components/pages/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-singular/src/app/components/pages/participant-list/participant-list.component.ts
@@ -43,6 +43,7 @@ export class ParticipantsListComponent implements OnInit {
   participants: Participant[] = [];
   private expandedMap: Record<string, boolean> = {};
   errorMessage: string | null = null;
+  isPageBusy = false;
   @Input() allowParticipantRemoval = false;
 
   constructor(
@@ -131,21 +132,19 @@ export class ParticipantsListComponent implements OnInit {
   }
 
   onEditActivity(participantGuid: string, activityToEdit: ActivityInstance): void {
+    this.isPageBusy = true;
     this.setParticipant(participantGuid);
-
-    this.activityService
-      .createInstance(this.config.studyGuid, activityToEdit.activityCode)
-      .pipe(take(1))
-      .subscribe(activity => {
-        this.setCurrentActivity(activity as ActivityInstance);
-        this.redirectToSurvey(activity.instanceGuid);
-      });
+    this.setCurrentActivity(activityToEdit, false);
+    this.redirectToSurvey(activityToEdit.instanceGuid);
+    this.isPageBusy = false;
   }
 
   onViewActivity(participantGuid: string, activity: ActivityInstance): void {
+    this.isPageBusy = true;
     this.setParticipant(participantGuid);
     this.setCurrentActivity(activity, true);
     this.redirectToSurvey(activity.instanceGuid);
+    this.isPageBusy = false;
   }
 
   onAddParticipantClick(): void {


### PR DESCRIPTION
Please take a look at the attached ticket as it describes specific problem I am trying to address (users have reported others).

In review, please start with this comment as I think this is the biggest problem.
https://github.com/broadinstitute/ddp-angular/pull/1302/files/3f8e1df5440ab0dd6c9a6119ecf629dbf9f5e5dc#r880926312

After that first comment, you can take a look at changes made to disable buttons in order that they appear in File Changed page.