### PR TITLE
[DSS] DDP-7714: Fix setting `columnSpan` for tabular blocks

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityConverter.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityConverter.service.ts
@@ -145,6 +145,7 @@ export class ActivityConverter {
         activityBlock.content = [];
         for (const inputBlock of blockJson.content) {
             const block = this.questionConverter.buildQuestionBlock(inputBlock.question, null);
+            block.columnSpan = inputBlock.columnSpan || 1;
             this.buildShownField(block, inputBlock);
             this.buildEnabledField(block, inputBlock);
             block.id = inputBlock.blockGuid;

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityQuestionConverter.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityQuestionConverter.service.ts
@@ -63,7 +63,6 @@ export class ActivityQuestionConverter {
         questionBlock.tooltip = questionJson.tooltip;
         questionBlock.readonly = questionJson.readonly;
         questionBlock.displayNumber = displayNumber;
-        questionBlock.columnSpan = questionJson.columnSpan ?? 1;
         questionBlock.serverValidationMessages = questionJson.validationFailures ?
             questionJson.validationFailures.map(validationFailure => validationFailure.message) : [];
 


### PR DESCRIPTION
After the fix we define `columnSpan` property of a tabular block in the proper place.

**_Real data example from FON study (after the fix):_**
![image](https://user-images.githubusercontent.com/7396837/174307678-d44ee96f-5207-4504-8c30-48401b8e1f8d.png)
