### PR TITLE
[DSM] FON: DDP-8201: Fix styles for tabular block in Medical history

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/FON/pages/activities/components/activity/activity.component.scss
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/FON/pages/activities/components/activity/activity.component.scss
@@ -320,7 +320,7 @@ $field-disabled-border: $__Mulled_wine_transparent;
   /* ------------- Tabular blocks custom styles --------------------- */
 
   /* tabular block for Enrollment form */
-  .main_activity.ENROLLMENT {
+  .main_activity.MEDICAL_HISTORY {
     .tabular-container {
       grid-template-columns: 28px auto 1fr 1fr !important;
       border: none !important;
@@ -328,10 +328,6 @@ $field-disabled-border: $__Mulled_wine_transparent;
       .header {
         text-align: left;
         font-weight: 600;
-
-        &:nth-child(2) {
-          padding-left: 12px;
-        }
       }
 
       .cell {
@@ -350,7 +346,7 @@ $field-disabled-border: $__Mulled_wine_transparent;
           .ddp-answer-field {
             padding: 0;
 
-            &:nth-child(2) {
+            + .ddp-answer-field {
               width: 125px !important;
 
               .mat-form-field {


### PR DESCRIPTION
Fixed styles for tabular block in `Medical history` form.
Previously it was a part/section of `Enrollment` form, then the `Medical history` form was extracted.

**_Before the fix:_**
![bf1](https://user-images.githubusercontent.com/7396837/177988314-1676e518-6c87-4602-8efd-ba8627686543.png)


**_After the fix:_**
![af1](https://user-images.githubusercontent.com/7396837/177988328-cb886437-90b0-4314-8769-c415b4055480.png)
