### PR TITLE
handle undefined language

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/internationalization/languageSelector.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/internationalization/languageSelector.component.ts
@@ -74,7 +74,7 @@ import { ActivatedRoute, Router } from '@angular/router';
             >
                 <title
                     id="title"
-                    [lang]="currentLanguage.languageCode"
+                    [lang]="currentLanguage?.languageCode"
                     translate
                 >
                     SDK.LanguageSelector.LanguageSelection
@@ -155,8 +155,9 @@ export class LanguageSelectorComponent implements OnInit, OnDestroy {
     public get binaryDisplayedLanguage(): string {
         let lang = this.currentLanguage;
 
+
         if (this.reverseBinaryLanguageSelector) {
-            lang = this.studyLanguages.find(studyLang => studyLang.languageCode !== this.currentLanguage.languageCode);
+            lang = this.studyLanguages.find(studyLang => studyLang.languageCode !== this.currentLanguage?.languageCode);
         }
 
         return lang.displayName;


### PR DESCRIPTION
Handle undefined currentlanguage with '?' mark. problem was caused because - language is set asynchronously and in function it was undefined and was not handled correctly.