### PR TITLE
Prevent Angular from sending page_view Gtag events. Gtag does that au…

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/analyticsEvents.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/analyticsEvents.service.ts
@@ -1,78 +1,87 @@
-import { Injectable } from '@angular/core';
-import { Subject, Observable } from 'rxjs';
-import { AnalyticsEvent } from '../models/analyticsEvent';
-import { GTagEvent } from '../models/gtagEvent';
-import { filter } from 'rxjs/operators';
-import { GoogleAnalyticsEvent, isAnalyticsEvent, isGtagEvent } from '../models/googleAnalyticsEvent';
+import {Injectable} from '@angular/core';
+import {Subject, Observable} from 'rxjs';
+import {AnalyticsEvent} from '../models/analyticsEvent';
+import {GTagEvent} from '../models/gtagEvent';
+import {filter} from 'rxjs/operators';
+import {GoogleAnalyticsEvent, isAnalyticsEvent, isGtagEvent} from '../models/googleAnalyticsEvent';
 
 
 @Injectable()
 export class AnalyticsEventsService {
 
-  private events = new Subject<GoogleAnalyticsEvent>();
+    private events = new Subject<GoogleAnalyticsEvent>();
 
-  public emitCustomEvent(
-    eventCategory: string,
-    eventAction: string,
-    eventLabel: string | null = null,
-    eventValue: string | null = null): void {
-    const event: AnalyticsEvent = {
-      hitType: 'event',
-      // set page directly in order to exclude sensitive query params
-      // and simpler aggregation of stats
-      page: location.pathname,
-      location: this.location,
-      eventCategory,
-      eventAction,
-      eventLabel: eventLabel === null ? eventAction : eventLabel,
-      eventValue
-    };
-    this.events.next(event);
-    this.events.next(this.buildGTagEvent(eventCategory, eventAction));
-  }
+    public emitCustomEvent(
+        eventCategory: string,
+        eventAction: string,
+        eventLabel: string | null = null,
+        eventValue: string | null = null): void {
+        const event: AnalyticsEvent = {
+            hitType: 'event',
+            // set page directly in order to exclude sensitive query params
+            // and simpler aggregation of stats
+            page: location.pathname,
+            location: this.location,
+            eventCategory,
+            eventAction,
+            eventLabel: eventLabel === null ? eventAction : eventLabel,
+            eventValue
+        };
+        this.events.next(event);
+        this.events.next(this.buildGTagEvent(eventCategory, eventAction));
+    }
 
-  public emitCustomGtagEvent(eventName: string, clickText?: string, clickUrl?: string): void {
-    const newEvent = this.buildGTagEvent(eventName, clickText, clickUrl);
-    this.events.next(newEvent);
-    return;
-  }
+    public emitCustomGtagEvent(eventName: string, clickText?: string, clickUrl?: string): void {
+        const newEvent = this.buildGTagEvent(eventName, clickText, clickUrl);
+        this.events.next(newEvent);
+        return;
+    }
 
-  public emitNavigationEvent(): void {
-    const event: AnalyticsEvent = {
-      hitType: 'pageview',
-      // set page directly in order to exclude sensitive query params
-      // and simpler aggregation of stats
-      page: location.pathname,
-      location: this.location
-    };
-    this.events.next(event);
-    // this is a gtag "recommended event" https://developers.google.com/tag-platform/gtagjs/reference/events#page_view
-    this.events.next(this.buildGTagEvent('page_view'));
-  }
+    public emitNavigationEvent(): void {
+        const event: AnalyticsEvent = {
+            hitType: 'pageview',
+            // set page directly in order to exclude sensitive query params
+            // and simpler aggregation of stats
+            page: location.pathname,
+            location: this.location
+        };
+        this.events.next(event);
+        // this is a gtag "recommended event" https://developers.google.com/tag-platform/gtagjs/reference/events#page_view
+        this.events.next(this.buildGTagEvent('page_view'));
+    }
 
-  public get analyticEvents(): Observable<AnalyticsEvent> {
-    return this.events.pipe(filter(anEvent => isAnalyticsEvent(anEvent))) as Observable<AnalyticsEvent>;
-  }
+    public get analyticEvents(): Observable<AnalyticsEvent> {
+        return this.events.pipe(filter(anEvent => isAnalyticsEvent(anEvent))) as Observable<AnalyticsEvent>;
+    }
 
-  public get gTagEvents(): Observable<GTagEvent> {
-    return this.events.pipe(filter(anEvent => isGtagEvent(anEvent))) as Observable<GTagEvent>;
-  }
+    public get gTagEvents(): Observable<GTagEvent> {
+        return this.events.pipe(filter(anEvent => isGtagEvent(anEvent))) as Observable<GTagEvent>;
+    }
 
-  private get location(): string {
-    return `${location.protocol}//${location.hostname}${location.port ? `:${location.port}` : ``}${location.pathname}`;
-  }
+    /* There does not appear to be a way to prevent gtag.js from automatically sending page view events
+    despite what their documentation says here:
+    https://developers.google.com/analytics/devguides/collection/gtagjs#disable_pageview_measurement
+    Use this option to avoid sending duplicate page_view events given gtag is going to send its own no matter
+    what */
+    public get gTagEventsExcludingPageViews(): Observable<GTagEvent> {
+        return this.gTagEvents.pipe(filter(event => event.event_name !== 'page_view'));
+    }
 
-  // Build gtag.js events that correspond to https://developers.google.com/tag-platform/gtagjs/reference#event
-  // click_text and click_url are optional custom parameters
-  private buildGTagEvent(eventName: string, clickText?: string, clickUrl?: string): GTagEvent {
-    const newEvent: GTagEvent = {
-      event_name: eventName,
-      parameters: {
-        page_location: this.location,
-        click_text: clickText,
-        click_url: clickUrl,
-      }
-    };
-    return newEvent;
-  }
+    private get location(): string {
+        return `${location.protocol}//${location.hostname}${location.port ? `:${location.port}` : ``}${location.pathname}`;
+    }
+
+    // Build gtag.js events that correspond to https://developers.google.com/tag-platform/gtagjs/reference#event
+    // click_text and click_url are optional custom parameters
+    private buildGTagEvent(eventName: string, clickText?: string, clickUrl?: string): GTagEvent {
+        const newEvent: GTagEvent = {
+            event_name: eventName,
+            parameters: {
+                page_location: this.location,
+                click_text: clickText,
+                click_url: clickUrl,
+            }
+        };
+        return newEvent;
+    }
 }

