### PR TITLE
[DSS] DDP-8151: Move import of BrowserAnimationsModule from ddp-sdk to every single study

### DIFF
--- a/ddp-workspace/projects/basil-app/src/app/app.module.ts
+++ b/ddp-workspace/projects/basil-app/src/app/app.module.ts
@@ -1,4 +1,5 @@
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgModule } from '@angular/core';
 import { NavigationEnd, Router, RouterModule, Routes } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -98,6 +99,7 @@ declare const ga: (...args: any[]) => void;
   imports: [
     RouterModule.forRoot(appRoutes, { enableTracing: false, relativeLinkResolution: 'legacy' }),
     BrowserModule,
+    BrowserAnimationsModule,
     DdpModule,
     MatButtonModule, MatToolbarModule, MatIconModule, MatMenuModule, MatCardModule,
     MatGridListModule, MatInputModule, MatRadioModule, MatSidenavModule, MatProgressSpinnerModule,

--- a/ddp-workspace/projects/ddp-angio/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-angio/src/app/app.module.ts
@@ -1,5 +1,6 @@
 import { NgModule, Injector, APP_INITIALIZER } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { LOCATION_INITIALIZED } from '@angular/common';
 import { AppRoutingModule } from './app-routing.module';
 
@@ -122,6 +123,7 @@ export function translateFactory(translate: TranslateService, injector: Injector
 @NgModule({
     imports: [
         BrowserModule,
+        BrowserAnimationsModule,
         AppRoutingModule,
         DdpModule,
         ToolkitModule

--- a/ddp-workspace/projects/ddp-atcp/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-atcp/src/app/app.module.ts
@@ -13,6 +13,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import {
   TranslateService,
   TranslateModule,
@@ -165,6 +166,7 @@ export function translateFactory(
 @NgModule({
   imports: [
     BrowserModule,
+    BrowserAnimationsModule,
     FormsModule,
     ReactiveFormsModule,
     CommonModule,

--- a/ddp-workspace/projects/ddp-basil/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-basil/src/app/app.module.ts
@@ -1,4 +1,5 @@
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { APP_INITIALIZER, Injector, NgModule } from '@angular/core';
 import { LOCATION_INITIALIZED, CommonModule } from '@angular/common';
 import { RECAPTCHA_LANGUAGE, RecaptchaFormsModule, RecaptchaModule } from 'ng-recaptcha';
@@ -114,6 +115,7 @@ export function languageFactory(language: LanguageService): string {
     imports: [
         AppRoutingModule,
         BrowserModule,
+        BrowserAnimationsModule,
         CommonModule,
         DdpModule,
         RecaptchaModule,

--- a/ddp-workspace/projects/ddp-brain/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-brain/src/app/app.module.ts
@@ -1,4 +1,5 @@
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgModule, Injector, APP_INITIALIZER } from '@angular/core';
 import { LOCATION_INITIALIZED } from '@angular/common';
 
@@ -138,6 +139,7 @@ export function translateFactory(translate: TranslateService, injector: Injector
     ],
     imports: [
         BrowserModule,
+        BrowserAnimationsModule,
         AppRoutingModule,
         DdpModule,
         ToolkitModule,

--- a/ddp-workspace/projects/ddp-brugada/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-brugada/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { DdpModule } from 'ddp-sdk';
 import { ToolkitModule } from 'toolkit';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ReactiveFormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
 import { MatIconModule } from '@angular/material/icon';
@@ -75,6 +76,7 @@ import { AppRoutingModule } from './app-routing.module';
   ],
   imports: [
     BrowserModule,
+    BrowserAnimationsModule,
     ReactiveFormsModule,
     MatIconModule,
     MatExpansionModule,

--- a/ddp-workspace/projects/ddp-cgc/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-cgc/src/app/app.module.ts
@@ -4,6 +4,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { TranslateService } from '@ngx-translate/core';
 import { AppRoutingModule } from './app-routing.module';
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { translateFactory } from './util/translateFactory';
 import { MaterialModule } from './modules/material/material.module';
 import { NgModule, Injector, APP_INITIALIZER } from '@angular/core';
@@ -97,6 +98,7 @@ tkCfg.activityUrl = Route.Activity;
   imports: [
     DdpModule,
     BrowserModule,
+    BrowserAnimationsModule,
     ToolkitModule,
     MaterialModule,
     AppRoutingModule,

--- a/ddp-workspace/projects/ddp-circadia/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-circadia/src/app/app.module.ts
@@ -1,5 +1,6 @@
 import { NgModule, Injector, APP_INITIALIZER } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { DatePipe, LOCATION_INITIALIZED } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
@@ -145,6 +146,7 @@ export function translateFactory(
   ],
   imports: [
     BrowserModule,
+    BrowserAnimationsModule,
     FormsModule,
     ReactiveFormsModule,
     HttpClientModule,

--- a/ddp-workspace/projects/ddp-esc/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-esc/src/app/app.module.ts
@@ -1,5 +1,6 @@
 import { NgModule, Injector, APP_INITIALIZER } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { LOCATION_INITIALIZED } from '@angular/common';
 import { AppRoutingModule } from './app-routing.module';
 
@@ -109,6 +110,7 @@ export function translateFactory(translate: TranslateService, injector: Injector
 @NgModule({
   imports: [
     BrowserModule,
+    BrowserAnimationsModule,
     AppRoutingModule,
     DdpModule,
     ToolkitModule

--- a/ddp-workspace/projects/ddp-fon/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-fon/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { DdpModule } from 'ddp-sdk';
 import { ToolkitModule } from 'toolkit';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ReactiveFormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
 import { MatIconModule } from '@angular/material/icon';
@@ -75,6 +76,7 @@ import { AppRoutingModule } from './app-routing.module';
   ],
   imports: [
     BrowserModule,
+    BrowserAnimationsModule,
     ReactiveFormsModule,
     MatIconModule,
     MatExpansionModule,

--- a/ddp-workspace/projects/ddp-lms/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-lms/src/app/app.module.ts
@@ -1,6 +1,7 @@
 import { APP_INITIALIZER, Injector, NgModule } from '@angular/core';
 import { LOCATION_INITIALIZED } from '@angular/common';
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { TranslateService } from '@ngx-translate/core';
 
 import { DdpModule, ConfigurationService, LanguageService, LoggingService } from 'ddp-sdk';
@@ -128,6 +129,7 @@ const translateFactory =
   ],
   imports: [
     BrowserModule,
+    BrowserAnimationsModule,
     DdpModule,
     ToolkitModule,
     AppRoutingModule,

--- a/ddp-workspace/projects/ddp-mbc/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-mbc/src/app/app.module.ts
@@ -1,5 +1,6 @@
 import { APP_INITIALIZER, Injector, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { LOCATION_INITIALIZED } from '@angular/common';
 import { AppRoutingModule } from './app-routing.module';
 
@@ -125,6 +126,7 @@ function translateFactory(translate: TranslateService,
 @NgModule({
     imports: [
         BrowserModule,
+        BrowserAnimationsModule,
         AppRoutingModule,
         DdpModule,
         ToolkitModule

--- a/ddp-workspace/projects/ddp-mpc/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-mpc/src/app/app.module.ts
@@ -1,5 +1,6 @@
 import { NgModule, Injector, APP_INITIALIZER } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { LOCATION_INITIALIZED } from '@angular/common';
 import { AppRoutingModule } from './app-routing.module';
 
@@ -110,6 +111,7 @@ export function translateFactory(translate: TranslateService, injector: Injector
 @NgModule({
   imports: [
     BrowserModule,
+    BrowserAnimationsModule,
     AppRoutingModule,
     DdpModule,
     ToolkitModule

--- a/ddp-workspace/projects/ddp-osteo/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-osteo/src/app/app.module.ts
@@ -1,5 +1,6 @@
 import { NgModule, Injector, APP_INITIALIZER } from '@angular/core';
 import { BrowserModule, HammerModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { LOCATION_INITIALIZED, CommonModule } from '@angular/common';
 import { AppRoutingModule } from './app-routing.module';
 
@@ -146,6 +147,7 @@ export function translateFactory(translate: TranslateService, injector: Injector
 @NgModule({
   imports: [
     BrowserModule,
+    BrowserAnimationsModule,
     CommonModule,
     AppRoutingModule,
     DdpModule,

--- a/ddp-workspace/projects/ddp-pancan/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-pancan/src/app/app.module.ts
@@ -1,4 +1,5 @@
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { APP_INITIALIZER, Injector, NgModule } from '@angular/core';
 import { CommonModule, LOCATION_INITIALIZED } from '@angular/common';
 import { AppRoutingModule } from './app-routing.module';
@@ -161,6 +162,7 @@ export function translateFactory(translate: TranslateService,
     ],
     imports: [
         BrowserModule,
+        BrowserAnimationsModule,
         AppRoutingModule,
         CommonModule,
         DdpModule,

--- a/ddp-workspace/projects/ddp-prion/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-prion/src/app/app.module.ts
@@ -1,6 +1,7 @@
 // Angular imports
 import { APP_INITIALIZER, Injector, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CommonModule, LOCATION_INITIALIZED } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { FlexLayoutModule, FlexModule } from '@angular/flex-layout';
@@ -242,6 +243,7 @@ export function translateFactory(translate: TranslateService, injector: Injector
 @NgModule({
   imports: [
     BrowserModule,
+    BrowserAnimationsModule,
     AppRoutingModule,
     DdpModule,
     ToolkitPrionModule,

--- a/ddp-workspace/projects/ddp-rarex/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-rarex/src/app/app.module.ts
@@ -1,6 +1,7 @@
 import { NgModule, Injector, APP_INITIALIZER } from '@angular/core';
 import { LOCATION_INITIALIZED, CommonModule } from '@angular/common';
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MatButtonModule } from '@angular/material/button';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatTableModule } from '@angular/material/table';
@@ -123,6 +124,7 @@ export const translateFactory = (
 @NgModule({
   imports: [
     BrowserModule,
+    BrowserAnimationsModule,
     CommonModule,
     AppRoutingModule,
     DdpModule,

--- a/ddp-workspace/projects/ddp-rgp/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-rgp/src/app/app.module.ts
@@ -60,6 +60,7 @@ import { UserActivitiesComponent } from './components/user-activities/user-activ
 import { StudyMessagesComponent } from './components/study-messages/study-messages.component';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 const baseElt = document.getElementsByTagName('base');
 
@@ -170,6 +171,7 @@ export function translateFactory(
     ],
     imports: [
         BrowserModule,
+        BrowserAnimationsModule,
         AppRoutingModule,
         DdpModule,
         ToolkitModule,

--- a/ddp-workspace/projects/ddp-sdk/src/lib/ddp.module.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/ddp.module.ts
@@ -3,7 +3,6 @@ import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { HTTP_INTERCEPTORS, HttpClient, HttpClientModule } from '@angular/common/http';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { Title } from '@angular/platform-browser';
 import { A11yModule } from '@angular/cdk/a11y';
 // ngx-translate
@@ -238,7 +237,6 @@ export function createTranslateLoader(http: HttpClient): TranslateHttpLoader {
 @NgModule({
     imports: [
         CommonModule,
-        BrowserAnimationsModule,
         HttpClientModule,
         FormsModule,
         ReactiveFormsModule,

--- a/ddp-workspace/projects/ddp-singular/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-singular/src/app/app.module.ts
@@ -1,6 +1,7 @@
-import { AnalyticsEventCategories, AnalyticsEventsService, DdpModule } from 'ddp-sdk';
+import { AnalyticsEventsService, DdpModule } from 'ddp-sdk';
 import { ToolkitModule } from 'toolkit';
 import { NgModule } from '@angular/core';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { AppComponent } from './app.component';
 import { RecaptchaModule } from 'ng-recaptcha';
 import { ReactiveFormsModule } from '@angular/forms';
@@ -40,6 +41,7 @@ import { LoginComponent } from './components/login/login.component';
 import { ActivitySectionProgressBarComponent } from './components/activity-section-progress-bar/activity-section-progress-bar.component';
 import { ActivitySectionPageProgressComponent } from './components/activity-section-page-progress/activity-section-page-progress.component';
 
+
 declare const gtag: (...args: any[]) => void;
 
 @NgModule({
@@ -77,6 +79,7 @@ declare const gtag: (...args: any[]) => void;
     imports: [
         DdpModule,
         BrowserModule,
+        BrowserAnimationsModule,
         ToolkitModule,
         MaterialModule,
         RecaptchaModule,

--- a/ddp-workspace/projects/ddp-testboston/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-testboston/src/app/app.module.ts
@@ -1,4 +1,5 @@
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgModule, Injector, APP_INITIALIZER } from '@angular/core';
 import { LOCATION_INITIALIZED, CommonModule, ViewportScroller } from '@angular/common';
 import { AppRoutingModule } from './app-routing.module';
@@ -166,6 +167,7 @@ export function languageFactory(language: LanguageService): string {
     ],
     imports: [
         BrowserModule,
+        BrowserAnimationsModule,
         AppRoutingModule,
         CommonModule,
         DdpModule,

--- a/ddp-workspace/projects/toolkit-prion/src/lib/toolkit.module.ts
+++ b/ddp-workspace/projects/toolkit-prion/src/lib/toolkit.module.ts
@@ -14,6 +14,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { MatButtonModule } from '@angular/material/button';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 // SDK imports
 import { AnalyticsEventsService, DdpModule } from 'ddp-sdk';
@@ -48,6 +49,7 @@ import { PrionCommonLandingComponent } from './components/common-landing/prionCo
 import { PrionRedirectToLoginLandingComponent } from './components/redirect-to-login-landing/prionRedirectToLoginLanding.component';
 import { PrionRedirectToAuth0LoginComponent } from './components/redirect-to-auth0-login/prionRedirectToAuth0Login.component';
 
+
 @NgModule({
   imports: [
     CommonModule,
@@ -66,6 +68,7 @@ import { PrionRedirectToAuth0LoginComponent } from './components/redirect-to-aut
     DdpModule,
     ToolkitModule,
     MatButtonModule,
+    BrowserAnimationsModule
   ],
   providers: [
     CommunicationService,

--- a/ddp-workspace/projects/toolkit/src/lib/toolkit.module.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/toolkit.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { FlexLayoutModule } from '@angular/flex-layout';
 import { RouterModule, Router, NavigationEnd } from '@angular/router';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 // Modules
 import { DdpModule, AnalyticsEventsService } from 'ddp-sdk';
@@ -100,6 +101,7 @@ import { AppRedesignedBaseComponent } from './components/app/app-redesigned-base
 @NgModule({
     imports: [
         CommonModule,
+        BrowserAnimationsModule,
         MatToolbarModule,
         MatIconModule,
         FlexLayoutModule,


### PR DESCRIPTION
The issue is described [in DDP-8151 ticket](https://broadinstitute.atlassian.net/browse/DDP-8151).