### PR TITLE
adding configurable export options (DDP-7581)

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/ALL-STUDIES/all-studies.routing.module.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/ALL-STUDIES/all-studies.routing.module.ts
@@ -32,6 +32,7 @@ import {NgModule} from '@angular/core';
 import {RouterModule, Routes} from '@angular/router';
 import {AllStudiesComponent} from './all-studies.component';
 import {HomeComponent} from '../home/home.component';
+import {ExportHelpComponent} from '../help/help.component';
 
 
 
@@ -96,6 +97,7 @@ export const AppRoutes: Routes = [
 
       {path: 'test-dss', component: TestDssComponent},
       {path: 'dss-error', component: DssErrorPageComponent},
+      {path: 'help', component: ExportHelpComponent}
     ]},
 ];
 

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/filter-column/models/column.model.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/filter-column/models/column.model.ts
@@ -136,7 +136,7 @@ export class ParticipantColumn {
   public static COHORT_TAG_NAME = new ParticipantColumn('Cohort Tag Name', 'cohortTagName', 'c', 'dsm');
 
   //FON
-  public static ACTIVITY_STATUS = new ParticipantColumn('Enrollmentt Status', 'activityStatus', 'data');
+  public static ACTIVITY_STATUS = new ParticipantColumn('Enrollment Status', 'activityStatus', 'data');
 
   constructor(public display: string, public name: string, public tableAlias?: string, public object?: string, public esData?: boolean) {
     this.display = display;

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/help/help.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/help/help.component.html
@@ -1,0 +1,87 @@
+<h3>Participant List Export</h3>
+Participant export enables download of tabular files (.tsv or .xlsx) containing the data currently visible in the Participant List.
+One row will be generated per participant.
+
+<h4>File format</h4>
+  <div class="panel">
+    <ul>
+      <li>
+        <b>.xlsx</b> will create an Excel spreadsheet of the participant data.  Empty cells will represent null values.
+      </li>
+      <li>
+        <b>.tsv</b> (tab-delimited values).  Will export a tab-delimited file.  This may be useful in environments where Excel is unavailable, or if the
+        number of columns to be exported exceeds 16K.  In order to have data be compliant, double-quotes will be replaced by single quotes, and any values including
+        tabs or line breaks will be surrounded in double-quotes.
+      </li>
+    </ul>
+
+
+  </div>
+
+<h4>Split multiselect choices into separate columns</h4>
+<ul>
+  <li>
+    <b>Yes</b> Each multiselect question will have a column for each answer option.  For example, the question "Which symptoms have you had?"
+    with options "fever", "nausea", and "persisent cough", will be exported into 3 columns.
+    <table class="table table-striped">
+      <thead>
+      <tr>
+        <td>MEDICAL_HISTORY.SYMTPOMS.FEVER</td><td>MEDICAL_HISTORY.SYMPTOMS.NAUSEA</td><td>MEDICAL_HISTORY.SYMPTOMS.COUGH</td>
+      </tr>
+      <tr>
+        <td>fever</td><td>nausea</td><td>persistent cough</td>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+        <td>0</td><td>1</td><td>0</td>
+      </tr>
+      <tr>
+        <td>1</td><td>1</td><td>0</td>
+      </tr>
+      <tr>
+        <td>0</td><td>0</td><td>0</td>
+      </tr>
+      </tbody>
+    </table>
+
+  </li>
+  <li>
+    <b>No</b> will store multi-select questions as a single column, with a comma-delimited string of the answers given. For example, the question "Which symptoms have you had?"
+    with options "fever", "nausea", and "persisent cough", will be exported into 1 column.
+    <table class="table table-striped">
+      <thead>
+      <tr>
+        <td>MEDICAL_HISTORY.SYMTPOMS</td>
+      </tr>
+      <tr>
+        <td>symptoms</td>
+      </tr>
+      </thead>
+      <tbody>
+      <tr>
+        <td>nausea</td>
+      </tr>
+      <tr>
+        <td>fever, nausea</td>
+      </tr>
+      <tr>
+        <td></td>
+      </tr>
+      </tbody>
+    </table>
+  </li>
+</ul>
+<h4>Include all completions of an activity</h4>
+This option controls how the export will behave if a participant has completed an activity multiple times.
+<ul>
+  <li>
+    <b>Yes</b> A new set of columns will be added to the export for each time the activity was completed.  These will be
+    denoted by _2, _3, etc...  Columns will appear in order of *recency*.  So e.g. MEDICAL_HISTORY.SYMPTOMS represents the
+    most recent completion, while MEDICAL_HISTORY_2.SYMPTOMS represents the next-most recent, and so on.
+  </li>
+  <li>
+    <b>No</b> Only the most recent completion for each activity will be included in the export.
+  </li>
+</ul>
+

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/help/help.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/help/help.component.ts
@@ -1,0 +1,25 @@
+import {Component, OnDestroy, OnInit} from '@angular/core';
+import { Auth } from '../services/auth.service';
+import {Observable, Subject} from 'rxjs';
+
+@Component({
+  selector: 'app-help',
+  templateUrl: './help.component.html',
+  styleUrls: []
+})
+export class ExportHelpComponent implements OnInit, OnDestroy {
+  selectedRealm: Observable<string>;
+  destroy = new Subject();
+
+  constructor(public auth: Auth) {}
+
+  ngOnInit(): void {
+    this.selectedRealm = this.auth.getSelectedStudy();
+  }
+
+
+  ngOnDestroy(): void {
+    this.destroy.next(null);
+  }
+
+}

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.html
@@ -893,7 +893,10 @@
       <ng-container *ngIf="modalAnchor === 'saveFilter'">Please enter a name for your filter</ng-container>
       <ng-container *ngIf="modalAnchor === 'assignParticipant'">Select the person you want to assign the participant
       </ng-container>
-      <ng-container *ngIf="modalAnchor === 'exportOptions'"><h4>Configure export</h4>
+      <ng-container *ngIf="modalAnchor === 'exportOptions'">
+        <h4>Configure export
+          <a [routerLink]="['../help']" target="_blank"><span class="fa fa-question-circle"></span></a>
+        </h4>
       </ng-container>
 
     </div>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.html
@@ -185,7 +185,7 @@
                 <td>
                   <button mat-icon-button [color]="getFilterButtonColorStyle(isSelectedFilter(savedFilter.filterName))"
                           (click)="selectFilter(savedFilter)">
-                    <mat-icon>  
+                    <mat-icon>
                       <i class="fas fa-filter fa-sm"></i>
                     </mat-icon>
                   </button>
@@ -758,7 +758,7 @@
                             <ng-container
                               *ngIf="col.type === 'OPTIONS'">{{getOptionDisplay(col.options, tag[col.participantColumn.name])}}
                             </ng-container>
-                          </ng-container>                        
+                          </ng-container>
                         </p>
                       </li>
                     </ul>
@@ -893,6 +893,9 @@
       <ng-container *ngIf="modalAnchor === 'saveFilter'">Please enter a name for your filter</ng-container>
       <ng-container *ngIf="modalAnchor === 'assignParticipant'">Select the person you want to assign the participant
       </ng-container>
+      <ng-container *ngIf="modalAnchor === 'exportOptions'"><h4>Configure export</h4>
+      </ng-container>
+
     </div>
     <div class="app-modal-body">
       <ng-container *ngIf="modalAnchor === 'saveFilter'">
@@ -903,6 +906,45 @@
           <mat-hint class="ErrorMessageForm" *ngIf="plus">Name can't contain +</mat-hint>
         </mat-form-field>
       </ng-container>
+      <ng-container *ngIf="modalAnchor === 'exportOptions'">
+        <mat-radio-group [(ngModel)]="exportFileFormat">
+          File format:
+          <div>
+
+            <mat-radio-button color="primary" disableRipple value="tsv">
+              <span tooltip="tab-delimited values">.tsv</span>
+            </mat-radio-button>
+            <mat-radio-button color="primary" disableRipple value="xlsx">
+              <span tooltip="Microsoft Excel workbook">.xlsx</span>
+            </mat-radio-button>
+          </div>
+        </mat-radio-group>
+        <br/>
+        <mat-radio-group [(ngModel)]="exportSplitOptions">
+          Split multiselect choices into separate columns:
+          <div>
+
+             <mat-radio-button color="primary" disableRipple [value]="true">
+              <span tooltip="Each option of a multiselect will be displayed in a separate column, with 0/1 indicating selection">Yes</span>
+            </mat-radio-button>
+            <mat-radio-button color="primary" disableRipple [value]="false">
+              <span tooltip="Multiselects will be exported as a comma-delimited list of the selections">No</span>
+            </mat-radio-button>
+          </div>
+        </mat-radio-group>
+        <br/>
+        <mat-radio-group [(ngModel)]="exportOnlyMostRecent">
+          Include all completions of an activity:
+          <div>
+            <mat-radio-button color="primary" disableRipple [value]="false">
+              <span tooltip="Include all, with each activity completion in a separate column">Yes</span>
+            </mat-radio-button>
+            <mat-radio-button color="primary" disableRipple [value]="true">
+              <span tooltip="Only values from the participant's most recent completion of each activity will be included">No</span>
+            </mat-radio-button>
+          </div>
+        </mat-radio-group>
+      </ng-container>
       <ng-container *ngIf="modalAnchor === 'assignParticipant'">
         <mat-checkbox color="primary" disableRipple
                      [(ngModel)]="assignMR">Assign to request MR
@@ -912,6 +954,9 @@
                      [(ngModel)]="assignTissue">Assign to request Tissue
         </mat-checkbox>
         <app-assignee (selectedAssignee)="assigneeSelected($event)" [assignees]="assignees"></app-assignee>
+      </ng-container>
+      <ng-container *ngIf="modalAnchor === 'downloadError'">
+        An error occurred processing the participant download, please contact your DSM developer<br/>
       </ng-container>
     </div>
     <div class="app-modal-footer">
@@ -930,6 +975,19 @@
         </button>
         <button type="button" class="btn btn-primary"
                 (click)="assign()" [disabled]="!assignMR && !assignTissue">Assign
+        </button>
+      </ng-container>
+      <ng-container *ngIf="modalAnchor === 'exportOptions'">
+        <button type="button" class="btn btn-primary"
+                (click)="executeDownload()">Download
+        </button>
+        <button type="button" class="btn"
+                (click)="modal.hide()">Cancel
+        </button>
+      </ng-container>
+      <ng-container *ngIf="modalAnchor === 'downloadError'">
+        <button type="button" class="btn btn-primary"
+                (click)="modal.hide()">Ok
         </button>
       </ng-container>
     </div>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -1657,44 +1657,6 @@ export class ParticipantListComponent implements OnInit {
   }
 
   downloadCurrentData(): void {
-    if (!this.hasRole().isFeatureFlagExportNew()) {
-      return this.chooseExportOptions();
-    }
-    const dialogRef = this.openDialog('Exporting participants list...');
-    const columns = [];
-    for(const col in this.selectedColumns) {
-      for (const key in this.selectedColumns[col]) {
-        columns.push(this.selectedColumns[col][key]['participantColumn']);
-      }
-    }
-    this.dsmService.downloadParticipantData(
-      localStorage.getItem(ComponentService.MENU_SELECTED_REALM),
-      this.jsonPatch,
-      this.parent,
-      columns,
-      this.viewFilter,
-      null,
-      this.sortBy
-    ).subscribe({
-      next: response => {
-        let fileName = 'file';
-        const contentDisposition = response.headers.get('Content-Disposition');
-        if (contentDisposition) {
-          const fileNameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
-          const matches = fileNameRegex.exec(contentDisposition);
-          if (matches != null && matches[1]) {
-            fileName = matches[1].replace(/['"]/g, '');
-          }
-        }
-        const fileContent = response.body;
-        const blob = new Blob([fileContent], { type: 'application/octet-stream' });
-        saveAs(blob, fileName);
-        dialogRef.close();
-      }}
-    );
-  }
-
-  chooseExportOptions(): void {
     this.openModal('exportOptions');
   }
 

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -92,6 +92,10 @@ export class ParticipantListComponent implements OnInit {
   filterQuery: string = null;
   activityDefinitions = new Map();
 
+  exportFileFormat: string = "tsv";
+  exportSplitOptions: boolean = true;
+  exportOnlyMostRecent: boolean = false;
+
   selectedColumns = {};
   prevSelectedColumns = {};
   defaultColumns = [];
@@ -1653,6 +1657,9 @@ export class ParticipantListComponent implements OnInit {
   }
 
   downloadCurrentData(): void {
+    if (!this.hasRole().isFeatureFlagExportNew()) {
+      return this.chooseExportOptions();
+    }
     const dialogRef = this.openDialog('Exporting participants list...');
     const columns = [];
     for(const col in this.selectedColumns) {
@@ -1683,6 +1690,55 @@ export class ParticipantListComponent implements OnInit {
         const blob = new Blob([fileContent], { type: 'application/octet-stream' });
         saveAs(blob, fileName);
         dialogRef.close();
+      }}
+    );
+  }
+
+  chooseExportOptions(): void {
+    this.openModal('exportOptions');
+  }
+
+  executeDownload(): void {
+    this.modal.hide();
+
+    const dialogRef = this.openDialog('Exporting participants list...');
+    const columns = [];
+    for(const col in this.selectedColumns) {
+      for (const key in this.selectedColumns[col]) {
+        columns.push(this.selectedColumns[col][key]);
+      }
+    }
+    this.dsmService.downloadParticipantData(
+      localStorage.getItem(ComponentService.MENU_SELECTED_REALM),
+      this.jsonPatch,
+      this.parent,
+      columns,
+      this.viewFilter,
+      null,
+      this.sortBy,
+      this.exportFileFormat,
+      this.exportSplitOptions,
+      this.exportOnlyMostRecent
+    ).subscribe({
+      next: response => {
+        let fileName = 'file';
+        const contentDisposition = response.headers.get('Content-Disposition');
+        if (contentDisposition) {
+          const fileNameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
+          const matches = fileNameRegex.exec(contentDisposition);
+          if (matches != null && matches[1]) {
+            fileName = matches[1].replace(/['"]/g, '');
+          }
+        }
+        const fileContent = response.body;
+        const blob = new Blob([fileContent], { type: 'application/octet-stream' });
+        saveAs(blob, fileName);
+        dialogRef.close();
+      },
+      error: err => {
+        dialogRef.close();
+        // open a dialog to show the error so the user doesn't lose their current view
+        this.openModal('downloadError');
       }}
     );
   }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dsm.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dsm.service.ts
@@ -214,7 +214,8 @@ export class DSMService {
   }
 
   public downloadParticipantData(realm: string, jsonPatch: string, parent: string, columns: {}, json: ViewFilter,
-                                 filterQuery: string, sortBy?: Sort):
+                                 filterQuery: string, sortBy?: Sort, fileFormat?: string, splitOptions?: boolean,
+                                 onlyMostRecent?: boolean):
     Observable<any> {
     const viewFilterCopy = this.getFilter(json);
     const url = this.baseUrl + DSMService.UI + 'participantList';
@@ -225,6 +226,15 @@ export class DSMService {
     map.push({name: 'parent', value: parent});
     if (sortBy) {
       map.push({name: 'sortBy', value: JSON.stringify(sortBy)});
+    }
+    if (fileFormat) {
+      map.push({name: 'fileFormat', value: fileFormat});
+    }
+    if (typeof splitOptions === "boolean") {
+      map.push({name: 'splitOptions', value: splitOptions});
+    }
+    if (typeof splitOptions === "boolean") {
+      map.push({name: 'onlyMostRecent', value: onlyMostRecent});
     }
     if (filterQuery != null) {
       map.push({name: 'filterQuery', value: filterQuery});

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/role.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/role.service.ts
@@ -31,6 +31,7 @@ export class RoleService {
   private _isParticipantEdit = false;
   private _isDSSTesting = true; //TODO remove before final merge, for testing only
   private _isKitUploadInvalidAddress = false;
+  private _isFeatureFlagExportNew = false;
 
   private _userId: string;
   private _user: string;
@@ -126,6 +127,9 @@ export class RoleService {
           }
           else if (entry === 'kit_upload_invalid_address') {
             this._isKitUploadInvalidAddress = true;
+          }
+          else if (entry === 'feature_flag_export_new') {
+            this._isFeatureFlagExportNew = true;
           }
         }
       }
@@ -262,5 +266,9 @@ export class RoleService {
 
   public allowedToUploadKitInvalidAddress(): boolean {
     return this._isKitUploadInvalidAddress;
+  }
+
+  public isFeatureFlagExportNew() : boolean {
+    return this._isFeatureFlagExportNew;
   }
 }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/role.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/role.service.ts
@@ -31,7 +31,6 @@ export class RoleService {
   private _isParticipantEdit = false;
   private _isDSSTesting = true; //TODO remove before final merge, for testing only
   private _isKitUploadInvalidAddress = false;
-  private _isFeatureFlagExportNew = false;
 
   private _userId: string;
   private _user: string;
@@ -127,9 +126,6 @@ export class RoleService {
           }
           else if (entry === 'kit_upload_invalid_address') {
             this._isKitUploadInvalidAddress = true;
-          }
-          else if (entry === 'feature_flag_export_new') {
-            this._isFeatureFlagExportNew = true;
           }
         }
       }
@@ -266,9 +262,5 @@ export class RoleService {
 
   public allowedToUploadKitInvalidAddress(): boolean {
     return this._isKitUploadInvalidAddress;
-  }
-
-  public isFeatureFlagExportNew() : boolean {
-    return this._isFeatureFlagExportNew;
   }
 }


### PR DESCRIPTION
DDP-7581  This adds a configuration modal to the export participants download button
![image](https://user-images.githubusercontent.com/2800795/178002746-badc715d-cdd6-46b6-a651-f564e926a990.png)


This also adds error handling to the download process, so if a server error occurs, a dialog explaining that will be shown to the user.  
![image](https://user-images.githubusercontent.com/2800795/177606405-853932eb-1da7-4c3a-a46b-ad20a7cb1658.png)

A help page is also linked from the export modal to give details about the configuration options.

![image](https://user-images.githubusercontent.com/2800795/178002637-87e425df-e561-4cd3-b068-486972184cab.png)


This corresponds to the backend PR https://github.com/broadinstitute/ddp-study-server/pull/1922

TO TEST:
 1. Go to participant list for a study
 2. press the download icon
 3. select options
 4. hit "Download"
 5. confirm the downloaded file reflects the options you selected