### PR TITLE
DDP-8628 [DSM] adding human-readable export option

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/help/help.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/help/help.component.html
@@ -18,10 +18,10 @@ One row will be generated per participant.
 
   </div>
 
-<h4>Split multiselect choices into separate columns</h4>
+<h4>Human readable / Analysis friendly</h4>
 <ul>
   <li>
-    <b>Yes</b> Each multiselect question will have a column for each answer option.  For example, the question "Which symptoms have you had?"
+    <b>Analysis friendly</b> Each picklist answers will be displayed as a stable id, rather than the displayed text.  For multiselects, each answer option will appear in a separate column.  For example, the question "Which symptoms have you had?"
     with options "fever", "nausea", and "persisent cough", will be exported into 3 columns.
     <table class="table table-striped">
       <thead>
@@ -47,7 +47,7 @@ One row will be generated per participant.
 
   </li>
   <li>
-    <b>No</b> will store multi-select questions as a single column, with a comma-delimited string of the answers given. For example, the question "Which symptoms have you had?"
+    <b>Human readable</b> will use display text where possible, and will show multi-select questions as a single column, with a comma-delimited string of the answers given. For example, the question "Which symptoms have you had?"
     with options "fever", "nausea", and "persisent cough", will be exported into 1 column.
     <table class="table table-striped">
       <thead>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.html
@@ -923,12 +923,11 @@
         <mat-radio-group [(ngModel)]="exportFileFormat">
           File format:
           <div>
-
-            <mat-radio-button color="primary" disableRipple value="tsv">
-              <span tooltip="tab-delimited values">.tsv</span>
-            </mat-radio-button>
             <mat-radio-button color="primary" disableRipple value="xlsx">
-              <span tooltip="Microsoft Excel workbook">.xlsx</span>
+              <span tooltip="Microsoft Excel workbook">Excel (.xlsx)</span>
+            </mat-radio-button>
+            <mat-radio-button color="primary" disableRipple value="tsv">
+              <span tooltip="tab-delimited values">Tab-delimited (.tsv)</span>
             </mat-radio-button>
           </div>
         </mat-radio-group>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.html
@@ -921,7 +921,7 @@
       </ng-container>
       <ng-container *ngIf="modalAnchor === 'exportOptions'">
         <mat-radio-group [(ngModel)]="exportFileFormat">
-          File format:
+          File format: <a [routerLink]="['../help']" target="_blank"><span class="fa fa-question-circle"></span></a>
           <div>
             <mat-radio-button color="primary" disableRipple value="xlsx">
               <span tooltip="Microsoft Excel workbook">Excel (.xlsx)</span>
@@ -932,21 +932,20 @@
           </div>
         </mat-radio-group>
         <br/>
-        <mat-radio-group [(ngModel)]="exportSplitOptions">
-          Split multiselect choices into separate columns:
+        <mat-radio-group [(ngModel)]="exportHumanReadable">
+          Option text format: <a [routerLink]="['../help']" target="_blank"><span class="fa fa-question-circle"></span></a>
           <div>
-
-             <mat-radio-button color="primary" disableRipple [value]="true">
-              <span tooltip="Each option of a multiselect will be displayed in a separate column, with 0/1 indicating selection">Yes</span>
+             <mat-radio-button color="primary" disableRipple [value]="false">
+              <span tooltip="Each option of a multiselect will be displayed in a separate column, with 0/1 indicating selection">Analysis-friendly</span>
             </mat-radio-button>
-            <mat-radio-button color="primary" disableRipple [value]="false">
-              <span tooltip="Multiselects will be exported as a comma-delimited list of the selections">No</span>
+            <mat-radio-button color="primary" disableRipple [value]="true">
+              <span tooltip="Multiselects will be exported as a comma-delimited list of the selections">Human-readable</span>
             </mat-radio-button>
           </div>
         </mat-radio-group>
         <br/>
         <mat-radio-group [(ngModel)]="exportOnlyMostRecent">
