### PR TITLE
DDP-7581 - remove dashboard export

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/app.module.ts
@@ -22,7 +22,7 @@ declare const DDP_ENV: any;
 
 export const sdkConfig = new ConfigurationService();
 
-sdkConfig.backendUrl = 'https://pepper-dev.datadonationplatform.org';
+sdkConfig.backendUrl = 'https://pepper-staging.datadonationplatform.org';
 sdkConfig.auth0Domain = DDP_ENV.auth0Domain;
 sdkConfig.auth0ClientId = DDP_ENV.auth0ClientKey;
 sdkConfig.adminClientId = DDP_ENV.adminClientId || DDP_ENV.auth0ClientKey;

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard/dashboard.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard/dashboard.component.html
@@ -1128,18 +1128,6 @@
             </ng-container>
           </ng-container>
         </ng-container>
-        <tr>
-          <td colspan="4">
-            <br/>
-            <mat-select placeholder="Select source" [(ngModel)]="downloadSource" class="Input--Bigger-WIDTH">
-              <mat-option *ngFor="let key of getSourceKeys()" [value]="key">{{dataSources.get(key)}}</mat-option>
-            </mat-select>
-            <button type="button" mat-raised-button color="primary"
-                    (click)="dataExport(downloadSource)"
-                    [disabled]="participantList.length === 0 || downloadSource == null">Export Data
-            </button>
-          </td>
-        </tr>
         </tbody>
       </table>
     </div>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard/dashboard.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard/dashboard.component.ts
@@ -63,7 +63,6 @@ export class DashboardComponent implements OnInit {
     [ 'k', 'Sample' ],
     [ 'a', 'Abstraction' ] ]);
   sourceColumns = {};
-  downloadSource;
   hasESData = false;
   activityDefinitionList: ActivityDefinition[] = [];
   participantList: Participant[] = [];
@@ -484,54 +483,6 @@ export class DashboardComponent implements OnInit {
     });
   }
 
-  dataExport(source: string): void {
-    this.loadingDDPData = true;
-    if (source != null) {
-      const date = new Date();
-      const columns = {};
-      this.dataSources.forEach((value: string, key: string) => {
-        if (this.sourceColumns[ key ] != null && this.sourceColumns[ key ].length !== 0) {
-          columns[ key ] = this.sourceColumns[ key ];
-        }
-      });
-      if (this.participantList.length !== 0) {
-        if (source === 'm') {
-          Utils.downloadCurrentData(
-            this.participantList, [ [ 'data', 'data' ], [ 'participant', 'p' ], [ 'medicalRecords', 'm' ] ],
-            columns, 'Participants-MR-' + Utils.getDateFormatted(date, Utils.DATE_STRING_CVS) + Statics.CSV_FILE_EXTENSION
-          );
-          this.downloadDone();
-        } else if (source === 'oD') {
-          Utils.downloadCurrentData(
-            this.participantList, [ [ 'data', 'data' ], [ 'participant', 'p' ], [ 'oncHistoryDetails', 'oD', 'tissues', 't' ] ],
-            columns, 'Participants-OncHistory-' + Utils.getDateFormatted(date, Utils.DATE_STRING_CVS) + Statics.CSV_FILE_EXTENSION
-          );
-          this.downloadDone();
-        } else if (source === 'k') {
-          Utils.downloadCurrentData(this.participantList,
-            [ [ 'data', 'data' ], [ 'participant', 'p' ], [ 'kits', 'k' ] ],
-            columns,
-            'Participants-Sample-' + Utils.getDateFormatted(date, Utils.DATE_STRING_CVS) + Statics.CSV_FILE_EXTENSION
-          );
-          this.downloadDone();
-        } else if (source === 'a') {
-          // TODO add final abstraction values to download
-          Utils.downloadCurrentData(
-            this.participantList, [ [ 'data', 'data' ], [ 'participant', 'p' ], [ 'abstractionActivities', 'a' ] ],
-            columns, 'Participants-Abstraction-' + Utils.getDateFormatted(date, Utils.DATE_STRING_CVS) + Statics.CSV_FILE_EXTENSION
-          );
-          this.downloadDone();
-        } else {
-          Utils.downloadCurrentData(
-            this.participantList, [ [ 'data', 'data' ], [ source, source ] ], columns,
-            'Participants-' + source + Utils.getDateFormatted(date, Utils.DATE_STRING_CVS) + Statics.CSV_FILE_EXTENSION, true
-          );
-          this.downloadDone();
-        }
-      }
-    }
-  }
-
   getParticipantData(): void {
     this.dsmService.applyFilter(null, localStorage.getItem(ComponentService.MENU_SELECTED_REALM), 'participantList', null)
       .subscribe({
@@ -551,21 +502,6 @@ export class DashboardComponent implements OnInit {
           this.errorMessage = 'Error - Downloading Participant List, Please contact your DSM developer';
         }
       });
-  }
-
-  downloadDone(): void {
-    this.loadingDDPData = false;
-    this.errorMessage = null;
-  }
-
-  getSourceKeys(): string[] {
-    const keys = [];
-    this.dataSources.forEach((value: string, key: string) => {
-      if (key !== 'data' && key !== 'p' && key !== 't') {
-        keys.push(key);
-      }
-    });
-    return keys;
   }
 
 }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/filter-column/filter-column.model.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/filter-column/filter-column.model.ts
