### PR TITLE
DDP-8486 - LMS  email bugs

### DIFF
--- a/ddp-workspace/projects/ddp-lms/src/app/activity-page/activity-page.component.ts
+++ b/ddp-workspace/projects/ddp-lms/src/app/activity-page/activity-page.component.ts
@@ -5,14 +5,14 @@ import {
   ToolkitConfigurationService,
   WorkflowBuilderService
 } from 'toolkit';
-import {ActivatedRoute} from "@angular/router";
+import {ActivatedRoute} from '@angular/router';
 import {
   ACTUAL_PARTICIPANT_ID_TOKEN,
   actualParticipantIdProvider
-} from "./localProviders";
-import {Observable} from "rxjs";
-import {first, tap} from "rxjs/operators";
-import {SessionMementoService} from "ddp-sdk";
+} from './localProviders';
+import {Observable} from 'rxjs';
+import {first, tap} from 'rxjs/operators';
+import {SessionMementoService} from 'ddp-sdk';
 
 @Component({
   selector: 'app-activity-page',
@@ -40,7 +40,7 @@ export class ActivityPageComponent extends ActivityRedesignedComponent implement
     super(headerConfig, _activatedRoute, _workflowBuilder, config);
   }
 
-  ngOnInit() {
+  ngOnInit(): void {
     super.ngOnInit();
     this.setParticipantGuid();
   }

--- a/ddp-workspace/projects/ddp-lms/src/app/activity-page/localProviders.ts
+++ b/ddp-workspace/projects/ddp-lms/src/app/activity-page/localProviders.ts
@@ -1,0 +1,20 @@
+import { Observable } from 'rxjs/index';
+import { filter, pluck } from 'rxjs/operators';
+import { InjectionToken, Provider } from '@angular/core';
+import { ActivatedRoute, Params } from '@angular/router';
+
+
+export const ACTUAL_PARTICIPANT_ID_TOKEN: InjectionToken<Observable<string>> = new InjectionToken<Observable<string>>(
+  'Actual participant id token'
+);
+
+export const actualParticipantIdProvider: Provider = {
+  provide: ACTUAL_PARTICIPANT_ID_TOKEN,
+  useFactory: (
+    activatedRoute: ActivatedRoute,
+  ) => activatedRoute.queryParams.pipe(
+    filter(({ participantGuid }: Params) => !!participantGuid),
+    pluck('participantGuid')
+  ),
+  deps: [ActivatedRoute]
+};


### PR DESCRIPTION
Handling the following route appropriately: `{{baseWebUrl}}/activity/{{activityInstanceGuid}}?participantGuid={{participant_guid}}`

How to reproduce:
1. Create parent and child accounts;
2. fill out a consent form for parents;
3. then go back to the dashboard and open the parent's activity 
4. and in the end enter the URL mentioned above in the browser, where you will have written child credentials

Solved: 
It will redirect you to the child's activity


https://broadinstitute.atlassian.net/browse/DDP-8486