### PR TITLE
DDP-7351-scroll-up-error

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityQuestion.component.ts
@@ -1,6 +1,15 @@
 import { Component, ElementRef, EventEmitter, Inject, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
 import { BehaviorSubject, combineLatest, Observable, Subject } from 'rxjs';
-import { delay, filter, map, shareReplay, startWith, takeUntil, tap } from 'rxjs/operators';
+import {
+    debounceTime,
+    delay,
+    filter,
+    map,
+    shareReplay,
+    startWith,
+    takeUntil,
+    tap,
+} from 'rxjs/operators';
 
 import { ActivityQuestionBlock } from '../../../models/activity/activityQuestionBlock';
 import { WindowRef } from '../../../services/windowRef';
@@ -136,6 +145,7 @@ export class ActivityQuestionComponent implements OnInit, OnDestroy {
     private setupScrollToErrorAction(): void {
         this.validationRequested$.pipe(
             filter(validationRequested => validationRequested && this.block.scrollTo),
+            debounceTime(300),
             tap(() => {
                 const headerOffset = this.config.scrollToErrorOffset;
                 const top = this.scrollAnchor.nativeElement.getBoundingClientRect().top

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity.component.ts
@@ -212,11 +212,10 @@ export class ActivityComponent extends BaseActivityComponent implements OnInit, 
                         // delay needed for validationRequested to be processed
                         delay(0),
                         tap(() => {
+                            this.validationRequested = false;
                             this.sendSectionAnalytics();
                             if (this.currentSection.valid) {
                                 // reset scrolling signal and disable a local validation
-                                this.validationRequested = false;
-
                                 this.visitedSectionIndexes[nextIndex] = true;
                                 this.saveLastVisitedSectionIndex(nextIndex);
                                 this.currentSectionIndex = nextIndex;


### PR DESCRIPTION
Related ticket -> https://broadinstitute.atlassian.net/jira/software/c/projects/DDP/boards/836?modal=detail&selectedIssue=DDP-8341&quickFilter=2669

I think issue here is that in some cases validationRequest property was not updated in the if statemant, because of that changeDetection was not activating validationRequested setter in activityQuestion component, where validationRequested$ 
observable emits the new value. scrolling is only triggered when a new value is received. I moved validationRequest property out of the if statement so that it's always updated. 