### PR TITLE
[DSM] FON: DDP-8251 styling `cMRI` form tabular block

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/FON/pages/activities/components/activity/activity.component.scss
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/FON/pages/activities/components/activity/activity.component.scss
@@ -446,6 +446,7 @@ $field-disabled-border: $__Mulled_wine_transparent;
       grid-template-columns: auto auto !important;
       justify-content: space-around;
       height: 41px;
+      margin-bottom: 12px;
     }
   }
 

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/FON/pages/activities/components/activity/activity.component.scss
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/FON/pages/activities/components/activity/activity.component.scss
@@ -390,12 +390,6 @@ $field-disabled-border: $__Mulled_wine_transparent;
       grid-template-columns: auto 150px 150px !important;
       border: none !important;
 
-      /* TODO: remove this temp FIX!! just to fix the wrong config form back-end */
-      .header:nth-of-type(3) {
-        display: none;
-      }
-      /* end of the TODO */
-
       .header, .question-title {
         padding-left: 20px !important;
         font-weight: 600;
@@ -409,16 +403,6 @@ $field-disabled-border: $__Mulled_wine_transparent;
 
       .cell {
         border: none !important;
-
-        &:nth-child(12),
-        &:nth-child(20) {
-          height: 48px;
-        }
-
-        &:nth-child(10),
-        &:nth-child(18) {
-          grid-column: span 2 !important;
-        }
       }
 
       .composite-answer {
@@ -456,6 +440,84 @@ $field-disabled-border: $__Mulled_wine_transparent;
           .ddp-answer-container {
             grid-template-columns: auto auto !important;
             justify-content: space-around;
+            height: 41px;
+          }
+        }
+      }
+
+      ddp-activity-composite-answer {
+        .ddp-answer-container {
+          justify-content: space-between;
+
+          .ddp-answer-field {
+            padding: 0;
+          }
+
+          .mat-form-field {
+            max-width: 120px;
+          }
+        }
+      }
+    }
+  }
+
+  /* tabular block for cMRI form (pretty the same like for CARDIAC_CT) */
+  .main_activity.CMRI {
+    .tabular-container {
+      grid-template-columns: auto 150px 150px !important;
+      border: none !important;
+
+      .header, .question-title {
+        padding-left: 20px !important;
+        font-weight: 600;
+      }
+
+      .question-title {
+        display: flex;
+        align-items: flex-start;
+        margin-top: 10px;
+      }
+
+      .cell {
+        border: none !important;
+      }
+
+      .composite-answer {
+        &-CQ_CMRI_RV_END_DIASTOLIC_VOLUME,
+        &-CQ_CMRI_END_SYSTOLIC_VOLUME,
+        &-CQ_CMRI_LV_END_DIASTOLIC_VOLUME,
+        &-CQ_CMRI_LV_END_SYSTOLIC_VOLUME
+        {
+          .ddp-answer-container {
+            grid-template-columns: auto auto !important;
+          }
+
+          /* TODO: remove this temp FIX!! just to fix the wrong config form back-end */
+          .ddp-answer-field:first-of-type::after {
+            content: 'Or';
+            top: -12px;
+            position: relative;
+            left: 4px;
+          }
+          /* end of the TODO */
+        }
+
+        &-CQ_CMRI_RV_EJECTION_FRACTION,
+        &-CQ_CMRI_LV_EJECTION_FRACTION
+        {
+          .ddp-answer-container {
+            grid-template-columns: auto !important;
+            justify-content: left;
+          }
+        }
+
+        &-CQ_CMRI_RV_CARDIAC_OUTPUT,
+        &-CQ_CMRI_LV_CARDIAC_OUTPUT
+        {
+          .ddp-answer-container {
+            grid-template-columns: auto auto !important;
+            justify-content: space-around;
+            height: 41px;
           }
         }
       }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/FON/pages/activities/components/activity/activity.component.scss
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/FON/pages/activities/components/activity/activity.component.scss
@@ -384,26 +384,75 @@ $field-disabled-border: $__Mulled_wine_transparent;
     }
   }
 
