### PR TITLE
DDP-8200: Alternative fix for a bug when it is possible to save an empty address

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.ts
@@ -556,8 +556,7 @@ export class AddressEmbeddedComponent implements OnDestroy, OnInit {
             tap((errorMessage) => this.stateUpdates$.next({formErrorMessages: [{ message: errorMessage, isEasyPostError: false }]}))
         );
 
-        const canSaveRealAddress: FuncType<boolean> = (address: Address | null) =>
-            this.enoughDataToSave(address) && this.meetsActivityRequirements(address);
+        const canSaveRealAddress: FuncType<boolean> = (address: Address | null) => this.meetsActivityRequirements(address);
 
         // "Real" as opposed to "Temp". Important we return the saved address as properties are added on server
         const saveRealAddressAction$ = this.saveTrigger$.pipe(
@@ -703,12 +702,14 @@ export class AddressEmbeddedComponent implements OnDestroy, OnInit {
         ).subscribe();
     }
 
-
     private meetsActivityRequirements(currentAddress: Address | null): boolean {
         if (this.block.requireVerified && !currentAddress) {
             return false;
         }
-        return !(this.block.requirePhone && currentAddress && !(currentAddress.phone));
+        if (this.block.requirePhone && !(currentAddress?.phone)) {
+            return false;
+        }
+        return this.enoughDataToSave(currentAddress);
     }
 
     private computeValidityForSparseAddress(address: Address | null): boolean {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressEmbedded.component.ts
@@ -703,13 +703,11 @@ export class AddressEmbeddedComponent implements OnDestroy, OnInit {
     }
 
     private meetsActivityRequirements(currentAddress: Address | null): boolean {
-        if (this.block.requireVerified && !currentAddress) {
+        if (this.block.requireVerified && !this.enoughDataToSave(currentAddress)) {
             return false;
         }
-        if (this.block.requirePhone && !(currentAddress?.phone)) {
-            return false;
-        }
-        return this.enoughDataToSave(currentAddress);
+
+        return  !(this.block.requirePhone && !(currentAddress?.phone));
     }
 
     private computeValidityForSparseAddress(address: Address | null): boolean {


### PR DESCRIPTION
The bug-fix is an alternative for [bug-fix PR#1462](https://github.com/broadinstitute/ddp-angular/pull/1462).
The logic is practically the same like it was before, all existing tests pass. 

Meanwhile in [PR#1462](https://github.com/broadinstitute/ddp-angular/pull/1462) the suggested changes seem like breaking changes, they break current tests and check different set of mailing address fields.

The main difference between these two PRs is `enoughDataToSave` method.
In current existing code (as well as here in the PR) we check if at least one of proper address fields is not blank,
Vice versa, the [PR#1462](https://github.com/broadinstitute/ddp-angular/pull/1462) requires all those fields to be non-empty.

The thing is that all the changes are situated in ddp-sdk library (common for all studies). 
Thereby, changes in PR#1462 (suggested for fixing [ DDP-8200 bug](https://broadinstitute.atlassian.net/browse/DDP-8200) for LMS study) can potentially lead to changed behavior in other studies (breaking changes?).
 Or, may be, it can mean that we had a non-caught bug for quite a while. 
 
**_In addition:_**
We also have a configuration `addressEnforceRequiredFields` flag (on a study level, see `ConfigurationService`) that is used for  enforcing (all) required fields to be entered. Is is used in testboston study only for now.

------------------
**_Update:_**

Checked on LMS study. Seems the bug is fixed.
![scre1](https://user-images.githubusercontent.com/7396837/178017868-2298b716-1ea5-4151-aaeb-e640431c34ec.png)

Screen record:

https://user-images.githubusercontent.com/7396837/178017914-d22e474b-7f5b-4a36-a34d-1733d74ef5eb.mp4

