### PR TITLE
[SDK] [SINGULAR] DDP-8490 Placeholder text in Singular survey is cutoff in mobile displays

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-text-input/activityTextInput.component.scss
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-text-input/activityTextInput.component.scss
@@ -1,6 +1,12 @@
 ::ng-deep .suggestion-match {
   text-decoration: underline;
 }
+@media only screen and (max-width: 1024px) {
+  ::ng-deep .example-input-field .mat-form-field-label-wrapper label{
+    line-height: 17px;
+  }
+}
+
 
 .example-input-field,
 .example-input-field-confirmation {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/datePicker.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/datePicker.component.ts
@@ -183,6 +183,11 @@ import { InputRestriction } from '../models/InputRestriction';
         width: 2.4em;
         padding: 0 2px 0 0;
     }
+    @media only screen and (max-width: 1024px) {
+        ::ng-deep .two-char-input .mat-form-field-label-wrapper label{
+            line-height: 17px;
+        }
+    }
     .four-char-input {
         width: 3.5em;
         padding: 0 2px 0 0;


### PR DESCRIPTION
Fixing Placeholder's mobile view issue. The ActivityTextInput and datePicker components were modified to support the line-height field's property for labels.

SDK adjustments have been made to make them applicable to the entire app.

Before the fix:

![image](https://user-images.githubusercontent.com/109761417/182454717-7a720eb5-fb83-4ea6-a610-454f2158ea82.png)

After the fix:

![image](https://user-images.githubusercontent.com/109761417/182454794-1ebb37a6-79b3-4abd-a57a-a0aa22cb203e.png)
