### PR TITLE
DDP-7499 fix decimal number scaling

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/utility/decimalHelper.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/utility/decimalHelper.ts
@@ -4,7 +4,7 @@ import { NumericAnswerType } from '../models/activity/numericAnswerType';
 
 export class DecimalHelper {
     static mapDecimalAnswerToNumber(answer: DecimalAnswer): number {
-        return answer.value * Math.pow(10, -(answer.scale));
+        return answer.value/ Math.pow(10, answer.scale);
     }
 
     static isDecimalAnswerType(obj: any): boolean {


### PR DESCRIPTION
replace multiplier with division, since javascript adds trailing 0s and 1 in the end which allows the user to break validation.
for example 700 * Math.pow(10, -3) returns 0.7000000000000001