### PR TITLE
[DSM] DDP-7606_reasearch_sample

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/shipping/shipping.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/shipping/shipping.component.html
@@ -236,7 +236,7 @@
             </ng-container>
           </td>
           <td
-            [ngClass]="{'highlight_sample': kitRequest.receivedBy === 'BSP' && isClinicalStudy && (shippingPage === RECEIVED || shippingPage === OVERVIEW)}">
+            [ngClass]="{'highlight_sample': isResearchSample(kitRequest)}">
             <!--            pt shortID-->
             {{kitRequest.getID()}}
             <div *ngIf="kitRequest.express && shippingPage === QUEUE" class="Float--right Router--Outlet">
@@ -249,7 +249,7 @@
             <!--            preferred Language-->
             <ng-container *ngIf="kitRequest.preferredLanguage != null && kitRequest.preferredLanguage !== ''">{{getLanguage().getLanguageName(kitRequest.preferredLanguage)}}</ng-container>
           </td>
-          <td *ngIf="shippingPage !== DEACTIVATED && !kitType.externalShipper" [ngClass]="{'highlight_sample': kitRequest.receivedBy === 'BSP' && isClinicalStudy && (shippingPage === RECEIVED || shippingPage === OVERVIEW)}">
+          <td *ngIf="shippingPage !== DEACTIVATED && !kitType.externalShipper" [ngClass]="{'highlight_sample': isResearchSample(kitRequest)}">
             <!--            shipping ID-->
             {{kitRequest.ddpLabel}}
           </td>
@@ -266,54 +266,54 @@
             {{kitRequest.getError()}}
           </td>
           <td *ngIf="shippingPage === DEACTIVATED || shippingPage === OVERVIEW && !kitType.externalShipper"
-              [ngClass]="{'highlight_sample': kitRequest.receivedBy === 'BSP' && isClinicalStudy && (shippingPage === RECEIVED || shippingPage === OVERVIEW)}">
+              [ngClass]="{'highlight_sample': isResearchSample(kitRequest)}">
             <!--            deactivation reason-->
             {{kitRequest.deactivationReason}}
           </td>
           <td *ngIf="shippingPage === DEACTIVATED || shippingPage === OVERVIEW && !kitType.externalShipper"
-              [ngClass]="{'highlight_sample': kitRequest.receivedBy === 'BSP' && isClinicalStudy && (shippingPage === RECEIVED || shippingPage === OVERVIEW)}">
+              [ngClass]="{'highlight_sample': isResearchSample(kitRequest)}">
             <!--            deactivation date-->
             <ng-container *ngIf="kitRequest.deactivatedDate === 0"> -</ng-container>
             <ng-container *ngIf="kitRequest.deactivatedDate !== 0">{{kitRequest.deactivatedDate | date:'medium'}}</ng-container>
           </td>
-          <td *ngIf="shippingPage === SENT" [ngClass]="{'highlight_sample': kitRequest.receivedBy === 'BSP' && isClinicalStudy && (shippingPage === RECEIVED || shippingPage === OVERVIEW)}">
+          <td *ngIf="shippingPage === SENT" [ngClass]="{'highlight_sample': isResearchSample(kitRequest)}">
             <!--            tracking to number-->
             <ng-container *ngIf="kitRequest.easypostTrackingToUrl != null"><a href="{{kitRequest.easypostTrackingToUrl}}" target="_blank">{{kitRequest.trackingToId}}</a>
             </ng-container>
             <ng-container *ngIf="kitRequest.easypostTrackingToUrl == null">{{kitRequest.trackingToId}}</ng-container>
           </td>
-          <td *ngIf="shippingPage === SENT" [ngClass]="{'highlight_sample': kitRequest.receivedBy === 'BSP' && isClinicalStudy && (shippingPage === RECEIVED || shippingPage === OVERVIEW)}">
+          <td *ngIf="shippingPage === SENT" [ngClass]="{'highlight_sample': isResearchSample(kitRequest)}">
             <!--            tracking return number-->
             <ng-container *ngIf="kitRequest.easypostTrackingReturnUrl != null"><a href="{{kitRequest.easypostTrackingReturnUrl}}" target="_blank">{{kitRequest.trackingReturnId}}</a>
             </ng-container>
             <ng-container *ngIf="kitRequest.easypostTrackingReturnUrl == null">{{kitRequest.trackingReturnId}}</ng-container>
           </td>
-          <td *ngIf="shippingPage === SENT || shippingPage === OVERVIEW" [ngClass]="{'highlight_sample': kitRequest.receivedBy === 'BSP' && isClinicalStudy && (shippingPage === RECEIVED || shippingPage === OVERVIEW)}">
+          <td *ngIf="shippingPage === SENT || shippingPage === OVERVIEW" [ngClass]="{'highlight_sample': isResearchSample(kitRequest)}">
             <!--            sent date-->
             <ng-container *ngIf="kitRequest.scanDate === 0"> -</ng-container>
             <ng-container *ngIf="kitRequest.scanDate !== 0">{{kitRequest.scanDate | date:'medium'}}</ng-container>
           </td>
-          <td *ngIf="shippingPage === RECEIVED || shippingPage === OVERVIEW" [ngClass]="{'highlight_sample': kitRequest.receivedBy === 'BSP' && isClinicalStudy && (shippingPage === RECEIVED || shippingPage === OVERVIEW)}">
+          <td *ngIf="shippingPage === RECEIVED || shippingPage === OVERVIEW" [ngClass]="{'highlight_sample': isResearchSample(kitRequest)}">
             <!--            received date-->
             <ng-container *ngIf="kitRequest.receiveDate === 0"> -</ng-container>
             <ng-container *ngIf="kitRequest.receiveDate !== 0">{{kitRequest.receiveDate | date:'medium'}}</ng-container>
           </td>
