### PR TITLE
[DSM] DDP-8231: add counter to avoid infinite spinner

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
@@ -158,26 +158,7 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
       instanceName: this.compService.getRealm(),
       data: {}
     };
-    this.checkParticipantStatusInterval = setInterval(() => {
-      if (this.updatingParticipant) {
-        this.dsmService.checkUpdatingParticipantStatus().subscribe({
-          next: data => {
-            const parsedData = JSON.parse(data.body);
-            if (parsedData[ 'resultType' ] === 'SUCCESS'
-                && this.isReturnedUserAndParticipantTheSame(parsedData)) {
-              this.updateParticipantObjectOnSuccess();
-              this.openResultDialog('Participant successfully updated');
-            } else if (parsedData[ 'resultType' ] === 'ERROR'
-                && this.isReturnedUserAndParticipantTheSame(parsedData)) {
-              this.openResultDialog(parsedData[ 'errorMessage' ]);
-            }
-         },
-          error: () => {
-            this.openResultDialog('Error - Failed to update participant');
-         }
-        });
-      }
-    }, 5000);
+    this.handleParticipantProfileUpdate();
     this.loadInstitutions();
     this.scrolled = false;
     if(!this.selectedActivityCode) {
@@ -193,6 +174,39 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
     this.addMedicalProviderInformation();
     this.getMercuryEligibleSamples();
     this.canSequence = this.canHaveSequencing(this.participant);
+  }
+
+  private handleParticipantProfileUpdate(): void {
+    let checkUpdateStatusCounter = 0;
+    this.checkParticipantStatusInterval = setInterval(() => {
+      if (this.updatingParticipant) {
+        if (checkUpdateStatusCounter >= 5) {
+          this.updatingParticipant = false;
+          this.openResultDialog('DSM triggered DSS to change it but system is not responding.');
+          checkUpdateStatusCounter = 0;
+          return;
+        }
+        checkUpdateStatusCounter += 1;
+        this.dsmService.checkUpdatingParticipantStatus().subscribe({
+          next: data => {
+            const parsedData = JSON.parse(data.body);
+            if (parsedData['resultType'] === 'SUCCESS'
+              && this.isReturnedUserAndParticipantTheSame(parsedData)) {
+              this.updateParticipantObjectOnSuccess();
+              this.openResultDialog('Participant successfully updated');
+            } else if (parsedData['resultType'] === 'ERROR'
+              && this.isReturnedUserAndParticipantTheSame(parsedData)) {
+              this.openResultDialog(parsedData['errorMessage']);
+            }
+            checkUpdateStatusCounter = 0;
+          },
+          error: () => {
+            this.openResultDialog('Error - Failed to update participant');
+            checkUpdateStatusCounter = 0;
+          }
+        });
+      }
+    }, 5000);
   }
 
   addMedicalProviderInformation(): void {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
@@ -182,7 +182,7 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
       if (this.updatingParticipant) {
         if (checkUpdateStatusCounter >= 5) {
           this.updatingParticipant = false;
-          this.openResultDialog('DSM triggered DSS to change it but system is not responding.');
+          this.openResultDialog('Your update has been saved, but the system is unable to display it at the moment. \nPlease try refreshing this page or come back to it later to see the update. Sorry for any inconvenience.');
           checkUpdateStatusCounter = 0;
           return;
         }


### PR DESCRIPTION
Ticket: https://broadinstitute.atlassian.net/browse/DDP-8231

For some reason `DSS` does not return any response at all and we get infinite spinner, thus we decided to send status check request only 5 times and if we don't get any response from `DSS` stop sending requests and pop up default message.