### PR TITLE
[SINGULAR] DDP-8404: Switch on approved feature flags

### DIFF
--- a/ddp-workspace/projects/ddp-singular/src/app/config/feature-flags/feature-flags-setup.ts
+++ b/ddp-workspace/projects/ddp-singular/src/app/config/feature-flags/feature-flags-setup.ts
@@ -4,8 +4,8 @@ import { FeatureFlagsEnum} from './feature-flags.enum';
 
 
 const initialFlags: FeatureFlags = {
-  [FeatureFlagsEnum.ShowDDP8404HomePageUpdate] : false,
-  [FeatureFlagsEnum.ShowDDP8560DashboardPageUpdate] : false
+  [FeatureFlagsEnum.ShowDDP8404HomePageUpdate] : true,
+  [FeatureFlagsEnum.ShowDDP8560DashboardPageUpdate] : true
 };
 
 const featureFlags: BehaviorSubject<FeatureFlags> = new BehaviorSubject(initialFlags);


### PR DESCRIPTION
Switched on all feature flags because they got IRB approval [(see Slack comment)](https://broadinstitute.slack.com/archives/C03R0A8HTD2/p1661892027683839).