### PR TITLE
Fixed logic of Day, Month, Year required rules.

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/dateValidators/activityDayRequiredDateValidationRule.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/dateValidators/activityDayRequiredDateValidationRule.ts
@@ -11,7 +11,7 @@ export class ActivityDayRequiredDateValidationRule extends ActivityAbstractValid
     public recalculate(): boolean {
         if (this.question.answer != null) {
             const value = this.question.answer;
-            if (!this.isBlank(value) && value.day === null) {
+            if (value.day === null) {
                 this.result = this.message;
                 return false;
             }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/dateValidators/activityMonthRequiredDateValidationRule.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/dateValidators/activityMonthRequiredDateValidationRule.ts
@@ -11,7 +11,7 @@ export class ActivityMonthRequiredDateValidationRule extends ActivityAbstractVal
     public recalculate(): boolean {
         if (this.question.answer != null) {
             const value = this.question.answer;
-            if (!this.isBlank(value) && value.month === null) {
+            if (value.month === null) {
                 this.result = this.message;
                 return false;
             }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/dateValidators/activityYearRequiredDateValidationRule.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/validators/dateValidators/activityYearRequiredDateValidationRule.ts
@@ -11,7 +11,7 @@ export class ActivityYearRequiredDateValidationRule extends ActivityAbstractVali
     public recalculate(): boolean {
         if (this.question.answer != null) {
             const value = this.question.answer;
-            if (!this.isBlank(value) && value.year === null) {
+            if (value.year === null) {
                 this.result = this.message;
                 return false;
             }


### PR DESCRIPTION
Fixed logic of Day, Month, Year required rules.
This fixes is needed because if user doesn't pick whatever day/month/year (answer the date question with any of upper mentioned rules), then user can simply skip this question. Required rule is not approach for situations like user must to answer the date question (it should required), but also he should be able to specify only year.