### PR TITLE
[SDK] [SINGULAR] DDP-8483 fix styles after QA review

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-composite-answer/activityCompositeAnswer.component.html
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-composite-answer/activityCompositeAnswer.component.html
@@ -8,7 +8,8 @@
     </p>
     <div class="ddp-answer-container"
          [ngClass]="setOrientationClass(block.childOrientation)"
-         [gdColumns]="gridLayoutColumnConfig()">
+         [style.display]="isGridLayout() ? 'grid' : ''"
+         [ngStyle]="{'grid-template-columns': gridLayoutColumnConfig()}">
         <ng-container *ngFor="let childBlock of childBlockRow; let column = index">
             <div *ngIf="block.tabularSeparator && column >= 1" class="tabular-separator">
                 <span>{{block.tabularSeparator}}</span>

--- a/ddp-workspace/projects/ddp-singular/src/app/components/activity/activity.component.html
+++ b/ddp-workspace/projects/ddp-singular/src/app/components/activity/activity.component.html
@@ -1,4 +1,4 @@
-<div class="activity" [ngClass]="{'has-sticky-section': model.subtitle, 'consent': isConsent}">
+<div class="activity" [ngClass]="{'has-sticky-section': model?.subtitle, 'consent': isConsent}">
   <section *ngIf="!isLoaded" class="section section--spinner">
     <mat-spinner></mat-spinner>
   </section>

--- a/ddp-workspace/projects/ddp-singular/src/styles/_activities.scss
+++ b/ddp-workspace/projects/ddp-singular/src/styles/_activities.scss
@@ -113,6 +113,25 @@
 
   .Question--COMPOSITE {
     margin: 1.5rem 0;
+
+      .composite-answer {
+          &-WHAT_IS_YOUR_HEIGHT {
+
+              .ddp-answer-container {
+                  column-gap: 25px;
+
+                  @media (max-width: 450px) {
+                      flex-direction: column;
+                  }
+              }
+
+              .ddp-answer-field {
+                  padding-left: 0;
+                  padding-right: 0;
+                  flex-grow: 1;
+              }
+          }
+      }
   }
 
   ddp-activity-picklist-answer {


### PR DESCRIPTION
According to https://broadinstitute.atlassian.net/browse/DDP-8483?focusedCommentId=1330165:
1. fixed a force adding `display: grid` styles by `ngColumns` directive when a window resize occurs
2. Aligned styles 