### PR TITLE
DDP-7581 - changing default export to Excel

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.html
@@ -913,12 +913,11 @@
         <mat-radio-group [(ngModel)]="exportFileFormat">
           File format:
           <div>
-
-            <mat-radio-button color="primary" disableRipple value="tsv">
-              <span tooltip="tab-delimited values">.tsv</span>
-            </mat-radio-button>
             <mat-radio-button color="primary" disableRipple value="xlsx">
-              <span tooltip="Microsoft Excel workbook">.xlsx</span>
+              <span tooltip="Microsoft Excel workbook">Excel (.xlsx)</span>
+            </mat-radio-button>
+            <mat-radio-button color="primary" disableRipple value="tsv">
+              <span tooltip="tab-delimited values">Tab-delimited (.tsv)</span>
             </mat-radio-button>
           </div>
         </mat-radio-group>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -92,7 +92,7 @@ export class ParticipantListComponent implements OnInit {
   filterQuery: string = null;
   activityDefinitions = new Map();
 
-  exportFileFormat: string = 'tsv';
+  exportFileFormat: string = 'xlsx';
   exportSplitOptions: boolean = true;
   exportOnlyMostRecent: boolean = false;
 
@@ -1670,7 +1670,7 @@ export class ParticipantListComponent implements OnInit {
   executeDownload(): void {
     this.modal.hide();
 
-    const dialogRef = this.openDialog('Exporting participants list...');
+    const dialogRef = this.openDialog('Exporting participants list. This may take several minutes...');
     const columns = [];
     for(const col in this.selectedColumns) {
       for (const key in this.selectedColumns[col]) {


### PR DESCRIPTION
This updates the default export file format to Excel, and adds more description to the menu options

![image](https://user-images.githubusercontent.com/2800795/179790355-b673cc91-ffc1-43df-bf3a-c42b0f96a278.png)

TO TEST:
1. load participant list for a study
2. click the download button.
3. confirm modal appears as above, with `.xlsx` selected as default
4. press "Download", and confirm that an .xlsx file is downloaded