### PR TITLE
DDP/7520 - DDP/7501 tooltip and dropdown year menu fix

### DIFF
--- a/ddp-workspace/projects/ddp-fon/src/assets/circle-info-solid.svg
+++ b/ddp-workspace/projects/ddp-fon/src/assets/circle-info-solid.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" width="20px" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+</svg>

--- a/ddp-workspace/projects/ddp-fon/src/index.html
+++ b/ddp-workspace/projects/ddp-fon/src/index.html
@@ -17,7 +17,9 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
 
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-95RZ7RFCYH"></script>
+      <script src="https://kit.fontawesome.com/9096d3094f.js" crossorigin="anonymous"></script>
     <script>
+
       window.dataLayer = window.dataLayer || [];
 
       function gtag() {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/question-prompt/questionPrompt.component.scss
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/question-prompt/questionPrompt.component.scss
@@ -6,3 +6,4 @@
     line-height: var(--question-prompt-additional-header-line-height, 20px);
   }
 }
+

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/question-prompt/questionPrompt.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/question-prompt/questionPrompt.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { ActivityQuestionBlock } from '../../../../models/activity/activityQuestionBlock';
 
+
 @Component({
     selector: 'ddp-question-prompt',
     template: `
@@ -12,7 +13,7 @@ import { ActivityQuestionBlock } from '../../../../models/activity/activityQuest
                  [innerHTML]="block.additionalInfoHeader"
                  class="ddp-question-prompt__info-header">
            </span>
-           <ddp-tooltip *ngIf="block.tooltip" class="tooltip" [text]="block.tooltip"></ddp-tooltip>
+           <ddp-tooltip *ngIf="block.tooltip" class="tooltip" [text]="block.tooltip" [icon]="icon"></ddp-tooltip>
         </p>
     </div>`,
     styleUrls: ['questionPrompt.component.scss']
@@ -22,6 +23,8 @@ export class QuestionPromptComponent {
      * Content is expected to be an HTML fragment
      */
     @Input() block: ActivityQuestionBlock<any>;
+
+    readonly icon: string =  '../../../../../assets/circle-info-solid.svg';
 
     public get displayAsRequired(): boolean {
         return this.block?.isRequired && this.block?.question && (this.block.question.trim().length > 0);

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/user/userPreferences.component.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/user/userPreferences.component.spec.ts
@@ -138,7 +138,7 @@ describe('UserPreferencesComponent', () => {
         fixture.detectChanges();
 
         expect(component.endYear).toBe(2013);
-        expect(component.startYear).toBe(1913);
+        expect(component.startYear).toBe(1893);
     });
 
     it('calls for user profile when userProfileFieldsForEditing is not empty', () => {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/user/userPreferences.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/user/userPreferences.component.ts
@@ -119,7 +119,7 @@ export class UserPreferencesComponent implements OnDestroy {
         firstName: ['', Validators.required],
         lastName: ['', Validators.required],
     });
-    private readonly YEARS_BACK = 100;
+    private readonly YEARS_BACK = 120;
     public readonly endYear: number;
     public readonly startYear: number;
     public loaded = true;


### PR DESCRIPTION
There is a changes in SDK. one change is about tooltip, because there was not any icon declaration which displayed this tooltip icon and this is the reason why I made changes in SDK, second one is about dropdown year menu change, I had changed a "startYear" property and "YEARS_BACK" property because in the backend,  year calculation started from 1898 and our QA sad that it should be 1913 and also in front side dropdown menu showing last year only 1922 so this solution fix this problem for all studies.