### PR TITLE
[DSM] DDP-7581: removing export feature from dashboard

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard/dashboard.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard/dashboard.component.html
@@ -1128,18 +1128,6 @@
             </ng-container>
           </ng-container>
         </ng-container>
-        <tr>
-          <td colspan="4">
-            <br/>
-            <mat-select placeholder="Select source" [(ngModel)]="downloadSource" class="Input--Bigger-WIDTH">
-              <mat-option *ngFor="let key of getSourceKeys()" [value]="key">{{dataSources.get(key)}}</mat-option>
-            </mat-select>
-            <button type="button" mat-raised-button color="primary"
-                    (click)="dataExport(downloadSource)"
-                    [disabled]="participantList.length === 0 || downloadSource == null">Export Data
-            </button>
-          </td>
-        </tr>
         </tbody>
       </table>
     </div>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard/dashboard.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard/dashboard.component.ts
@@ -63,7 +63,6 @@ export class DashboardComponent implements OnInit {
     [ 'k', 'Sample' ],
     [ 'a', 'Abstraction' ] ]);
   sourceColumns = {};
-  downloadSource;
   hasESData = false;
   activityDefinitionList: ActivityDefinition[] = [];
   participantList: Participant[] = [];
@@ -484,54 +483,6 @@ export class DashboardComponent implements OnInit {
     });
   }
 
-  dataExport(source: string): void {
-    this.loadingDDPData = true;
-    if (source != null) {
-      const date = new Date();
-      const columns = {};
-      this.dataSources.forEach((value: string, key: string) => {
-        if (this.sourceColumns[ key ] != null && this.sourceColumns[ key ].length !== 0) {
-          columns[ key ] = this.sourceColumns[ key ];
-        }
-      });
-      if (this.participantList.length !== 0) {
-        if (source === 'm') {
-          Utils.downloadCurrentData(
-            this.participantList, [ [ 'data', 'data' ], [ 'participant', 'p' ], [ 'medicalRecords', 'm' ] ],
-            columns, 'Participants-MR-' + Utils.getDateFormatted(date, Utils.DATE_STRING_CVS) + Statics.CSV_FILE_EXTENSION
-          );
-          this.downloadDone();
-        } else if (source === 'oD') {
-          Utils.downloadCurrentData(
-            this.participantList, [ [ 'data', 'data' ], [ 'participant', 'p' ], [ 'oncHistoryDetails', 'oD', 'tissues', 't' ] ],
-            columns, 'Participants-OncHistory-' + Utils.getDateFormatted(date, Utils.DATE_STRING_CVS) + Statics.CSV_FILE_EXTENSION
-          );
-          this.downloadDone();
-        } else if (source === 'k') {
-          Utils.downloadCurrentData(this.participantList,
-            [ [ 'data', 'data' ], [ 'participant', 'p' ], [ 'kits', 'k' ] ],
-            columns,
-            'Participants-Sample-' + Utils.getDateFormatted(date, Utils.DATE_STRING_CVS) + Statics.CSV_FILE_EXTENSION
-          );
-          this.downloadDone();
-        } else if (source === 'a') {
-          // TODO add final abstraction values to download
-          Utils.downloadCurrentData(
-            this.participantList, [ [ 'data', 'data' ], [ 'participant', 'p' ], [ 'abstractionActivities', 'a' ] ],
-            columns, 'Participants-Abstraction-' + Utils.getDateFormatted(date, Utils.DATE_STRING_CVS) + Statics.CSV_FILE_EXTENSION
-          );
-          this.downloadDone();
-        } else {
-          Utils.downloadCurrentData(
-            this.participantList, [ [ 'data', 'data' ], [ source, source ] ], columns,
-            'Participants-' + source + Utils.getDateFormatted(date, Utils.DATE_STRING_CVS) + Statics.CSV_FILE_EXTENSION, true
-          );
-          this.downloadDone();
-        }
-      }
-    }
-  }
-
   getParticipantData(): void {
     this.dsmService.applyFilter(null, localStorage.getItem(ComponentService.MENU_SELECTED_REALM), 'participantList', null)
       .subscribe({
@@ -551,21 +502,6 @@ export class DashboardComponent implements OnInit {
           this.errorMessage = 'Error - Downloading Participant List, Please contact your DSM developer';
         }
       });
-  }
-
-  downloadDone(): void {
-    this.loadingDDPData = false;
-    this.errorMessage = null;
-  }
-
-  getSourceKeys(): string[] {
-    const keys = [];
-    this.dataSources.forEach((value: string, key: string) => {
-      if (key !== 'data' && key !== 'p' && key !== 't') {
-        keys.push(key);
-      }
-    });
-    return keys;
   }
 
 }


### PR DESCRIPTION
This removes the broken export feature from the bottom of the dashboard -- all exports should be done via the particpant list. As best as I can tell this feature did not use any backend APIs (part of the reason why it was broken), and so there is no corresponding backend change needed.

BEFORE:
![image](https://user-images.githubusercontent.com/2800795/180503382-416580c6-191f-4f01-879e-06a74c327b80.png)

AFTER:
![image](https://user-images.githubusercontent.com/2800795/180503432-48402e9d-2b7b-45ff-be5a-35bb02c553b5.png)


TO TEST:

Load any study's dashboard
confirm that the "export" button does not appear