### PR TITLE
DDP-7581: updating export default options

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard/dashboard.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard/dashboard.component.html
@@ -1128,18 +1128,6 @@
             </ng-container>
           </ng-container>
         </ng-container>
-        <tr>
-          <td colspan="4">
-            <br/>
-            <mat-select placeholder="Select source" [(ngModel)]="downloadSource" class="Input--Bigger-WIDTH">
-              <mat-option *ngFor="let key of getSourceKeys()" [value]="key">{{dataSources.get(key)}}</mat-option>
-            </mat-select>
-            <button type="button" mat-raised-button color="primary"
-                    (click)="dataExport(downloadSource)"
-                    [disabled]="participantList.length === 0 || downloadSource == null">Export Data
-            </button>
-          </td>
-        </tr>
         </tbody>
       </table>
     </div>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard/dashboard.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard/dashboard.component.ts
@@ -63,7 +63,6 @@ export class DashboardComponent implements OnInit {
     [ 'k', 'Sample' ],
     [ 'a', 'Abstraction' ] ]);
   sourceColumns = {};
-  downloadSource;
   hasESData = false;
   activityDefinitionList: ActivityDefinition[] = [];
   participantList: Participant[] = [];
@@ -484,54 +483,6 @@ export class DashboardComponent implements OnInit {
     });
   }
 
-  dataExport(source: string): void {
-    this.loadingDDPData = true;
-    if (source != null) {
-      const date = new Date();
-      const columns = {};
-      this.dataSources.forEach((value: string, key: string) => {
-        if (this.sourceColumns[ key ] != null && this.sourceColumns[ key ].length !== 0) {
-          columns[ key ] = this.sourceColumns[ key ];
-        }
-      });
-      if (this.participantList.length !== 0) {
-        if (source === 'm') {
-          Utils.downloadCurrentData(
-            this.participantList, [ [ 'data', 'data' ], [ 'participant', 'p' ], [ 'medicalRecords', 'm' ] ],
-            columns, 'Participants-MR-' + Utils.getDateFormatted(date, Utils.DATE_STRING_CVS) + Statics.CSV_FILE_EXTENSION
-          );
-          this.downloadDone();
-        } else if (source === 'oD') {
-          Utils.downloadCurrentData(
-            this.participantList, [ [ 'data', 'data' ], [ 'participant', 'p' ], [ 'oncHistoryDetails', 'oD', 'tissues', 't' ] ],
-            columns, 'Participants-OncHistory-' + Utils.getDateFormatted(date, Utils.DATE_STRING_CVS) + Statics.CSV_FILE_EXTENSION
-          );
-          this.downloadDone();
-        } else if (source === 'k') {
-          Utils.downloadCurrentData(this.participantList,
-            [ [ 'data', 'data' ], [ 'participant', 'p' ], [ 'kits', 'k' ] ],
-            columns,
-            'Participants-Sample-' + Utils.getDateFormatted(date, Utils.DATE_STRING_CVS) + Statics.CSV_FILE_EXTENSION
-          );
-          this.downloadDone();
-        } else if (source === 'a') {
-          // TODO add final abstraction values to download
-          Utils.downloadCurrentData(
-            this.participantList, [ [ 'data', 'data' ], [ 'participant', 'p' ], [ 'abstractionActivities', 'a' ] ],
-            columns, 'Participants-Abstraction-' + Utils.getDateFormatted(date, Utils.DATE_STRING_CVS) + Statics.CSV_FILE_EXTENSION
-          );
-          this.downloadDone();
-        } else {
-          Utils.downloadCurrentData(
-            this.participantList, [ [ 'data', 'data' ], [ source, source ] ], columns,
-            'Participants-' + source + Utils.getDateFormatted(date, Utils.DATE_STRING_CVS) + Statics.CSV_FILE_EXTENSION, true
-          );
-          this.downloadDone();
-        }
-      }
-    }
-  }
-
   getParticipantData(): void {
     this.dsmService.applyFilter(null, localStorage.getItem(ComponentService.MENU_SELECTED_REALM), 'participantList', null)
       .subscribe({
@@ -551,21 +502,6 @@ export class DashboardComponent implements OnInit {
           this.errorMessage = 'Error - Downloading Participant List, Please contact your DSM developer';
         }
       });
-  }
-
-  downloadDone(): void {
-    this.loadingDDPData = false;
-    this.errorMessage = null;
-  }
-
-  getSourceKeys(): string[] {
-    const keys = [];
-    this.dataSources.forEach((value: string, key: string) => {
-      if (key !== 'data' && key !== 'p' && key !== 't') {
-        keys.push(key);
-      }
-    });
-    return keys;
   }
 
 }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.html
@@ -923,12 +923,11 @@
         <mat-radio-group [(ngModel)]="exportFileFormat">
           File format:
           <div>
-
-            <mat-radio-button color="primary" disableRipple value="tsv">
-              <span tooltip="tab-delimited values">.tsv</span>
-            </mat-radio-button>
             <mat-radio-button color="primary" disableRipple value="xlsx">
-              <span tooltip="Microsoft Excel workbook">.xlsx</span>
+              <span tooltip="Microsoft Excel workbook">Excel (.xlsx)</span>
+            </mat-radio-button>
+            <mat-radio-button color="primary" disableRipple value="tsv">
+              <span tooltip="tab-delimited values">Tab-delimited (.tsv)</span>
             </mat-radio-button>
           </div>
         </mat-radio-group>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -92,9 +92,9 @@ export class ParticipantListComponent implements OnInit {
   filterQuery: string = null;
   activityDefinitions = new Map();
 
-  exportFileFormat = 'tsv';
-  exportSplitOptions = true;
-  exportOnlyMostRecent = false;
+  exportFileFormat: string = 'xlsx';
+  exportSplitOptions: boolean = true;
+  exportOnlyMostRecent: boolean = false;
 
   selectedColumns = {};
   prevSelectedColumns = {};
@@ -1673,7 +1673,7 @@ export class ParticipantListComponent implements OnInit {
   executeDownload(): void {
     this.modal.hide();
 
-    const dialogRef = this.openDialog('Exporting participants list...');
+    const dialogRef = this.openDialog('Exporting participants list. This may take several minutes...');
     const columns = [];
     for(const col in this.selectedColumns) {
       for (const key in this.selectedColumns[col]) {


### PR DESCRIPTION
This merges some already-merged-into-the-rc code back into develop.  It changes the default export option to Excel, and also removes the broken export button from the dashboard.

TO TEST:
1.  Load the participant list for a study
2. Press the "download" button
3. confirm Excel/.xlsx  is selected by default
![image](https://user-images.githubusercontent.com/2800795/182865738-2e2d91f1-f309-4681-9367-85588d4b8370.png)

4. go to the dashboard
5. confirm the export button is no longer at the bottom of the page
 
![image](https://user-images.githubusercontent.com/2800795/182866245-5e43382f-6a20-4d9f-b293-1caeb032a333.png)
