### PR TITLE
DDP-8466 | absent ddpParticipantId

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/medical-record/medical-record.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/medical-record/medical-record.component.ts
@@ -249,7 +249,7 @@ export class MedicalRecordComponent implements OnInit {
     } else {
       this.downloading = true;
       this.message = 'Downloading... This might take a while';
-      this.dsmService.downloadPDF(this.participant.participant.ddpParticipantId, this.medicalRecord.medicalRecordId,
+      this.dsmService.downloadPDF(this.participant.data.profile['guid'], this.medicalRecord.medicalRecordId,
         this.startDate, this.endDate, this.mrCoverPdfSettings, localStorage.getItem(ComponentService.MENU_SELECTED_REALM),
         configName, this.pdfs, null
       )


### PR DESCRIPTION
Ticket: https://broadinstitute.atlassian.net/browse/DDP-8466

Problem: The client code tries to read `ddpParticipantId` from `dsm.participant` which may be absent due to the fact that some participants don't have any record in DB thereby don't have anything under `dsm.participant` too, which is common case.

Solution: Change code so that `ddpParticipantId` is read from `dsm.data.profile`, it's guaranteed to be there.