### PR TITLE
[SINGULAR] DDP-8460: Refactor using of composite questions separator

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/FON/pages/activities/components/activity/activity.component.scss
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/FON/pages/activities/components/activity/activity.component.scss
@@ -412,15 +412,6 @@ $field-disabled-border: $__Mulled_wine_transparent;
     .ddp-answer-container {
       grid-template-columns: auto auto !important;
     }
-
-    /* TODO: remove this temp FIX!! just to fix the wrong config form back-end */
-    .ddp-answer-field:first-of-type::after {
-      content: 'Or';
-      top: -12px;
-      position: relative;
-      left: 4px;
-    }
-    /* end of the TODO */
   }
 
   @mixin ejection-fraction {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/FON/pages/activities/components/activity/activity.component.scss
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/FON/pages/activities/components/activity/activity.component.scss
@@ -364,13 +364,6 @@ $field-disabled-border: $__Mulled_wine_transparent;
           .ddp-answer-field {
             padding: unset !important;
 
-            /* TODO: remove this temp FIX!! just to fix the wrong config form back-end */
-            &::after {
-              content: 'OR';
-              padding-left: 16px;
-            }
-            /* end of the TODO */
-
             select {
               margin: 0;
             }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-composite-answer/activityCompositeAnswer.component.html
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-composite-answer/activityCompositeAnswer.component.html
@@ -10,7 +10,7 @@
          [ngClass]="setOrientationClass(block.childOrientation)"
          [gdColumns]="gridLayoutColumnConfig()">
         <ng-container *ngFor="let childBlock of childBlockRow; let column = index">
-            <div *ngIf="block.tabularSeparator && column === 1" class="tabular-separator">
+            <div *ngIf="block.tabularSeparator && column >= 1" class="tabular-separator">
                 <span>{{block.tabularSeparator}}</span>
             </div>
             <ddp-activity-answer


### PR DESCRIPTION
Hardcoded values were removed from 
ddp-workspace\projects\ddp-dsm-ui\src\app\FON\pages\activities\components\activity\activity.component.scss

Tabular separator are being handled properly:

![image](https://user-images.githubusercontent.com/109761417/181378684-049cee6b-9efd-4139-a610-b7b5dc77ec16.png)
