### PR TITLE
[DSM] DDP-8624 new changes

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -1125,9 +1125,8 @@ export class ParticipantListComponent implements OnInit {
       const val = value as Filter[];
       const newVal = [];
       val.forEach(el => {
-        let defaultColumn = this.defaultColumns.find(col => {
-          el['participantColumn']['name'] === col['participantColumn']['name']
-        });
+        const defaultColumn = this.defaultColumns.find(col =>
+          el['participantColumn']['name'] === col['participantColumn']['name']);
         if (defaultColumn) {
           newVal.push(el);
         }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -1077,10 +1077,10 @@ export class ParticipantListComponent implements OnInit {
       this.setSavedFilterColumnsIfSelected();
       return;
     }
-    const filteredColumns = this.extractDefaultColumns(this.selectedColumns);
-    Object.assign(this.selectedColumns, filteredColumns);
+    const filteredColumns = this.getDefaultColumns();
+    this.selectedColumns = filteredColumns;
     if (this.isDataOfViewFilterExists()) {
-      this.viewFilter.columns = this.extractDefaultColumns(this.viewFilter.columns);
+      this.viewFilter.columns = this.getDefaultColumns();
     }
   }
 
@@ -1118,17 +1118,19 @@ export class ParticipantListComponent implements OnInit {
     return isSavedFilterSelected;
   }
 
-  private extractDefaultColumns(selectedColumns: {}): {} {
+  private getDefaultColumns(): {} {
     const filteredColumns = {};
-    for (const [key, value] of Object.entries(selectedColumns)) {
+
+    for (const [key, value] of Object.entries(this.sourceColumns)) {
       const val = value as Filter[];
       const newVal = [];
       val.forEach(el => {
-        this.defaultColumns.forEach(col => {
-          if (el['participantColumn']['name'] === col['participantColumn']['name']) {
-            newVal.push(el);
-          }
+        let defaultColumn = this.defaultColumns.find(col => {
+          el['participantColumn']['name'] === col['participantColumn']['name']
         });
+        if (defaultColumn) {
+          newVal.push(el);
+        }
       });
       filteredColumns[key] = newVal;
     }


### PR DESCRIPTION
Changing from `Object.assign(this.selectedColumns, filteredColumns)` in participant-list.component.ts to just normal object assignment which was causing the main error
Also I changed the `extractDefaultColumns()` to `getDefaultColumns()` to find the columns from `sourceColumns` instead of `selectedColumns`, otherwise the not selected default column could get lost

To test: select a saved filter from the saved filters list and apply it by clicking on the funnel sign.

Then select `Reload With Default Filter` , desired behavior is that the columns from the default column should appear and all the other columns should be gone
