### PR TITLE
[DSM] FON - paginator v4 - disabled icons

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/FON/components/paginator/paginator.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/FON/components/paginator/paginator.component.html
@@ -2,8 +2,8 @@
 
   <div class="paginator-pages">
     <div class="paginator-pages-left-icons">
-      <i (click)="shiftPage('START')" class="fa-regular fa-angles-left"></i>
-      <i (click)="shiftPage('ONE_LESS')" class="fa-regular fa-angle-left"></i>
+      <button [disabled]="isFirst" (click)="shiftPage('START')"><i  class="fa-regular fa-angles-left"></i></button>
+      <button [disabled]="isFirst" (click)="shiftPage('ONE_LESS')"><i  class="fa-regular fa-angle-left"></i></button>
     </div>
 
     <div class="paginator-pages-pages">
@@ -11,8 +11,8 @@
     </div>
 
     <div class="paginator-pages-right-icons">
-      <i (click)="shiftPage('ONE_MORE')" class="fa-regular fa-angle-right"></i>
-      <i (click)="shiftPage('END')" class="fa-regular fa-angles-right"></i>
+      <button (click)="shiftPage('ONE_MORE')" [disabled]="isLast"><i class="fa-regular fa-angle-right"></i></button>
+      <button (click)="shiftPage('END')" [disabled]="isLast"><i  class="fa-regular fa-angles-right"></i></button>
     </div>
   </div>
 

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/FON/components/paginator/paginator.component.scss
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/FON/components/paginator/paginator.component.scss
@@ -8,7 +8,7 @@
 }
 
 @mixin iconHover {
-  & > i:hover {
+  & > :hover {
     color: $__Dark_pastel_blue;
     cursor: pointer;
   }
@@ -29,11 +29,24 @@
       @include flexContainer(center);
       margin-right: 15px;
       @include iconHover;
-      & i:not(:last-of-type) {
-        margin-right: 8px;
-      }
-      & i {
-        margin-top: 3px;
+      button {
+        border: none;
+        background-color: transparent;
+        &:disabled {
+          opacity: 0.6;
+
+          &:hover {
+            color: $__Gunmetal!important;
+            cursor: not-allowed!important;
+          }
+        }
+
+        &:not(:last-of-type) {
+          margin-right: 8px;
+        }
+        & i {
+          margin-top: 3px;
+        }
       }
     }
 

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/FON/components/paginator/paginator.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/FON/components/paginator/paginator.component.ts
@@ -48,6 +48,8 @@ export class PaginatorComponent {
   private currentPageIndex: number;
   private visiblePages: number;
 
+  private lastPage: number;
+
   @Output() pageChanged = new EventEmitter<PageProps>();
 
   @Input('config') set setConfiguration(configuration: Configuration) {
@@ -63,6 +65,7 @@ export class PaginatorComponent {
 
   public get currentPageRange(): (string | number)[] {
     const currentRange = this.filteredCurrentPageRange;
+    this.lastPage = (currentRange as any).at(-1);
     return this.fillWithDots(currentRange);
   }
 
@@ -96,6 +99,14 @@ export class PaginatorComponent {
   public setRows(rows: number): void {
     this.rowsPerPage = rows;
     this.changePage(1);
+  }
+
+  get isFirst(): boolean {
+    return this.currentPageIndex === 1;
+  }
+
+  get isLast(): boolean {
+    return this.currentPageIndex === this.lastPage;
   }
 
   /* Paginator Engine */


### PR DESCRIPTION
Arrows are disabled when the last or the first page is reached:
![image](https://user-images.githubusercontent.com/77500504/177491536-f2fc2a7a-bf15-4595-829d-dfec428df521.png)