+  /* common mixins for CARDIAC_CT and cMRI forms */
+  @mixin tabular-container {
+    grid-template-columns: auto 150px 150px !important;
+    border: none !important;
+
+    .header, .question-title {
+      padding-left: 20px !important;
+      font-weight: 600;
+    }
+
+    .question-title {
+      display: flex;
+      align-items: flex-start;
+      margin-top: 10px;
+    }
+
+    .cell {
+      border: none !important;
+    }
+
+    ddp-activity-composite-answer {
+      .ddp-answer-container {
+        justify-content: space-between;
+
+        .ddp-answer-field {
+          padding: 0;
+        }
+
+        .mat-form-field {
+          max-width: 120px;
+        }
+      }
+    }
+  }
+
+  @mixin diastolic-systolic-volume {
+    .ddp-answer-container {
+      grid-template-columns: auto auto !important;
+    }
+
+    /* TODO: remove this temp FIX!! just to fix the wrong config form back-end */
+    .ddp-answer-field:first-of-type::after {
+      content: 'Or';
+      top: -12px;
+      position: relative;
+      left: 4px;
+    }
+    /* end of the TODO */
+  }
+
+  @mixin ejection-fraction {
+    .ddp-answer-container {
+      grid-template-columns: auto !important;
+      justify-content: left;
+    }
+  }
+
+  @mixin cardiac-output {
+    .ddp-answer-container {
+      grid-template-columns: auto auto !important;
+      justify-content: space-around;
+      height: 41px;
+    }
+  }
+
   /* tabular block for CARDIAC_CT form */
   .main_activity.CARDIAC_CT {
     .tabular-container {
-      grid-template-columns: auto 150px 150px !important;
-      border: none !important;
-
-      .header, .question-title {
-        padding-left: 20px !important;
-        font-weight: 600;
-      }
-
-      .question-title {
-        display: flex;
-        align-items: flex-start;
-        margin-top: 10px;
-      }
-
-      .cell {
-        border: none !important;
-      }
+      @include tabular-container;
 
       .composite-answer {
         &-CQ_RV_END_DIASTOLIC_VOLUME,
@@ -411,51 +460,19 @@ $field-disabled-border: $__Mulled_wine_transparent;
         &-CQ_LV_END_DIASTOLIC_VOLUME,
         &-CQ_LV_END_SYSTOLIC_VOLUME
         {
-          .ddp-answer-container {
-            grid-template-columns: auto auto !important;
-          }
-
-          /* TODO: remove this temp FIX!! just to fix the wrong config form back-end */
-          .ddp-answer-field:first-of-type::after {
-            content: 'Or';
-            top: -12px;
-            position: relative;
-            left: 4px;
-          }
-          /* end of the TODO */
+          @include diastolic-systolic-volume;
         }
 
         &-CQ_RV_EJECTION_FRACTION,
         &-CQ_LV_END_EJECTION_FRACTION
         {
-          .ddp-answer-container {
-            grid-template-columns: auto !important;
-            justify-content: left;
-          }
+          @include ejection-fraction;
         }
 
         &-CQ_RV_CARDIAC_OUTPUT,
         &-CQ_LV_CARDIAC_OUTPUT
         {
-          .ddp-answer-container {
-            grid-template-columns: auto auto !important;
-            justify-content: space-around;
-            height: 41px;
-          }
-        }
-      }
-
-      ddp-activity-composite-answer {
-        .ddp-answer-container {
-          justify-content: space-between;
-
-          .ddp-answer-field {
-            padding: 0;
-          }
-
-          .mat-form-field {
-            max-width: 120px;
-          }
+          @include cardiac-output;
         }
       }
     }
@@ -464,23 +481,7 @@ $field-disabled-border: $__Mulled_wine_transparent;
   /* tabular block for cMRI form (pretty the same like for CARDIAC_CT) */
   .main_activity.CMRI {
     .tabular-container {
-      grid-template-columns: auto 150px 150px !important;
-      border: none !important;
-
-      .header, .question-title {
-        padding-left: 20px !important;
-        font-weight: 600;
-      }
-
-      .question-title {
-        display: flex;
-        align-items: flex-start;
-        margin-top: 10px;
-      }
-
-      .cell {
-        border: none !important;
-      }
+      @include tabular-container;
 
       .composite-answer {
         &-CQ_CMRI_RV_END_DIASTOLIC_VOLUME,
@@ -488,51 +489,19 @@ $field-disabled-border: $__Mulled_wine_transparent;
         &-CQ_CMRI_LV_END_DIASTOLIC_VOLUME,
         &-CQ_CMRI_LV_END_SYSTOLIC_VOLUME
         {
-          .ddp-answer-container {
-            grid-template-columns: auto auto !important;
-          }
-
-          /* TODO: remove this temp FIX!! just to fix the wrong config form back-end */
-          .ddp-answer-field:first-of-type::after {
-            content: 'Or';
-            top: -12px;
-            position: relative;
-            left: 4px;
-          }
-          /* end of the TODO */
+          @include diastolic-systolic-volume;
         }
 
         &-CQ_CMRI_RV_EJECTION_FRACTION,
         &-CQ_CMRI_LV_EJECTION_FRACTION
         {
-          .ddp-answer-container {
-            grid-template-columns: auto !important;
-            justify-content: left;
-          }
+          @include ejection-fraction;
         }
 
         &-CQ_CMRI_RV_CARDIAC_OUTPUT,
         &-CQ_CMRI_LV_CARDIAC_OUTPUT
         {
-          .ddp-answer-container {
-            grid-template-columns: auto auto !important;
-            justify-content: space-around;
-            height: 41px;
-          }
-        }
-      }
-
-      ddp-activity-composite-answer {
-        .ddp-answer-container {
-          justify-content: space-between;
-
-          .ddp-answer-field {
-            padding: 0;
-          }
-
-          .mat-form-field {
-            max-width: 120px;
-          }
+          @include cardiac-output;
         }
       }
     }


### PR DESCRIPTION
Aligned the tabular block in `cMRI` form with mockups.
Also refactored styles to use them in more general way.

**_Screenshots:_**

![scrr1](https://user-images.githubusercontent.com/7396837/176630208-ba413348-1928-4a68-b35a-b0b08bf0c996.png)


![scrr2](https://user-images.githubusercontent.com/7396837/176630202-1171ccb7-599f-44ff-b6ac-2f73ce465120.png)