@@ -464,7 +464,7 @@ export class Filter {
               filter.participantColumn, filter.type, f.options, filter.filter2, filter.range, filter.exactMatch, filter.filter1,
               selectedOptions, filter.filter1 == null ? null : filter.filter1.value,
               filter.filter2 == null ? null : filter.filter2.value, null,
-              filter.empty, filter.notEmpty, f.singleOption, f.additionalType
+              filter.empty, filter.notEmpty, f.singleOption, f.additionalType, filter.parentName
             );
             filters.push(newFilter);
             break;

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/medical-record/medical-record.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/medical-record/medical-record.component.ts
@@ -304,26 +304,64 @@ export class MedicalRecordComponent implements OnInit {
   public setContact(contact: Lookup | string): void {
     if (contact != null) {
       if (contact instanceof Lookup) {
+        const nameValues = [];
         this.medicalRecord.name = contact.field1.value;
-        this.valueChanged(contact.field1.value, 'name');
+        nameValues.push({name: 'm.name', value: this.medicalRecord.name});
         if (contact.field2.value != null) {
           this.medicalRecord.contact = contact.field2.value;
-          this.valueChanged(contact.field2.value, 'contact');
+          nameValues.push({name: 'm.contact', value: this.medicalRecord.contact});
         }
         if (contact.field3.value != null) {
           this.medicalRecord.phone = contact.field3.value;
-          this.valueChanged(contact.field3.value, 'phone');
+          nameValues.push({name: 'm.phone', value: this.medicalRecord.phone});
         }
         if (contact.field4.value != null) {
           this.medicalRecord.fax = contact.field4.value;
-          this.valueChanged(contact.field4.value, 'fax');
+          nameValues.push({name: 'm.fax', value: this.medicalRecord.fax});
         }
-        this.lookups = [];
+        this.lookups        = [];
+        const participantId = this.getParticipantId();
+        const realm         = localStorage.getItem(ComponentService.MENU_SELECTED_REALM);
+        const patch         = new PatchUtil(
+          this.medicalRecord.medicalRecordId, 
+          this.role.userMail(),
+          null,
+          nameValues,
+          null,
+          participantId,
+          Statics.MR_ALIAS,
+          null,
+          realm,
+          this.participant.data.profile['guid']);
+        this.patchMultipleNameValues(patch);
       } else {
         this.medicalRecord.name = contact;
         this.valueChanged(contact, 'name');
       }
     }
+  }
+
+  patchMultipleNameValues(patch: PatchUtil): void {
+    this.dsmService.patchParticipantRecord(JSON.stringify(patch)).subscribe({
+      next: data => {
+        if (data) {
+        if (data instanceof Array) {
+          data.forEach( ( val ) => {
+                const nameValue = NameValue.parse(val);
+                this.medicalRecord[ nameValue.name ] = nameValue.value;
+              });
+          }
+        }
+        this.patchFinished = true;
+        this.currentPatchField = null;
+      },
+      error: err => {
+        if (err._body === Auth.AUTHENTICATION_ERROR) {
+          this.router.navigate([ Statics.HOME_URL ]);
+        }
+        this.additionalMessage = 'Error - Saving changes \n' + err;
+      }
+    });
   }
 
   getUtil(): Utils {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/medical-record/medical-record.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/medical-record/medical-record.component.ts
@@ -323,7 +323,7 @@ export class MedicalRecordComponent implements OnInit {
         const participantId = this.getParticipantId();
         const realm         = localStorage.getItem(ComponentService.MENU_SELECTED_REALM);
         const patch         = new PatchUtil(
-          this.medicalRecord.medicalRecordId, 
+          this.medicalRecord.medicalRecordId,
           this.role.userMail(),
           null,
           nameValues,

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/medical-record/medical-record.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/medical-record/medical-record.component.ts
@@ -151,7 +151,7 @@ export class MedicalRecordComponent implements OnInit {
       const patch1 = new PatchUtil(
         this.medicalRecord.medicalRecordId, this.role.userMail(),
         {name: parameterName, value: v}, null, null, participantId,
-        Statics.MR_ALIAS, null, realm, this.participant.participant.ddpParticipantId
+        Statics.MR_ALIAS, null, realm, this.participant.data.profile[ 'guid' ]
       );
       const patch = patch1.getPatch();
       this.patchFinished = false;

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/medical-record/medical-record.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/medical-record/medical-record.component.ts
@@ -386,6 +386,7 @@ export class MedicalRecordComponent implements OnInit {
 
   onAdditionalValueChange(evt: any, colName: string): void {
     let v;
+    colName = Utils.convertUnderScoresToCamelCase(colName);
     if (typeof evt === 'string') {
       v = evt;
     } else {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/onc-history-detail/onc-history-detail.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/onc-history-detail/onc-history-detail.component.html
@@ -50,7 +50,7 @@
     <tbody>
     <ng-container *ngFor="let oncHis of oncHistory | oncHistoryDetailSort:triggerSort; let i = index">
 
-      <tr [id]="oncHis.oncHistoryDetailId" [ngClass]="{'Green-background': oncHis.oncHistoryDetailId === oncHistoryId}">
+      <tr *ngIf="!oncHis.deleted" [id]="oncHis.oncHistoryDetailId" [ngClass]="{'Green-background': oncHis.oncHistoryDetailId === oncHistoryId}">
         <td>
           <mat-checkbox *ngIf="oncHis.request === 'request' || oncHis.request === 'sent'" color="primary" disableRipple
                        [(ngModel)]="oncHis.selected" (change)="selected()" [disabled]="!editable || participantExited">

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/onc-history-detail/onc-history-detail.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/onc-history-detail/onc-history-detail.component.ts
@@ -93,7 +93,7 @@ export class OncHistoryDetailComponent implements OnInit {
           name: parameterName,
           value: v
         }, null, 'participantId', this.participant.participant.participantId,
-        Statics.ONCDETAIL_ALIAS, null, realm, this.participant.participant.ddpParticipantId
+        Statics.ONCDETAIL_ALIAS, null, realm, this.participant.data.profile['guid']
       );
       const patch = patch1.getPatch();
       this.patchFinished = false;

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/onc-history-detail/onc-history-detail.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/onc-history-detail/onc-history-detail.component.ts
@@ -187,6 +187,7 @@ export class OncHistoryDetailComponent implements OnInit {
   // add additional value to oncHistoryDetails
   onAdditionalColChange(evt: any, index: number, colName: string): void {
     let v;
+    colName = Utils.convertUnderScoresToCamelCase(colName);
     if (typeof evt === 'string') {
       v = evt;
     } else {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/onc-history-detail/onc-history-detail.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/onc-history-detail/onc-history-detail.component.ts
@@ -227,12 +227,12 @@ export class OncHistoryDetailComponent implements OnInit {
     tissues.push(new Tissue(null, null, null, null, null, null,
       null, null, null, null, null, null, null, null,
       null, null, null, null, null, null, null,
-      null, null, null, null, null, null, null, null, null));
+      null, null, null, null, null, null, null, null, null, false));
     this.oncHistory.push(new OncHistoryDetail(participantId, null, null, null, null,
       null, null, null, null, null, null, null, null,
       null, null, null, null, null, null, null, null, null,
       null, null, null, tissues,
-      null, null, null, null));
+      null, null, null, null, false));
   }
 
   deleteOncHistory(index: number): void {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/onc-history-detail/onc-history-detail.model.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/onc-history-detail/onc-history-detail.model.ts
@@ -3,7 +3,6 @@ import { Tissue } from '../tissue/tissue.model';
 export class OncHistoryDetail {
   changed = false;
   selected = false;
-  deleted = false;
 
   changedBy: string;
 
@@ -17,7 +16,7 @@ export class OncHistoryDetail {
               public tissueReceived: string, public gender: string,
               public additionalValuesJson: {}, public tissues: Array<Tissue>,
               public tissueProblemOption: string, public destructionPolicy: string, public unableObtainTissue: boolean,
-              public numberOfRequests) {
+              public numberOfRequests, public deleted: boolean) {
     this.participantId = participantId;
     this.oncHistoryDetailId = oncHistoryDetailId;
     this.medicalRecordId = medicalRecordId;
@@ -47,6 +46,7 @@ export class OncHistoryDetail {
     this.tissueProblemOption = tissueProblemOption;
     this.destructionPolicy = destructionPolicy;
     this.unableObtainTissue = unableObtainTissue;
+    this.deleted = deleted;
   }
 
   static parse(json): OncHistoryDetail {
@@ -73,7 +73,7 @@ export class OncHistoryDetail {
       json.tFaxSent2, json.tFaxSent2By, json.tFaxConfirmed2,
       json.tFaxSent3, json.tFaxSent3By, json.tFaxConfirmed3,
       json.tissueReceived, json.gender, additionalValuesJson, tissues,
-      json.tissueProblemOption, json.destructionPolicy, json.unableObtainTissue, json.numberOfRequests
+      json.tissueProblemOption, json.destructionPolicy, json.unableObtainTissue, json.numberOfRequests, json.deleted
     );
   }
 }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.html
@@ -913,12 +913,11 @@
         <mat-radio-group [(ngModel)]="exportFileFormat">
           File format:
           <div>
-
-            <mat-radio-button color="primary" disableRipple value="tsv">
-              <span tooltip="tab-delimited values">.tsv</span>
-            </mat-radio-button>
             <mat-radio-button color="primary" disableRipple value="xlsx">
-              <span tooltip="Microsoft Excel workbook">.xlsx</span>
+              <span tooltip="Microsoft Excel workbook">Excel (.xlsx)</span>
+            </mat-radio-button>
+            <mat-radio-button color="primary" disableRipple value="tsv">
+              <span tooltip="tab-delimited values">Tab-delimited (.tsv)</span>
             </mat-radio-button>
           </div>
         </mat-radio-group>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.html
@@ -603,7 +603,7 @@
                     <ul class="NO-PADDING-START">
                       <li class="LIST-SEPARATOR" *ngFor="let onc of pt.oncHistoryDetails">
                         <p class="BIT-OF-MARGIN"
-                           *ngIf="onc.oncHistoryDetailId != null && onc.oncHistoryDetailId !== ''">
+                           *ngIf="onc.oncHistoryDetailId != null && onc.oncHistoryDetailId !== '' && !onc.deleted">
                           <ng-container
                             *ngIf="col.type !== 'ADDITIONALVALUE' && col.type !== 'DATE' && col.type !== 'OPTIONS' && col.type !== 'CHECKBOX' && col.type !== 'BOOLEAN'">
                             {{onc[col.participantColumn.name]}}
@@ -644,9 +644,9 @@
                     <ul class="NO-PADDING-START">
                       <li class="LIST-SEPARATOR" *ngFor="let onc of pt.oncHistoryDetails">
                         <ul class="NO-PADDING-START"
-                            *ngIf="onc.oncHistoryDetailId != null && onc.oncHistoryDetailId !== ''">
+                            *ngIf="onc.oncHistoryDetailId != null && onc.oncHistoryDetailId !== '' && !onc.deleted">
                           <li class="LIST-SEPARATOR" *ngFor="let tissue of onc.tissues" (click)="openTissue(pt, onc)">
-                            <p class="BIT-OF-MARGIN" *ngIf="tissue.tissueId != null && tissue.tissueId !== ''">
+                            <p class="BIT-OF-MARGIN" *ngIf="tissue.tissueId != null && tissue.tissueId !== '' && !tissue.deleted">
                               <ng-container
                                 *ngIf="col.type !== 'ADDITIONALVALUE' && col.type !== 'DATE' && col.type !== 'OPTIONS' && col.type !== 'CHECKBOX' && col.type !== 'BOOLEAN'">
                                 <ng-container *ngIf="col.participantColumn.tableAlias === 'sm'">

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.html
@@ -261,7 +261,7 @@
                         currentPage: activePage, totalItems: getPaginationParticipantListSize() }">
             <!--checkbox to assign or trigger blood kits-->
             <td>
-              <mat-checkbox color="primary" disableRipple
+              <mat-checkbox [color]="generateCheckboxColor(pt)" disableRipple
                            [checked]="pt.isSelected"
                            (change)="pt.isSelected = $event.checked; checkboxChecked(pt)"></mat-checkbox>
             </td>
@@ -877,7 +877,7 @@
           <tr *ngIf="hasAssignees()">
             <td [attr.colspan]="getColSpan()">
               <button mat-raised-button color="primary"
-                      (click)="openModal('assignParticipant')" [disabled]="isAssignButtonDisabled">Assign
+                      (click)="openModal('assignParticipant')" [disabled]="!isAnySelectedAssignable()">Assign
               </button>
             </td>
           </tr>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -92,7 +92,7 @@ export class ParticipantListComponent implements OnInit {
   filterQuery: string = null;
   activityDefinitions = new Map();
 
-  exportFileFormat: string = "tsv";
+  exportFileFormat: string = 'tsv';
   exportSplitOptions: boolean = true;
   exportOnlyMostRecent: boolean = false;
 

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -1446,7 +1446,7 @@ export class ParticipantListComponent implements OnInit {
     } else {
       filterText = Filter.getFilterText(filter, tmp);
     }
-    if (filterText != null) {
+    if (filterText != null && Object.keys(filterText).length > 0) {
       json.push(filterText);
     }
   }
@@ -1736,6 +1736,18 @@ export class ParticipantListComponent implements OnInit {
     } else {
       this.selectedPatients = this.selectedPatients.filter(guid => guid !== participant.data.profile['guid']);
     }
+  }
+
+  generateCheckboxColor(participant: Participant): string {
+    if (this.isAssignable(participant)) {
+      return 'accent';
+    } else {
+      return 'primary';
+    }
+  }
+
+  isAnySelectedAssignable(): boolean {
+    return this.participantList.find(participant => participant.isSelected && this.isAssignable(participant)) != null;
   }
 
   private isAssignable(participant: Participant): boolean {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -846,6 +846,7 @@ export class ParticipantListComponent implements OnInit {
 
   public selectFilter(viewFilter: ViewFilter): void {
     this.resetPagination();
+    this.resetSelectedPatients();
     this.loadingParticipants = localStorage.getItem(ComponentService.MENU_SELECTED_REALM);
     this.currentView = JSON.stringify(viewFilter);
     if (viewFilter != null) {
@@ -855,6 +856,10 @@ export class ParticipantListComponent implements OnInit {
       this.filtered = false;
     }
     this.applyFilter(viewFilter);
+  }
+
+  resetSelectedPatients(): void {
+    this.selectedPatients = [];
   }
 
   private applyFilter(viewFilter: ViewFilter, from: number = 0, to: number = this.role.getUserSetting().getRowsPerPage()): void {
@@ -1044,6 +1049,7 @@ export class ParticipantListComponent implements OnInit {
   public clearFilter(): void {
     this.start = new Date().getTime();
     this.filterQuery = null;
+    this.resetSelectedPatients();
     this.clearManualFilters();
     this.getData();
     this.setDefaultColumns();
@@ -1282,6 +1288,7 @@ export class ParticipantListComponent implements OnInit {
   public doFilter(): void {
     this.selectAll = this.selectedColumns['allSelected'];
     this.resetPagination();
+    this.resetSelectedPatients();
     const json = [];
     this.dataSources.forEach((value: string, key: string) => {
         this.createFilterJson(json, key);

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -92,7 +92,7 @@ export class ParticipantListComponent implements OnInit {
   filterQuery: string = null;
   activityDefinitions = new Map();
 
-  exportFileFormat: string = 'tsv';
+  exportFileFormat: string = 'xlsx';
   exportSplitOptions: boolean = true;
   exportOnlyMostRecent: boolean = false;
 
@@ -1670,7 +1670,7 @@ export class ParticipantListComponent implements OnInit {
   executeDownload(): void {
     this.modal.hide();
 
-    const dialogRef = this.openDialog('Exporting participants list...');
+    const dialogRef = this.openDialog('Exporting participants list. This may take several minutes...');
     const columns = [];
     for(const col in this.selectedColumns) {
       for (const key in this.selectedColumns[col]) {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.html
@@ -129,7 +129,7 @@
               [disabled]="updatedEmail === participant.data.profile['email'] || updatedEmail.length === 0 || !isEmailValid"
               (click)="updateEmail()">Update
             </button>
-          </td>          
+          </td>
           <td *ngIf="!hasRole().allowedToEditParticipant()">
             {{participant.data.profile['email']}}
           </td>
@@ -191,7 +191,7 @@ participant.data.dsm['diagnosisYear'] != null">
           </tr>
           <tr>
             <td>
-              <app-cohort-tag 
+              <app-cohort-tag
                 [ddpParticipantId]="participant.data.profile.guid"
                 [dsm]="participant.data.dsm"
               ></app-cohort-tag>
@@ -199,14 +199,6 @@ participant.data.dsm['diagnosisYear'] != null">
           </tr>
           </tbody>
         </table>
-        <!--TODO remove before final merge, for testing only -->
-        <div *ngIf="hasRole().allowedToTestDSSActivity() && participant.data != null">
-          <button mat-mini-fab color="primary" class="mat-fab-bottom-left" (click)="testGetActivity(participant.data.profile['guid'])">
-            <i class="fa-thin fa-badge-check"></i>
-          </button>
-          <span>Test GET Activity</span>
-
-        </div>
 
         <div *ngIf="isAddFamilyMember" class="Float--right Width--100">
           <div class="family-member-button">

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
@@ -1137,6 +1137,7 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
 
   onAdditionalValueChange(evt: any, colName: string): void {
     let v;
+    colName = Utils.convertUnderScoresToCamelCase(colName);
     if (typeof evt === 'string') {
       v = evt;
     } else {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
@@ -453,13 +453,13 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
           tissues.push(new Tissue(null, oncHis.oncHistoryDetailId, null, null, null, null,
             null, null, null, null, null, null, null, null
             , null, null, null, null, null, null, null, null, null,
-            null, null, null, null, null, null, null));
+            null, null, null, null, null, null, null, false));
           oncHis.tissues = tissues;
         } else if (oncHis.tissues.length < 1) {
           oncHis.tissues.push(new Tissue(null, oncHis.oncHistoryDetailId, null, null, null, null,
             null, null, null, null, null, null, null, null, null, null
             , null, null, null, null, null, null, null,
-            null, null, null, null, null, null, null));
+            null, null, null, null, null, null, null, false));
         }
       }
       if (!hasEmptyOncHis) {
@@ -467,13 +467,13 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
         tissues.push(new Tissue(null, null, null, null, null, null, null,
           null, null, null, null, null, null, null, null, null,
           null, null, null, null, null, null, null,
-          null, null, null, null, null, null, null));
+          null, null, null, null, null, null, null, false));
 
         const oncHis = new OncHistoryDetail(this.participant.participant.participantId,
           null, null, null, null, null, null, null, null, null, null,
           null, null, null, null, null, null, null, null,
           null, null, null, null, null, null, tissues, null, null, null,
-          null);
+          null, false);
         this.participant.oncHistoryDetails.push(oncHis);
       }
     }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
@@ -1436,10 +1436,4 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
     this.universalModal.show();
     return false;
   }
-  //TODO remove before final merge, for testing only
-  testGetActivity(participantId: string): void {
-    this.dsmService.testDSSGetActivity(participantId).subscribe(data => {
-      console.log(data);
-    });
-  }
 }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dsm.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dsm.service.ts
@@ -230,10 +230,10 @@ export class DSMService {
     if (fileFormat) {
       map.push({name: 'fileFormat', value: fileFormat});
     }
-    if (typeof splitOptions === "boolean") {
+    if (typeof splitOptions === 'boolean') {
       map.push({name: 'splitOptions', value: splitOptions});
     }
-    if (typeof splitOptions === "boolean") {
+    if (typeof splitOptions === 'boolean') {
       map.push({name: 'onlyMostRecent', value: onlyMostRecent});
     }
     if (filterQuery != null) {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/role.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/role.service.ts
@@ -29,7 +29,6 @@ export class RoleService {
   private _canEditDrugList = false;
   private _isParticipantListView = false;
   private _isParticipantEdit = false;
-  private _isDSSTesting = true; //TODO remove before final merge, for testing only
   private _isKitUploadInvalidAddress = false;
 
   private _userId: string;
@@ -251,11 +250,7 @@ export class RoleService {
   public allowedToEditParticipant(): boolean {
     return this._isParticipantEdit;
   }
-
-  public allowedToTestDSSActivity(): boolean {
-    return this._isDSSTesting;//TODO pegah remove before final merge, for testing only
-  }
-
+  
   private getClaimByKeyName( token: any, key: string ): any {
     return this.sessionService.getDSMClaims( token )[ this.config.auth0ClaimNameSpace + key ];
   }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/role.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/role.service.ts
@@ -250,7 +250,7 @@ export class RoleService {
   public allowedToEditParticipant(): boolean {
     return this._isParticipantEdit;
   }
-  
+
   private getClaimByKeyName( token: any, key: string ): any {
     return this.sessionService.getDSMClaims( token )[ this.config.auth0ClaimNameSpace + key ];
   }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/tissue-page/tissue-page.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/tissue-page/tissue-page.component.html
@@ -227,7 +227,7 @@
         </td>
       </tr>
       <ng-container *ngFor="let tis of oncHistoryDetail.tissues">
-        <tr>
+        <tr *ngIf="!tis.deleted">
           <td colspan="3">
             <app-tissue [participant]="participant" [oncHistoryDetail]="oncHistoryDetail" [tissueId]="tissueId"
                         [tissue]="tis" [editable]="editable && !participantExited" [additionalColumns]="settings['t']">

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/tissue-page/tissue-page.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/tissue-page/tissue-page.component.ts
@@ -94,7 +94,7 @@ export class TissuePageComponent implements OnInit {
   addTissue(): void {
     this.oncHistoryDetail.tissues.push(new Tissue(null, this.oncHistoryDetail.oncHistoryDetailId, null, null, null, null,
       null, null, null, null, null, null, null, null, null, null, null, null,
-      null, null, null, null, null, null, null, null, null, null, null, null));
+      null, null, null, null, null, null, null, null, null, null, null, null, false));
   }
 
   isPatchedCurrently(field: string): boolean {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/tissue/tissue.model.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/tissue/tissue.model.ts
@@ -1,7 +1,6 @@
 import {TissueSmId} from './sm-id.model';
 
 export class Tissue {
-  deleted = false;
 
   constructor(public tissueId: string, public oncHistoryDetailId: string, public notes: string, public countReceived: number,
               public tissueType: string, public tissueSite: string, public tumorType: string,
@@ -10,7 +9,8 @@ export class Tissue {
               public additionalValuesJson: {}, public expectedReturn: string, public returnDate: string,
               public returnFedexId: string, public shlWorkNumber: string, public tissueSequence: string, public tumorPercentage: string,
               public scrollsCount: number, public ussCount: number, public blocksCount: number, public hECount: number,
-              public scrollSMId: Array<TissueSmId>, public ussSMId: Array<TissueSmId>, public HESMId: Array<TissueSmId>) {
+              public scrollSMId: Array<TissueSmId>, public ussSMId: Array<TissueSmId>, public HESMId: Array<TissueSmId>,
+              public deleted: boolean) {
     this.tissueId = tissueId;
     this.oncHistoryDetailId = oncHistoryDetailId;
     this.notes = notes;
@@ -41,6 +41,7 @@ export class Tissue {
     this.scrollSMId = scrollSMId;
     this.ussSMId = ussSMId;
     this.HESMId = HESMId;
+    this.deleted = deleted;
   }
 
   static parse(json): Tissue {
@@ -55,6 +56,7 @@ export class Tissue {
       json.scrollsReceived, json.skId, json.smId, json.sentGp, json.firstSmId, additionalValuesJson, json.expectedReturn,
       json.returnDate, json.returnFedexId, json.shlWorkNumber, json.tissueSequence, json.tumorPercentage,
       json.scrollsCount, json.ussCount, json.blocksCount, json.hECount,
-      TissueSmId.parseArray(json.scrollSMID), TissueSmId.parseArray(json.ussSMID), TissueSmId.parseArray(json.heSMID));
+      TissueSmId.parseArray(json.scrollSMID), TissueSmId.parseArray(json.ussSMID), TissueSmId.parseArray(json.heSMID),
+      json.deleted);
   }
 }


### PR DESCRIPTION
This removes the broken export feature from the bottom of the dashboard -- all exports should be done via the particpant list.  As best as I can tell this feature did not use any backend APIs (part of the reason why it was broken), and so there is no corresponding backend change needed.

BEFORE:
![image](https://user-images.githubusercontent.com/2800795/180502870-150504be-5122-4364-8ee8-395032ce7344.png)


AFTER:
![image](https://user-images.githubusercontent.com/2800795/180502690-5110d636-8452-4a64-91f9-a80f1339502a.png)


TO TEST:
1. Load any study's dashboard
2. confirm that the "export" button does not appear
