### PR TITLE
DDP-8379 - OS email bugs

### DIFF
--- a/ddp-workspace/projects/ddp-osteo/src/app/components/activity-page/activity-page.component.ts
+++ b/ddp-workspace/projects/ddp-osteo/src/app/components/activity-page/activity-page.component.ts
@@ -1,17 +1,58 @@
-import { Component } from '@angular/core';
-import { ActivityRedesignedComponent } from 'toolkit';
+import { Component, Inject, OnInit } from '@angular/core';
+import {
+    ActivityRedesignedComponent,
+    HeaderConfigurationService,
+    ToolkitConfigurationService,
+    WorkflowBuilderService,
+} from 'toolkit';
+import { ACTUAL_PARTICIPANT_ID_TOKEN } from '../../../../../ddp-lms/src/app/activity-page/localProviders';
+import { Observable } from 'rxjs';
+import { SessionMementoService } from 'ddp-sdk';
+import { ActivatedRoute } from '@angular/router';
+import { first, tap } from 'rxjs/operators';
 
 @Component({
-  selector: 'app-activity-page',
-  template: `
-    <app-activity
-      [studyGuid]="studyGuid"
-      [activityGuid]="instanceGuid"
-      [agreeConsent]="config.agreeConsent"
-      (submit)="navigate($event)"
-      (stickySubtitle)="showStickySubtitle($event)"
-      (activityCode)="activityCodeChanged($event)">
-    </app-activity>
-  `,
+    selector: 'app-activity-page',
+    template: `
+        <app-activity
+            [studyGuid]="studyGuid"
+            [activityGuid]="instanceGuid"
+            [agreeConsent]="config.agreeConsent"
+            (submit)="navigate($event)"
+            (stickySubtitle)="showStickySubtitle($event)"
+            (activityCode)="activityCodeChanged($event)"
+        >
+        </app-activity>
+    `,
 })
-export class ActivityPageComponent extends ActivityRedesignedComponent {}
+export class ActivityPageComponent
+    extends ActivityRedesignedComponent
+    implements OnInit
+{
+    constructor(
+        @Inject(ACTUAL_PARTICIPANT_ID_TOKEN)
+        private readonly participantId$: Observable<string>,
+        private readonly sessionService: SessionMementoService,
+        headerConfig: HeaderConfigurationService,
+        _activatedRoute: ActivatedRoute,
+        _workflowBuilder: WorkflowBuilderService,
+        @Inject('toolkit.toolkitConfig') config: ToolkitConfigurationService
+    ) {
+        super(headerConfig, _activatedRoute, _workflowBuilder, config);
+    }
+    ngOnInit(): void {
+        super.ngOnInit();
+        this.setParticipantGuid();
+    }
+
+    private setParticipantGuid(): void {
+        this.participantId$
+            .pipe(
+                first(),
+                tap((participantGuid: string) =>
+                    this.sessionService.setParticipant(participantGuid)
+                )
+            )
+            .subscribe();
+    }
+}

--- a/ddp-workspace/projects/ddp-osteo/src/app/components/activity-page/osteo-providers.ts
+++ b/ddp-workspace/projects/ddp-osteo/src/app/components/activity-page/osteo-providers.ts
@@ -1,0 +1,17 @@
+import { Observable } from 'rxjs/index';
+import { filter, pluck } from 'rxjs/operators';
+import { InjectionToken, Provider } from '@angular/core';
+import { ActivatedRoute, Params } from '@angular/router';
+
+export const ACTUAL_PARTICIPANT_ID_TOKEN: InjectionToken<Observable<string>> =
+    new InjectionToken<Observable<string>>('Actual participant id token');
+
+export const actualParticipantIdProvider: Provider = {
+    provide: ACTUAL_PARTICIPANT_ID_TOKEN,
+    useFactory: (activatedRoute: ActivatedRoute) =>
+        activatedRoute.queryParams.pipe(
+            filter(({ participantGuid }: Params) => !!participantGuid),
+            pluck('participantGuid')
+        ),
+    deps: [ActivatedRoute],
+};


### PR DESCRIPTION
Handling the following route appropriately: {{baseWebUrl}}/activity/{{activityInstanceGuid}}?participantGuid={{participant_guid}}

How to reproduce:

Create parent and child accounts;
fill out a consent form for parents;
then go back to the dashboard and open the parent's activity
and in the end enter the URL mentioned above in the browser, where you will have written child credentials
Solved:
It will redirect you to the child's activity

https://broadinstitute.atlassian.net/browse/DDP-8379