### PR TITLE
[SINGULAR] DDP-8404: Fix key combination

### DIFF
--- a/ddp-workspace/projects/ddp-singular/src/app/app.component.ts
+++ b/ddp-workspace/projects/ddp-singular/src/app/app.component.ts
@@ -60,10 +60,10 @@ export class AppComponent {
     }
   }
 
-  // Opens a dialog by 'Ctrl+Alt+Home' to setup/toggle feature flags
+  // Opens a dialog by 'Ctrl+Alt+7' to setup/toggle feature flags
   // it is used for feature flags testing only.
   // should not be available on production
-  @HostListener('window:keydown.control.alt.home', ['$event'])
+  @HostListener('window:keydown.control.alt.7', ['$event'])
   handleKeyDown(event: KeyboardEvent): void {
     if (!this.isProdMode) {
       this.openFeatureFlagsSetupDialog();


### PR DESCRIPTION
Changed the key combination for opening feature flags dialog. 
As to be more consistent for Win / Mac users.