### PR TITLE
[SINGULAR]DDP-8482: Input fields for feet and inches for PATIENT_SURVEY and question stable id WHAT_IS_YOUR_HEIGHT_FEET is not preventing negative values

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.ts
@@ -23,8 +23,8 @@ import { LayoutType } from '../../../models/layout/layoutType';
                type="number"
                [appInputRestriction]="isIntegerQuestion ? InputRestriction.Integer : ''"
                [formControl]="numericField"
-               [min]="block.min"
-               [max]="block.max"
+               [min]="minValue"
+               [max]="maxValue"
                autocomplete="off"
                [step]="valueChangeStep"
                [placeholder]="placeholder || block.placeholder"
@@ -46,10 +46,20 @@ export class ActivityNumericAnswer implements OnInit, OnChanges, OnDestroy {
     public numericField: FormControl;
     InputRestriction = InputRestriction;
     private subs: Subscription;
+    public minValue: Number;
+    public maxValue: Number;
 
     public ngOnInit(): void {
         this.initForm();
-
+        const validatorItem=this.block.validators.find((item) => !!item);
+        if(!!validatorItem){
+            this.minValue=validatorItem['min'];
+            this.maxValue=validatorItem['max'];
+        }
+        else{
+            this.minValue=this.block.min;
+            this.maxValue=this.block.max;
+        }
         this.subs = this.numericField.valueChanges.subscribe((enteredValue: number) => {
             const answerToDisplay: string = this.mapAnswerToDisplay(enteredValue);
             const answerToPatch: NumericAnswerType = this.mapAnswerToPatchToServer(answerToDisplay);

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.ts
@@ -23,8 +23,8 @@ import { LayoutType } from '../../../models/layout/layoutType';
                type="number"
                [appInputRestriction]="isIntegerQuestion ? InputRestriction.Integer : ''"
                [formControl]="numericField"
-               [min]="minValue"
-               [max]="maxValue"
+               [min]="block.min"
+               [max]="block.max"
                autocomplete="off"
                [step]="valueChangeStep"
                [placeholder]="placeholder || block.placeholder"
@@ -46,20 +46,9 @@ export class ActivityNumericAnswer implements OnInit, OnChanges, OnDestroy {
     public numericField: FormControl;
     InputRestriction = InputRestriction;
     private subs: Subscription;
-    public minValue: Number;
-    public maxValue: Number;
 
     public ngOnInit(): void {
         this.initForm();
-        const validatorItem=this.block.validators.find((item) => !!item);
-        if(!!validatorItem){
-            this.minValue=validatorItem['min'];
-            this.maxValue=validatorItem['max'];
-        }
-        else{
-            this.minValue=this.block.min;
-            this.maxValue=this.block.max;
-        }
         this.subs = this.numericField.valueChanges.subscribe((enteredValue: number) => {
             const answerToDisplay: string = this.mapAnswerToDisplay(enteredValue);
             const answerToPatch: NumericAnswerType = this.mapAnswerToPatchToServer(answerToDisplay);

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityQuestionConverter.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityQuestionConverter.service.ts
@@ -278,8 +278,8 @@ export class ActivityQuestionConverter {
         numericBlock.placeholder = questionJson.placeholderText;
         const intRangeValidation = questionJson.validations.find(validation => validation.rule === ValidationRuleType.IntRange);
         if (intRangeValidation) {
-            numericBlock.min = isNaN(intRangeValidation.min) ? null : intRangeValidation.min;
-            numericBlock.max = isNaN(intRangeValidation.max) ? null : intRangeValidation.max;
+            numericBlock.min = intRangeValidation.min == null ? null : intRangeValidation.min;
+            numericBlock.max = intRangeValidation.max == null ? null : intRangeValidation.max;
         }
         return numericBlock;
     }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityQuestionConverter.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/activity/activityQuestionConverter.service.ts
@@ -278,8 +278,8 @@ export class ActivityQuestionConverter {
         numericBlock.placeholder = questionJson.placeholderText;
         const intRangeValidation = questionJson.validations.find(validation => validation.rule === ValidationRuleType.IntRange);
         if (intRangeValidation) {
-            numericBlock.min = intRangeValidation.min || null;
-            numericBlock.max = intRangeValidation.max || null;
+            numericBlock.min = isNaN(intRangeValidation.min) ? null : intRangeValidation.min;
+            numericBlock.max = isNaN(intRangeValidation.max) ? null : intRangeValidation.max;
         }
         return numericBlock;
     }


### PR DESCRIPTION
Preventing negative values for Numeric Questions.

Now it's taking the min and max values from the validations entry:

![image](https://user-images.githubusercontent.com/109761417/181652342-ddce25c3-e200-40af-8b45-2ce8ea717806.png)


![image](https://user-images.githubusercontent.com/109761417/181652472-241d1ba2-e70a-4da3-9222-af6e991ca48b.png)


