### PR TITLE
DDP-8655: explicitly limiting export to <10K participants

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.html
@@ -1042,12 +1042,17 @@
         </button>
       </ng-container>
       <ng-container *ngIf="modalAnchor === 'exportOptions'">
-        <button type="button" class="btn btn-primary"
-                (click)="executeDownload()">Download
-        </button>
-        <button type="button" class="btn"
-                (click)="modal.hide()">Cancel
-        </button>
+        <ng-container *ngIf="getPaginationParticipantListSize() >= EXPORT_SIZE_LIMIT">
+          <span class="text-danger text-left">Downloads of >{{EXPORT_SIZE_LIMIT}} participants are currently not supported.<br/> You must first filter the participant list into smaller groups. </span>
+        </ng-container>
+        <ng-container *ngIf="getPaginationParticipantListSize() < EXPORT_SIZE_LIMIT">
+          <button type="button" class="btn btn-primary"
+                  (click)="executeDownload()">Download
+          </button>
+          <button type="button" class="btn"
+                  (click)="modal.hide()">Cancel
+          </button>
+        </ng-container>
       </ng-container>
       <ng-container *ngIf="modalAnchor === 'downloadError'">
         <button type="button" class="btn btn-primary"

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -95,7 +95,7 @@ export class ParticipantListComponent implements OnInit {
   exportFileFormat = 'xlsx';
   exportHumanReadable = false;
   exportOnlyMostRecent = false;
-
+  EXPORT_SIZE_LIMIT = 10000; // limit due to ElasticSearch paging range limit
   selectedColumns = {};
   prevSelectedColumns = {};
   defaultColumns = [];


### PR DESCRIPTION
We cannot support export of >10000 participants using our current ElasticSearch querying methods, as they are based on requesting record ranges, and ElasticSearch does not support requesting any records past the 10000th. (even if you are only requesting a single record).  So supporting export of >10000 participants would require changing to use scrolling/cursor API.  Per Jeff, this is not worth the effort given current customer needs.  So in the meantime, we’re just going to disable those queries with a warning. 

![image](https://user-images.githubusercontent.com/2800795/186971384-bae3fbd0-aa88-4079-ae3c-5e50f9385509.png)
(note the above screenshot had the limit set to 100, rather than 10K, for testing purposes)

TO TEST:
1. load the participant list for a study
2. use the download button to export the participant list, confirm the dialog appears as normal.
3. edit the EXPORT_SIZE_LIMIT of participant-list.component.ts to be less than the # of participants in the study. 
4. Open the download modal, and confirm the warning appears, and download is not enabled.