### PR TITLE
RC [DSM] DDP-7896 - send symbolic date if N/A is chosen

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/field-datepicker/field-datepicker.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/field-datepicker/field-datepicker.component.ts
@@ -59,7 +59,7 @@ export class FieldDatepickerComponent implements OnInit, OnChanges {
   }
 
   private handleInput(dateString: string): void {
-    if (!['N/A', 'Not Found', this.defaultNaDate].includes(dateString)) {
+    if (this.isDateNotFound(dateString)) {
       if (dateString != null) {
         let tmpDate: string = dateString;
         if (dateString.length === 7) {
@@ -80,6 +80,10 @@ export class FieldDatepickerComponent implements OnInit, OnChanges {
     } else {
       this._dateString = dateString;
     }
+  }
+
+  isDateNotFound(dateString: string) {
+    return !['N/A', 'Not Found', this.defaultNaDate].includes(dateString);
   }
 
   public check(): void {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/field-datepicker/field-datepicker.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/field-datepicker/field-datepicker.component.ts
@@ -23,7 +23,7 @@ export class FieldDatepickerComponent implements OnInit, OnChanges {
   @Output() dateChanged = new EventEmitter();
 
   _dateString: string;
-  defaultDate: string = '1000-01-01';
+  defaultNaDate: string = '1000-01-01';
   error: string = null;
   estimated = false;
   datePicker: Date;
@@ -59,7 +59,7 @@ export class FieldDatepickerComponent implements OnInit, OnChanges {
   }
 
   private handleInput(dateString: string): void {
-    if (dateString !== 'N/A' && dateString !== 'Not Found' && dateString !== this.defaultDate) {
+    if (!['N/A', 'Not Found', this.defaultNaDate].includes(dateString)) {
       if (dateString != null) {
         let tmpDate: string = dateString;
         if (dateString.length === 7) {
@@ -75,7 +75,7 @@ export class FieldDatepickerComponent implements OnInit, OnChanges {
         }
         this.datePicker = Utils.getDate(tmpDate);
       }
-    } else if (dateString === this.defaultDate) {
+    } else if (dateString === this.defaultNaDate) {
       this._dateString = 'N/A';
     } else {
       this._dateString = dateString;
@@ -139,7 +139,7 @@ export class FieldDatepickerComponent implements OnInit, OnChanges {
   public setNA(): void {
     this.isNA = true;
     this._dateString = 'N/A';
-    this.emitDate(this.defaultDate);
+    this.emitDate(this.defaultNaDate);
   }
 
   public setNotFound(): void {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/field-datepicker/field-datepicker.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/field-datepicker/field-datepicker.component.ts
@@ -23,6 +23,7 @@ export class FieldDatepickerComponent implements OnInit, OnChanges {
   @Output() dateChanged = new EventEmitter();
 
   _dateString: string;
+  defaultDate: string = '1000-01-01';
   error: string = null;
   estimated = false;
   datePicker: Date;
@@ -58,7 +59,7 @@ export class FieldDatepickerComponent implements OnInit, OnChanges {
   }
 
   private handleInput(dateString: string): void {
-    if (dateString !== 'N/A' && dateString !== 'Not Found') {
+    if (dateString !== 'N/A' && dateString !== 'Not Found' && dateString !== this.defaultDate) {
       if (dateString != null) {
         let tmpDate: string = dateString;
         if (dateString.length === 7) {
@@ -69,14 +70,13 @@ export class FieldDatepickerComponent implements OnInit, OnChanges {
           this._dateString = dateString;
         } else if (dateString.includes('T')) {
             this._dateString = Utils.getDateFormatted(Utils.getDate(dateString.split('T')[0]), this.dateFormat);
-        } else if (dateString === '1000-01-01') {
-            this._dateString = !this.colorDuringPatch ? 'N/A' : '1000-01-01';
-        }
-        else {
+        } else {
           this._dateString = Utils.getDateFormatted(this.datePicker, this.dateFormat);
         }
         this.datePicker = Utils.getDate(tmpDate);
       }
+    } else if (dateString === this.defaultDate) {
+      this._dateString = 'N/A';
     } else {
       this._dateString = dateString;
     }
@@ -138,8 +138,8 @@ export class FieldDatepickerComponent implements OnInit, OnChanges {
 
   public setNA(): void {
     this.isNA = true;
-    this._dateString = '1000-01-01';
-    this.emitDate(this._dateString);
+    this._dateString = 'N/A';
+    this.emitDate(this.defaultDate);
   }
 
   public setNotFound(): void {


### PR DESCRIPTION
We were sending the value 'N/A' to the backend when N/A was chosen in the date picker.
I have created the defaultDate variable and now, if N/A is chosen we are saving the default date instead of 'N/A'. Also if we get the default date from the backend we are showing N/A to the user.

https://broadinstitute.atlassian.net/browse/DDP-7896