### PR TITLE
[SINGULAR] DDP-8566 Placeholders and text in input fields still being cutoff in mobile

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-text-input/activityTextInput.component.scss
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activity-text-input/activityTextInput.component.scss
@@ -5,6 +5,9 @@
   ::ng-deep .example-input-field .mat-form-field-label-wrapper label{
     line-height: 17px;
   }
+  ::ng-deep .example-input-field .mat-form-field-infix input{
+    line-height: 18px;
+  }
 }
 
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/answers/activityNumericAnswer.component.ts
@@ -35,6 +35,14 @@ import { LayoutType } from '../../../models/layout/layoutType';
         .input-field {
             width: 100%;
         }
+        @media only screen and (max-width: 1024px) {
+            ::ng-deep .input-field .mat-form-field-label-wrapper label{
+            line-height: 17px;
+            }
+            ::ng-deep .input-field .mat-form-field-infix input{
+            line-height: 17px;
+            }
+        }
     `]
 })
 export class ActivityNumericAnswer implements OnInit, OnChanges, OnDestroy {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/dropdownActivityPicklistQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/dropdownActivityPicklistQuestion.component.ts
@@ -68,13 +68,13 @@ import { NGXTranslateService } from '../../../services/internationalization/ngxT
           width: auto;
         }
         @media only screen and (max-width: 1024px) {
-          ::ng-deep .mat-form-field .mat-select-native-control{
+          ::ng-deep .width .mat-select-native-control{
           line-height: 17px;
             }
-          ::ng-deep .mat-form-field .mat-select{
+          ::ng-deep .width .mat-select{
             line-height: 17px;
             }
-          ::ng-deep .mat-form-field .mat-form-field-infix input{
+          ::ng-deep .width .mat-form-field-infix input{
             line-height: 17px;
             }
         }

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/dropdownActivityPicklistQuestion.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/activityForm/picklist/dropdownActivityPicklistQuestion.component.ts
@@ -30,6 +30,7 @@ import { NGXTranslateService } from '../../../services/internationalization/ngxT
 
       <ng-template #nativeSelect>
           <select matNativeControl
+                  class="mat-select-native-control"
                   [(ngModel)]="nativeSelectedValue"
                   [disabled]="readonly"
                   (change)="handleNativeSelect($event.target.value); details.show ? updateCharactersLeftIndicator(details.stableId) : null">
@@ -65,6 +66,17 @@ import { NGXTranslateService } from '../../../services/internationalization/ngxT
 
         .ddp-dropdown-field ::ng-deep .mat-form-field-infix {
           width: auto;
+        }
+        @media only screen and (max-width: 1024px) {
+          ::ng-deep .mat-form-field .mat-select-native-control{
+          line-height: 17px;
+            }
+          ::ng-deep .mat-form-field .mat-select{
+            line-height: 17px;
+            }
+          ::ng-deep .mat-form-field .mat-form-field-infix input{
+            line-height: 17px;
+            }
         }
     `]
 })

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.component.ts
@@ -157,13 +157,13 @@ import { ConfigurationService } from '../../services/configuration.service';
             margin:0;
         }
         @media only screen and (max-width: 1024px) {
-            ::ng-deep .mat-form-field .mat-form-field-label-wrapper label{
+            ::ng-deep .ddp-address-input .mat-form-field .mat-form-field-label-wrapper label{
             line-height: 17px;
             }
-            ::ng-deep .mat-form-field .mat-form-field-infix input{
+            ::ng-deep .ddp-address-input .mat-form-field .mat-form-field-infix input{
             line-height: 17px;
             }
-            ::ng-deep .mat-form-field .mat-select span{
+            ::ng-deep .ddp-address-input .mat-form-field .mat-select span{
             line-height: 17px;
             }
         }`],

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/address/addressInput.component.ts
@@ -155,6 +155,17 @@ import { ConfigurationService } from '../../services/configuration.service';
             flex-direction: column;
             padding: 0;
             margin:0;
+        }
+        @media only screen and (max-width: 1024px) {
+            ::ng-deep .mat-form-field .mat-form-field-label-wrapper label{
+            line-height: 17px;
+            }
+            ::ng-deep .mat-form-field .mat-form-field-infix input{
+            line-height: 17px;
+            }
+            ::ng-deep .mat-form-field .mat-select span{
+            line-height: 17px;
+            }
         }`],
     changeDetection: ChangeDetectionStrategy.OnPush
 })


### PR DESCRIPTION
Adding some styling changes on mobile view.

Before the fix:

![image](https://user-images.githubusercontent.com/109761417/183748476-eeb9b4fd-65c5-425b-bb66-b4fdf95fa02d.png)

After the fix:

![image](https://user-images.githubusercontent.com/109761417/183748621-9af364d9-59bd-4cbb-bcd4-25adb460cb0a.png)
