### PR TITLE
[DSM] DDP-8561:  external users

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -587,7 +587,7 @@ export class ParticipantListComponent implements OnInit {
           this.sourceColumns['data'].push(new Filter(ParticipantColumn.PREFERRED_LANGUAGE, Filter.OPTION_TYPE, options));
         }
 
-        if (jsonData.hideMRTissueWorkflow != null) {
+        if (jsonData.hideMRTissueWorkflow != null || !this.role.allowedToViewMedicalRecords()) {
           this.dataSources.delete('m');
           this.dataSources.delete('oD');
           this.dataSources.delete('t');

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.html
@@ -395,7 +395,7 @@ participant.data.dsm['diagnosisYear'] != null">
                       (change)="valueChanged($event, 'notes', 'r')"></textarea>
             </td>
           </tr>
-          <ng-container *ngIf="showParticipantRecord">
+          <ng-container *ngIf="showParticipantRecord && hasRole().allowedToViewMedicalRecords()">
             <tr *ngIf="participant.medicalRecords != null && participant.medicalRecords.length > 0">
               <td>Paper C/R Sent</td>
               <td>
@@ -415,7 +415,7 @@ participant.data.dsm['diagnosisYear'] != null">
               </td>
             </tr>
           </ng-container>
-          <tr *ngIf="participant.medicalRecords != null && participant.medicalRecords.length > 0">
+          <tr *ngIf="participant.medicalRecords != null && participant.medicalRecords.length > 0 && hasRole().allowedToViewMedicalRecords()">
             <td>Onc History Created</td>
             <td>
               <div class="Float--left">
@@ -433,7 +433,7 @@ participant.data.dsm['diagnosisYear'] != null">
               </div>
             </td>
           </tr>
-          <tr *ngIf="participant.medicalRecords != null && participant.medicalRecords.length > 0">
+          <tr *ngIf="participant.medicalRecords != null && participant.medicalRecords.length > 0 && hasRole().allowedToViewMedicalRecords()">
             <td>
               Incomplete/Minimal Medical Records
             </td>
@@ -446,7 +446,7 @@ participant.data.dsm['diagnosisYear'] != null">
               </mat-checkbox>
             </td>
           </tr>
-          <tr *ngIf="participant.medicalRecords != null && participant.medicalRecords.length > 0">
+          <tr *ngIf="participant.medicalRecords != null && participant.medicalRecords.length > 0 && hasRole().allowedToViewMedicalRecords()">
             <td>
               Ready for Abstraction
             </td>
@@ -461,7 +461,7 @@ participant.data.dsm['diagnosisYear'] != null">
           </tr>
         </table>
       </div>
-      <div class="Float--left Width--100" *ngIf="settings['r'] != null">
+      <div class="Float--left Width--100" *ngIf="settings['r'] != null && hasRole().allowedToViewMedicalRecords()">
         <table class="Width--100">
             <tr *ngFor="let fieldSetting of settings['r']">
               <td>{{fieldSetting.columnDisplay}}</td>
@@ -760,7 +760,7 @@ participant.data.dsm['diagnosisYear'] != null">
           </tab>
 
             <tab heading="Medical Records"
-                 *ngIf="participant.medicalRecords != null && participant.medicalRecords.length > 0"
+                 *ngIf="participant.medicalRecords != null && participant.medicalRecords.length > 0 && hasRole().allowedToViewMedicalRecords()"
                  [active]="tabActive('Medical Records')" (selectTab)="onSelect($event, 'Medical Records')">
               <br/><br/><br/>
 
@@ -833,7 +833,7 @@ participant.data.dsm['diagnosisYear'] != null">
             </tab>
 
             <tab heading="Onc History"
-                 *ngIf="isOncHistoryVisible"
+                 *ngIf="isOncHistoryVisible && hasRole().allowedToViewMedicalRecords()"
                  [active]="tabActive('Onc History')" (selectTab)="onSelect($event, 'Onc History')">
               <br/><br/><br/>
 


### PR DESCRIPTION
changing 'Medical Record' and 'Onc History' tab only to be visible of user has 'allowedToViewMedicalRecords' permission


to test: make a new user with only the pt_list_view access and not mr_view (cmi studies)
go to pt list:
customize view should not have mr and oncHistory columns to add to the pt table
going to pt page mr and oncHistory tab should not be visible 

<img width="1039" alt="Screen Shot 2022-08-26 at 10 19 06 PM" src="https://user-images.githubusercontent.com/20780088/187010578-3e6912bf-48d4-4385-9127-daeed06f248e.png">
<img width="1039" alt="Screen Shot 2022-08-26 at 10 18 53 PM" src="https://user-images.githubusercontent.com/20780088/187010579-4a9a9c67-6e80-4ee7-922c-d212a1390998.png">