-          Include all completions of an activity:
+          Include all completions of an activity: <a [routerLink]="['../help']" target="_blank"><span class="fa fa-question-circle"></span></a>
           <div>
             <mat-radio-button color="primary" disableRipple [value]="false">
               <span tooltip="Include all, with each activity completion in a separate column">Yes</span>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -93,7 +93,7 @@ export class ParticipantListComponent implements OnInit {
   activityDefinitions = new Map();
 
   exportFileFormat: string = 'xlsx';
-  exportSplitOptions: boolean = true;
+  exportHumanReadable: boolean = false;
   exportOnlyMostRecent: boolean = false;
 
   selectedColumns = {};
@@ -1689,7 +1689,7 @@ export class ParticipantListComponent implements OnInit {
       null,
       this.sortBy,
       this.exportFileFormat,
-      this.exportSplitOptions,
+      this.exportHumanReadable,
       this.exportOnlyMostRecent
     ).subscribe({
       next: response => {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -92,9 +92,9 @@ export class ParticipantListComponent implements OnInit {
   filterQuery: string = null;
   activityDefinitions = new Map();
 
-  exportFileFormat = 'tsv';
-  exportSplitOptions = true;
-  exportOnlyMostRecent = false;
+  exportFileFormat: string = 'xlsx';
+  exportSplitOptions: boolean = true;
+  exportOnlyMostRecent: boolean = false;
 
   selectedColumns = {};
   prevSelectedColumns = {};
@@ -1673,7 +1673,7 @@ export class ParticipantListComponent implements OnInit {
   executeDownload(): void {
     this.modal.hide();
 
-    const dialogRef = this.openDialog('Exporting participants list...');
+    const dialogRef = this.openDialog('Exporting participants list. This may take several minutes...');
     const columns = [];
     for(const col in this.selectedColumns) {
       for (const key in this.selectedColumns[col]) {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dsm.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dsm.service.ts
@@ -215,7 +215,7 @@ export class DSMService {
   }
 
   public downloadParticipantData(realm: string, jsonPatch: string, parent: string, columns: {}, json: ViewFilter,
-                                 filterQuery: string, sortBy?: Sort, fileFormat?: string, splitOptions?: boolean,
+                                 filterQuery: string, sortBy?: Sort, fileFormat?: string, humanReadable?: boolean,
                                  onlyMostRecent?: boolean):
     Observable<any> {
     const viewFilterCopy = this.getFilter(json);
@@ -231,10 +231,10 @@ export class DSMService {
     if (fileFormat) {
       map.push({name: 'fileFormat', value: fileFormat});
     }
-    if (typeof splitOptions === 'boolean') {
-      map.push({name: 'splitOptions', value: splitOptions});
+    if (typeof humanReadable === 'boolean') {
+      map.push({name: 'humanReadable', value: humanReadable});
     }
-    if (typeof splitOptions === 'boolean') {
+    if (typeof onlyMostRecent === 'boolean') {
       map.push({name: 'onlyMostRecent', value: onlyMostRecent});
     }
     if (filterQuery != null) {


### PR DESCRIPTION
We would like to give the users an explicit choice between human readable and analysis friendly formatting. This adds a single new variable "humanReadable" which consolidates a choice between splitting multiselect questions into multiple columns, and rendering option stable ids vs. the display text. This also merges some bugfixes and test improvements from develop

This is paired with https://github.com/broadinstitute/ddp-study-server/pull/2175

TO TEST:

open the participant list for the AT study
customize view to include the Medical History "telangiectasia" question
export the participant list, selecting "analysis-friendly"
confirm the telangiectasia responses are split into 4 columns - 1 each for eyes and skin, and 1 for each of the supporting details
export the participant list again, selecting "human-readable"
confirm the telangiectasia responses are shown in two columns -- one showing the main responses as dispaly text, and the other showing the consolidated details