-          <td *ngIf="shippingPage === SENT || shippingPage === RECEIVED || shippingPage === OVERVIEW" [ngClass]="{'highlight_sample': kitRequest.receivedBy === 'BSP' && isClinicalStudy && (shippingPage === RECEIVED || shippingPage === OVERVIEW)}">
+          <td *ngIf="shippingPage === SENT || shippingPage === RECEIVED || shippingPage === OVERVIEW" [ngClass]="{'highlight_sample': isResearchSample(kitRequest)}">
             <!--            mf qr-code-->
             {{kitRequest.kitLabel}}
           </td>
-          <td [ngClass]="{'highlight_sample': kitRequest.receivedBy === 'BSP' && isClinicalStudy && (shippingPage === RECEIVED || shippingPage === OVERVIEW)}">
+          <td [ngClass]="{'highlight_sample': isResearchSample(kitRequest)}">
             <!--            study-->
             {{kitRequest.realm}}
           </td>
-          <td [ngClass]="{'highlight_sample': kitRequest.receivedBy === 'BSP' && isClinicalStudy && (shippingPage === RECEIVED || shippingPage === OVERVIEW)}">
+          <td [ngClass]="{'highlight_sample': isResearchSample(kitRequest)}">
             <!--            kit type-->
             {{kitRequest.kitTypeName}}
           </td>
-          <td *ngIf="isClinicalStudy && (shippingPage === RECEIVED || shippingPage === OVERVIEW)" [ngClass]="{'highlight_sample': kitRequest.receivedBy === 'BSP' && isClinicalStudy && (shippingPage === RECEIVED || shippingPage === OVERVIEW)}">
+          <td *ngIf="isClinicalStudy && (shippingPage === RECEIVED || shippingPage === OVERVIEW)" [ngClass]="{'highlight_sample': isResearchSample(kitRequest)}">
             <!--            sample type-->
-            <ng-container *ngIf="kitRequest.receivedBy === 'MERCURY'">Clinical Sample</ng-container>
-            <ng-container *ngIf="kitRequest.receivedBy === 'BSP'">Research Sample</ng-container>
+            <ng-container *ngIf="!isResearchSample(kitRequest)">Clinical Sample</ng-container>
+            <ng-container *ngIf="isResearchSample(kitRequest)">Research Sample</ng-container>
           </td>
           <td
             *ngIf="getRole().allowedToDeactivateKits() && (shippingPage === DEACTIVATED || (shippingPage !== DEACTIVATED && (queueToPrint() || shippingPage === UPLOADED)))">

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/shipping/shipping.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/shipping/shipping.component.ts
@@ -99,6 +99,8 @@ export class ShippingComponent implements OnInit {
 
   isClinicalStudy: Boolean = false;
 
+  RESEARCH_SAMPLE = 'RUO';
+
   constructor(private route: ActivatedRoute, private router: Router, private dsmService: DSMService, private auth: Auth,
                private role: RoleService, private compService: ComponentService, private _changeDetectionRef: ChangeDetectorRef,
                private util: Utils, private language: Language, private localStorageService: LocalStorageService) {
@@ -810,5 +812,10 @@ export class ShippingComponent implements OnInit {
       }
     }
     return false;
+  }
+
+  isResearchSample(kitRequest: KitRequest): boolean {
+    return  kitRequest.sequencingRestriction && kitRequest.sequencingRestriction === this.RESEARCH_SAMPLE && this.isClinicalStudy
+      && (this.shippingPage === this.RECEIVED || this.shippingPage === this.OVERVIEW);
   }
 }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/shipping/shipping.model.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/shipping/shipping.model.ts
@@ -12,7 +12,7 @@ export class KitRequest {
               public externalOrderStatus: string, public preferredLanguage: string,
               public receiveDateString: string, public hruid: string, public gender: string,
               public collectionDate: string, public firstName?: string, public lastName?: string,
-              public dateOfBirth?: string, public shortId?: string, public receivedBy?: string) {
+              public dateOfBirth?: string, public shortId?: string, public receivedBy?: string, public sequencingRestriction?: string) {
   }
 
   public TRACKING_LINK = 'https://www.fedex.com/apps/fedextrack/?action=track&trackingnumber=';
@@ -30,7 +30,7 @@ export class KitRequest {
       json.receiveDate, json.deactivatedDate, json.deactivationReason, json.participant, json.easypostAddressId, json.nameLabel,
       json.kitLabel, json.express, json.labelDate, json.noReturn, json.externalOrderNumber, json.externalOrderStatus,
       json.preferredLanguage, json.receiveDateString, json.hruid, json.gender, json.collectionDate, json.firstName,
-      json.lastName, json.dateOfBirth, json.shortId, json.receivedBy
+      json.lastName, json.dateOfBirth, json.shortId, json.receivedBy, json.sequencingRestriction
     );
   }
 


### PR DESCRIPTION
The previous fix for DDP-7606 was checking the kit being received by BSP. It should check if the sample is marked as `research use only`. I added `sequencingRestriction` to the `KitRequest` class to check the highlight based on that. I also created `isResearchSample` method in `shipping.component.ts` for refactoring purposes
<img width="1680" alt="Screen Shot 2022-09-08 at 2 38 41 PM" src="https://user-images.githubusercontent.com/47120870/189219569-78a11981-8706-4519-b64a-078ff336f21f.png">
