### PR TITLE
[SINGULAR] [SDK] DDP-8492: Fix styles for mobile view (File upload)

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-file-answer/activityFileAnswer.component.html
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-file-answer/activityFileAnswer.component.html
@@ -48,9 +48,10 @@
                     color="primary" selected
                     (removed)="undoUploadedFile(i)"
                     #uploaded>
-                    {{ uploadedFile?.fileName }}
+                    <span class="file-name">{{ uploadedFile?.fileName }}</span>
                     <span class="file-size">{{'SDK.FileUpload.Size' | translate : { size: uploadedFile?.fileSize | fileSize} }}</span>
                     <button matChipRemove *ngIf="!readonly"
+                            class="cancel-btn"
                             mat-icon-button
                             [attr.aria-label]="'SDK.FileUpload.RemoveUploadedFile' | translate"
                             #undoUploadBtn>

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-file-answer/activityFileAnswer.component.scss
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-file-answer/activityFileAnswer.component.scss
@@ -1,5 +1,6 @@
 $drop-block-color: whitesmoke;
 $drop-block-active-color: lightyellow;
+$tablet-screen-width: 680px;
 
 .file-requirements {
     margin-bottom: 10px;
@@ -7,6 +8,12 @@ $drop-block-active-color: lightyellow;
 
 .file-upload-content {
     display: flex;
+    padding: 16px 0;
+
+    @media (max-width: $tablet-screen-width) {
+        flex-direction: column;
+        gap: 12px;
+    }
 }
 
 .file-upload-content.readonly {
@@ -38,6 +45,10 @@ $drop-block-active-color: lightyellow;
     justify-content: center;
     cursor: pointer;
 
+    @media (max-width: $tablet-screen-width) {
+        margin: 0 auto;
+    }
+
     &.file-over {
         background-color: $drop-block-active-color
     }
@@ -56,6 +67,7 @@ $drop-block-active-color: lightyellow;
 .uploaded-file {
     display: flex;
     flex-direction: column;
+
     .title {
         float: left;
     }
@@ -72,13 +84,32 @@ $drop-block-active-color: lightyellow;
         clear: both;
     }
 
-    .uploaded-file-chip {
-        .file-size {
-            margin-left: 5px;
+    &-chip {
+        height: auto;
+        min-width: 180px;
+        flex-wrap: wrap;
+        flex-basis: auto;
+        column-gap: 5px;
+        padding-right: 30px!important;
+
+        @media (max-width: 470px) {
+            flex-basis: min-content;
+        }
+        @media (max-width: 350px) {
+            flex-shrink: 0;
+        }
+
+        .cancel-btn {
+            position: absolute;
+            right: 6px;
         }
 
         .mat-icon-button {
             height: initial;
+
+            .mat-icon {
+                line-height: 16px;
+            }
         }
     }
 }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-file-answer/activityFileAnswer.component.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-file-answer/activityFileAnswer.component.spec.ts
@@ -7,6 +7,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
 import { By } from '@angular/platform-browser';
 import { Observable, of } from 'rxjs';
+import { TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
 
 import { TranslateTestingModule } from '../../../../testsupport/translateTestingModule';
 import { ActivityFileAnswer } from './activityFileAnswer.component';
@@ -18,7 +19,7 @@ import { QuestionPromptComponent } from '../question-prompt/questionPrompt.compo
 import { ValidationMessageComponent } from '../../../validationMessage.component';
 import { ActivityFileValidationRule } from '../../../../services/activity/validators/activityFileValidationRule';
 import { FileSizeFormatterPipe } from '../../../../pipes/fileSizeFormatter.pipe';
-import { TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
+import { ActivityFileAnswerSuccess } from '../activity-file-answer-success/activityFileAnswerSuccess.component';
 
 class TranslateLoaderMock implements TranslateLoader {
     getTranslation(code: string = ''): Observable<object> {
@@ -53,6 +54,7 @@ describe('ActivityFileAnswer', () => {
         await TestBed.configureTestingModule({
             declarations: [
                 ActivityFileAnswer,
+                ActivityFileAnswerSuccess,
                 QuestionPromptComponent,
                 ValidationMessageComponent,
                 FileSizeFormatterPipe
@@ -112,7 +114,7 @@ describe('ActivityFileAnswer', () => {
 
         it('should display an uploaded file data', () => {
             const uploadedFile = fixture.debugElement.query(By.css('.uploaded-file-chip')).nativeElement;
-            expect(uploadedFile.textContent.trim()).toContain('1.png (size: 4.77 MB)');
+            expect(uploadedFile.textContent.trim()).toContain('1.png(size: 4.77 MB)');
         });
 
         it('should call undoUploadedFile by click on remove uploaded file button', () => {


### PR DESCRIPTION
The bug - an incorrect displaying of uploaded files chips (mostly on mobiles)

**_Before:_**
![Screen Shot 2022-07-28 at 11 49 19 AM](https://user-images.githubusercontent.com/7396837/181802799-7984ec8d-e9aa-460e-8f24-c2f6378ce252.png)

**_After the fix:_**
![a_ipad1](https://user-images.githubusercontent.com/7396837/181802870-ffcb8a4d-05ae-46b6-aeec-655a419ef4f2.png)
![a_pixel2](https://user-images.githubusercontent.com/7396837/181802896-b2e62a9c-2343-41a5-81ab-9f73ca6c1095.png)
![a_iphone3](https://user-images.githubusercontent.com/7396837/181802895-7db3862f-a3eb-4a53-b943-cf6156094c0b.png)

