### PR TITLE
Ddp 7941 14 digits limitation

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/scan-pair/scan-pair.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/scan-pair/scan-pair.component.html
@@ -11,3 +11,4 @@
 <button mat-mini-fab type="button" (click)="removeMe()" color="primary" [disabled]="positionScanPair === countScanPair-1">-</button>
 <p style="vertical-align: text-bottom" class="Width--100 Color--warn Line--Break" *ngIf="hadErrorSending && errorMessage != null">Error occurred sending this scan pair!
 {{errorMessage}}</p>
+<p style="vertical-align: text-bottom" class="Width--100 Color--warn Line--Break" *ngIf="lengthError">{{lengthError}}</p>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/scan-pair/scan-pair.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/scan-pair/scan-pair.component.ts
@@ -29,7 +29,7 @@ export class ScanPairComponent implements OnInit {
   }
 
   moveFocus(leftValue: string): void {
-    if(leftValue.length < 14 && this.selectedScan == "Final Scan") {
+    if(leftValue.length < 14 && this.selectedScan === 'Final Scan') {
       this.lengthError = 'Error: Barcode contains less than 14 digits. You can manually enter any missing digits above.';
     } else {
       this.lengthError = null;

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/scan-pair/scan-pair.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/scan-pair/scan-pair.component.ts
@@ -16,6 +16,7 @@ export class ScanPairComponent implements OnInit {
   @Input() leftInputPlaceholder = 'Kit Label';
   @Input() rightInputPlaceholder = 'DSM Label';
   @Input() errorMessage: string;
+  @Input() selectedScan: string;
 
   @Output() pairScanned = new EventEmitter();
   @Output() removeScanPair = new EventEmitter();
@@ -28,7 +29,7 @@ export class ScanPairComponent implements OnInit {
   }
 
   moveFocus(leftValue: string): void {
-    if(leftValue.length < 14) {
+    if(leftValue.length < 14 && this.selectedScan == "Final Scan") {
       this.lengthError = 'Error: Barcode contains less than 14 digits. You can manually enter any missing digits above.';
     } else {
       this.lengthError = null;

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/scan-pair/scan-pair.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/scan-pair/scan-pair.component.ts
@@ -21,13 +21,21 @@ export class ScanPairComponent implements OnInit {
   @Output() removeScanPair = new EventEmitter();
   @Output() leftLabelAdded = new EventEmitter();
 
+  lengthError: string;
+
   ngOnInit(): void {
     this.leftInput.nativeElement.focus();
   }
 
   moveFocus(leftValue: string): void {
-    this.rightInput.nativeElement.focus();
-    this.leftLabelAdded.next([leftValue, this.positionScanPair]);
+    if(leftValue.length < 14) {
+      this.lengthError = "Error: Barcode contains less than 14 digits. You can manually enter any missing digits above.";
+    } else {
+      this.lengthError = null;
+      this.rightInput.nativeElement.focus();
+      this.leftLabelAdded.next([leftValue, this.positionScanPair]);
+    }
+
   }
 
   nextPair(leftValue: string, rightValue: string): void {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/scan-pair/scan-pair.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/scan-pair/scan-pair.component.ts
@@ -29,7 +29,7 @@ export class ScanPairComponent implements OnInit {
 
   moveFocus(leftValue: string): void {
     if(leftValue.length < 14) {
-      this.lengthError = "Error: Barcode contains less than 14 digits. You can manually enter any missing digits above.";
+      this.lengthError = 'Error: Barcode contains less than 14 digits. You can manually enter any missing digits above.';
     } else {
       this.lengthError = null;
       this.rightInput.nativeElement.focus();

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/scan/scan.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/scan/scan.component.html
@@ -1,7 +1,5 @@
 <h1>
-  <ng-container *ngIf="!scanTracking && !scanReceived"> Final Scan </ng-container>
-  <ng-container *ngIf="scanTracking"> Tracking Scan </ng-container>
-  <ng-container *ngIf="scanReceived"> Receiving Scan </ng-container>
+  <ng-container > {{ displayScanText }} </ng-container>
 </h1>
 
 <br/>
@@ -22,7 +20,7 @@
 <form>
   <ng-container *ngIf="!scanReceived">
     <div *ngFor="let row of scanPairs; let i = index">
-      <app-scan-pair [leftInputPlaceholder]="leftPlaceholder" [rightInputPlaceholder]="rightPlaceholder"
+      <app-scan-pair [leftInputPlaceholder]="leftPlaceholder" [selectedScan]="displayScanText" [rightInputPlaceholder]="rightPlaceholder"
                      (pairScanned)="scanDone($event)" (removeScanPair)="removeScanPair($event)"
                      (leftLabelAdded)="setLeftValue($event)" [isLeftValueDuplicate]="validateLeftValue(i)"
                      [isRightValueDuplicate]="validateRightValue(i)" [hadErrorSending]="checkSendStatus(i)"

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/scan/scan.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/scan/scan.component.ts
@@ -76,11 +76,11 @@ export class ScanComponent implements OnInit {
 
   public get displayScanText(): string {
     if(!this.scanTracking && !this.scanReceived)
-      return "Final Scan";
+      {return 'Final Scan';}
     else if(this.scanTracking)
-      return "Tracking Scan";
+      {return 'Tracking Scan';}
     else if(this.scanReceived)
-      return "Receiving Scan"
+      {return 'Receiving Scan';}
   }
 
   private checkIfKitLabelChanged(left: string, right: string, position: number): boolean {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/scan/scan.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/scan/scan.component.ts
@@ -74,6 +74,15 @@ export class ScanComponent implements OnInit {
     }
   }
 
+  public get displayScanText(): string {
+    if(!this.scanTracking && !this.scanReceived)
+      return "Final Scan";
+    else if(this.scanTracking)
+      return "Tracking Scan";
+    else if(this.scanReceived)
+      return "Receiving Scan"
+  }
+
   private checkIfKitLabelChanged(left: string, right: string, position: number): boolean {
     for (let i = 0; i < this.scanPairsValue.length; i++) {
       if (this.scanPairsValue[i].leftValue === left && i === position) {


### PR DESCRIPTION
I have added an extra check on the left value (For the final scan), which tests whether a user has entered 14 characters/digits or not. If a user enters less than 14, the following text displays, and the cursor won't move to the right field automatically:
"Error: Barcode contains less than 14 digits. You can manually enter any missing digits above."
<img width="760" alt="Screenshot 2022-08-29 at 10 13 01" src="https://user-images.githubusercontent.com/77500504/187134740-c2adf522-6210-4fd7-b2d0-8e858dd126f6.png">

[Ticket](https://broadinstitute.atlassian.net/browse/DDP-7941)