--- a/ddp-workspace/projects/ddp-singular/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-singular/src/app/app.module.ts
@@ -90,7 +90,7 @@ declare const gtag: (...args: any[]) => void;
 export class AppModule {
     constructor(private analytics: AnalyticsEventsService) {
         // https://developers.google.com/tag-platform/gtagjs/reference#event
-        this.analytics.gTagEvents
+        this.analytics.gTagEventsExcludingPageViews
             .subscribe(event => gtag('event', event.event_name, event.parameters));
     }
 }


### PR DESCRIPTION
Tried to explain problem in https://broadinstitute.atlassian.net/browse/DDP-8139
See comments with files for proposed fix explanation.

I have deployed this branch to dev environment and here are a couple of screenshots showing what happens when we now navigate to the /for-researchers page:
From browser, there is only one event (compare to screenshot in ticket)
![Screen Shot 2022-06-03 at 2 27 37 PM](https://user-images.githubusercontent.com/29984380/171924682-ef608b9f-a895-4a29-bdf2-de416763fbcc.png)
And only one page location event with "for researchers" in Google Analytics console:
![Screen Shot 2022-06-03 at 2 27 14 PM](https://user-images.githubusercontent.com/29984380/171924647-f8488f66-be1e-489c-9f3f-4a77ac5ecbd8.png)

