### PR TITLE
Dsm rc 20220714a ddp 8349

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/lookup/lookup.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/lookup/lookup.component.html
@@ -3,13 +3,13 @@
          matInput maxlength="200"
          placeholder="{{placeholder}}"
          [(ngModel)]="lookupValue" [disabled]="disabled"
-         (ngModelChange)="checkForLookup()" (change)="changeValue()"
+         (ngModelChange)="checkForLookup()"
          (blur)="currentField(null)" (focus)="currentField(fieldName)">
   <textarea *ngIf="multiLineInput"
             matInput maxlength="200"
             placeholder="{{placeholder}}"
             [(ngModel)]="lookupValue" [disabled]="disabled"
-            (ngModelChange)="checkForLookup()" (change)="changeValue()"
+            (ngModelChange)="checkForLookup()"
             (blur)="currentField(null)" (focus)="currentField(fieldName)"></textarea>
 </mat-form-field>
 <div>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/lookup/lookup.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/lookup/lookup.component.ts
@@ -1,16 +1,24 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnDestroy, OnInit,
+  Output,
+} from '@angular/core';
 
 import { Lookup } from './lookup.model';
 import { DSMService } from '../services/dsm.service';
 import { ComponentService } from '../services/component.service';
-import { Statics } from '../utils/statics';
+import {debounceTime, distinctUntilChanged, exhaustMap, tap} from 'rxjs/operators';
+import {Observable, Subject, Subscription} from 'rxjs';
+import {Statics} from '../utils/statics';
 
 @Component({
   selector: 'app-lookup',
   templateUrl: './lookup.component.html',
   styleUrls: ['./lookup.component.css']
 })
-export class LookupComponent {
+export class LookupComponent implements OnInit, OnDestroy {
   @Input() lookupValue: string;
   @Input() lookupType: string;
   @Input() disabled = false;
@@ -22,29 +30,31 @@ export class LookupComponent {
 
   @Output() lookupResponse = new EventEmitter<Lookup | string>();
 
+  lookedUpValue = new Subject<string>();
+  lookedUpValueUnsubscribe: Subscription;
+
   lookups: Array<Lookup> = [];
   currentPatchField: string;
 
-  constructor(private dsmService: DSMService) {
+  constructor(private dsmService: DSMService) {}
+
+  ngOnInit(): void {
+    this.lookedUpValueUnsubscribe = this.lookedUpValue
+      .pipe(
+        debounceTime(1000),
+        distinctUntilChanged((prev, curr) => !!this.lookups.find(data => data.field1.value === curr) || curr === prev),
+        exhaustMap(this.fetchLookedUpValue.bind(this)),
+        tap(this.setValues.bind(this))
+      )
+      .subscribe();
+  }
+
+  ngOnDestroy(): void {
+    this.lookedUpValueUnsubscribe.unsubscribe();
   }
 
   public checkForLookup(): Array<Lookup> {
-    let jsonData: any[];
-    if (this.lookupValue.trim() !== '') {
-      if (!(this.lookupValue.length > 1 && this.lookups.length === 0)) {
-        this.dsmService.lookupValue(this.lookupType, this.lookupValue, localStorage.getItem(ComponentService.MENU_SELECTED_REALM))
-          .subscribe(// need to subscribe, otherwise it will not send!
-            data => {
-              this.lookups = [];
-              jsonData = data;
-              jsonData.forEach((val) => {
-                const value = Lookup.parse(val);
-                this.lookups.push(value);
-              });
-            }
-          );
-      }
-    }
+    this.lookupValue.trim() !== '' && this.lookedUpValue.next(this.lookupValue);
     return this.lookups;
   }
 
@@ -73,4 +83,15 @@ export class LookupComponent {
   isPatchedCurrently(field: string): boolean {
     return this.currentPatchField === field;
   }
+
+  private fetchLookedUpValue(value: string): Observable<any> {
+    return this.dsmService.lookupValue(this.lookupType, value, localStorage.getItem(ComponentService.MENU_SELECTED_REALM));
+  }
+
+  private setValues(data: object[]): void {
+    this.lookups = [];
+    this.changeValue();
+    data.forEach((data_value: object) => this.lookups.push(Lookup.parse(data_value)));
+  }
+
 }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/medical-record/medical-record.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/medical-record/medical-record.component.ts
@@ -307,15 +307,15 @@ export class MedicalRecordComponent implements OnInit {
         const nameValues = [];
         this.medicalRecord.name = contact.field1.value;
         nameValues.push({name: 'm.name', value: this.medicalRecord.name});
-        if (contact.field2.value != null) {
+        if (contact?.field2?.value != null) {
           this.medicalRecord.contact = contact.field2.value;
           nameValues.push({name: 'm.contact', value: this.medicalRecord.contact});
         }
-        if (contact.field3.value != null) {
+        if (contact?.field3?.value != null) {
           this.medicalRecord.phone = contact.field3.value;
           nameValues.push({name: 'm.phone', value: this.medicalRecord.phone});
         }
-        if (contact.field4.value != null) {
+        if (contact?.field4?.value != null) {
           this.medicalRecord.fax = contact.field4.value;
           nameValues.push({name: 'm.fax', value: this.medicalRecord.fax});
         }


### PR DESCRIPTION
The only solution under the current architecture we have found is the following:
We are sending patch requests, not after the change event, but after the lookup request completes successfully.
Also, I have changed the input flow, in order to avoid unnecessary requests, by adding the request observable into the pipe, which is preceded by debounceTime the rxjs operator.

@Anzori-Ghurtchumelia

https://broadinstitute.atlassian.net/browse/DDP-8349