### PR TITLE
DDP/8429 - Family History Window pop-up

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityBlock/activityBlock.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/activity-blocks/activityBlock/activityBlock.component.ts
@@ -95,13 +95,8 @@ export class ActivityBlockComponent implements OnInit, OnDestroy {
 
                 if (blockVisibility) {
                     this.blockVisibilityChanged.emit(blockVisibility);
-                } else {
-                    /**
-                     * Emitting a `blockVisibilityChanged` event will call `detectChanges`
-                     * so we call this here only if there were no changes in block visibility
-                     */
-                    this.cdr.detectChanges();
                 }
+                this.cdr.detectChanges();
 
                 this.openCreatedInstanceDialog(instance.instanceGuid);
             });


### PR DESCRIPTION
I moved detectChanges() function outside of the else block as it was not called in some cases and because of that DOM was not updating in time for openCreatedInstanceDialog function where we were trying to find that modal activity element.
here is the ticket link.
https://broadinstitute.atlassian.net/browse/DDP-8429