### PR TITLE
[Not merge] Reusable Dashboard Component

### DIFF
--- a/ddp-workspace/projects/ddp-brain/src/app/app-routing.module.ts
+++ b/ddp-workspace/projects/ddp-brain/src/app/app-routing.module.ts
@@ -35,6 +35,7 @@ import { FaqComponent } from './components/faq/faq.component';
 import { DataComponent } from './components/data/data.component';
 import { AboutUsComponent } from './components/about-us/about-us.component';
 import { PrismComponent } from './components/prism/prism.component';
+import { CommonDashboardComponent } from 'projects/ddp-sdk/src/lib/components/dashboard/dashboard.component';
 
 const routes: Routes = [
     {
@@ -137,7 +138,7 @@ const routes: Routes = [
     },
     {
         path: AppRoutes.Dashboard,
-        component: DashboardRedesignedComponent,
+        component: CommonDashboardComponent,
         canActivate: [
             IrbGuard,
             AuthGuard

--- a/ddp-workspace/projects/ddp-pancan/src/app/app-routing.module.ts
+++ b/ddp-workspace/projects/ddp-pancan/src/app/app-routing.module.ts
@@ -24,6 +24,8 @@ import { ScientificResearchComponent } from './components/scientific-research/sc
 import { ColorectalPageComponent } from './components/splash-pages/colorectal-page/colorectal-page.component';
 import { LmsPageComponent } from './components/splash-pages/lms-page/lms-page.component';
 import { ActivityPageComponent } from './components/activity-page/activity-page.component';
+import { CommonDashboardComponent } from 'projects/ddp-sdk/src/lib/components/dashboard/dashboard.component';
+
 
 const routes: Routes = [
     {
@@ -34,7 +36,7 @@ const routes: Routes = [
     },
     {
         path: AppRoutes.Dashboard,
-        component: DashboardRedesignedComponent,
+        component: CommonDashboardComponent,
         canActivate: [
             IrbGuard,
             AuthGuard

--- a/ddp-workspace/projects/ddp-pancan/src/styles/dashboard.scss
+++ b/ddp-workspace/projects/ddp-pancan/src/styles/dashboard.scss
@@ -2,7 +2,7 @@
 
 $border-color: #E2E2E2;
 
-toolkit-dashboard-redesigned .main {
+ddp-common-dashboard .main {
     background-color: $section-grey-background-color;
 
     .dashboard-title-section {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/dashboard/dashboard.component.html
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/dashboard/dashboard.component.html
@@ -1,0 +1,113 @@
+<main class="main">
+    <section class="section" *ngIf="selectedUser$ | async as selectedUser">
+        <ddp-subject-panel [subject]="selectedUser"></ddp-subject-panel>
+    </section>
+    <section class="section dashboard-title-section">
+        <div class="content content_medium content_wide content_dashboard">
+            <div fxLayout="row" fxLayoutAlign="space-between center">
+                <h1 class="dashboard-title-section__title" fxLayoutAlign="center center">
+                    <ng-container *ngIf="useMultiParticipantDashboard; else regularDashboard">
+                        <mat-icon *ngIf="toolkitConfig.showTitleIcon">perm_identity</mat-icon>
+                        <span translate>Toolkit.Dashboard.ParticipantsTitle</span>
+                    </ng-container>
+                    <ng-template #regularDashboard><span translate>Toolkit.Dashboard.Title</span></ng-template>
+                </h1>
+                <div *ngIf="toolkitConfig.useMultiParticipantDashboard">
+                    <button mat-stroked-button
+                            class="add-participant-button button_small"
+                            [disabled]="addParticipantButtonDisabled"
+                            (click)="addParticipant()">
+                        <mat-icon>add</mat-icon>
+                        {{'Toolkit.Dashboard.AddParticipant' | translate}}
+                    </button>
+                </div>
+                <ng-container *ngIf="!toolkitConfig.useMultiParticipantDashboard && toolkitConfig.allowEditUserProfile">
+                    <ng-container *ngTemplateOutlet="editUserButton"></ng-container>
+                </ng-container>
+            </div>
+            <p *ngIf="invitationId" class="invitation-code">
+                <span class="invitation-code__text" translate>Toolkit.Dashboard.Invitation.InvitationCode</span>
+                <span>{{invitationId | invitation}}</span>
+            </p>
+        </div>
+    </section>
+    <section *ngIf="isAdmin && !subjectInfoExists; else dashboard" class="section">
+        <div class="content content_medium">
+            <div class="dashboard-message">
+                <p class="dashboard-message__text" translate>Toolkit.Dashboard.Invitation.Message</p>
+                <a class="button button_primary" [routerLink]="'/' + toolkitConfig.adminDashboardUrl" translate>
+                    Toolkit.Dashboard.Invitation.Button
+                </a>
+            </div>
+        </div>
+    </section>
+    <ng-template #dashboard>
+        <ng-container *ngFor="let announcement of announcementMessages; let i = index">
+            <ng-container *ngIf="announcement.shown">
+                <section class="section">
+                    <div class="content content_tight">
+                        <div class="dashboard-content">
+                            <div class="infobox infobox_dashboard">
+                                <button *ngIf="!announcement.permanent" mat-icon-button (click)="closeMessage(i)" class="close-button">
+                                    <mat-icon class="close">clear</mat-icon>
+                                </button>
+                                <div [innerHTML]="announcement.message"></div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+            </ng-container>
+        </ng-container>
+        <section class="section dashboard-section" [class.full-width]="useMultiParticipantDashboard">
+            <div class="content content_medium">
+                <mat-accordion *ngIf="useMultiParticipantDashboard; else activitiesTable" hideToggle multi>
+                    <mat-expansion-panel *ngFor="let participant of dashboardParticipants$ | async; first as isFirst; trackBy: trackById"
+                                         class="dashboard-panel"
+                                         [expanded]="isFirst"
+                                         (opened)="openParticipantPanel(participant.guid);"
+                                         (closed)="closeParticipantPanel(participant.guid);">
+                        <mat-expansion-panel-header class="dashboard-panel-header">
+                            <mat-panel-title class="dashboard-panel-title">
+                                {{participant.label}}
+                            </mat-panel-title>
+                            <mat-panel-description fxLayoutAlign="end center" class="dashboard-panel-description">
+                                <ng-container *ngIf="toolkitConfig.allowEditUserProfile">
+                                    <ng-container *ngTemplateOutlet="editUserButton; context: { participant: participant }">
+                                    </ng-container>
+                                </ng-container>
+                                <ng-container *ngIf="participantUserGuidToPanelIsOpen.get(participant.guid); else show">
+                                    {{'Toolkit.Dashboard.HidePanel' | translate}}
+                                    <mat-icon>expand_less</mat-icon>
+                                </ng-container>
+                                <ng-template #show>
+                                    {{'Toolkit.Dashboard.ShowPanel' | translate}}
+                                    <mat-icon>expand_more</mat-icon>
+                                </ng-template>
+                            </mat-panel-description>
+                        </mat-expansion-panel-header>
+                        <ng-container *ngTemplateOutlet="activitiesTable; context: {
+                            participantGuid: participant.guid,
+                            activities: participant.activities }">
+                        </ng-container>
+                    </mat-expansion-panel>
+                </mat-accordion>
+                <ng-template #activitiesTable let-participantGuid="participantGuid" let-activities="activities">
+                    <div class="dashboard-content dashboard-content_table">
+                        <ddp-user-activities [studyGuid]="studyGuid"
+                                             [displayedColumns]="toolkitConfig.dashboardDisplayedColumns"
+                                             [dataSource]="activities || (userActivities$ | async)"
+                                             (open)="navigate($event, participantGuid)">
+                        </ddp-user-activities>
+                    </div>
+                </ng-template>
+            </div>
+        </section>
+    </ng-template>
+    <ng-template #editUserButton let-participant="participant">
+        <button mat-button
+                class="edit-user-button"
+                (click)="$event.stopPropagation(); openUserEditDialog(participant)">
+            {{'Toolkit.Dashboard.EditUser' | translate}}
+        </button>
+    </ng-template>
+</main>

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/dashboard/dashboard.component.scss
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/dashboard/dashboard.component.scss
@@ -1,0 +1,6 @@
+.full-width {
+    width: 100%;
+}
+.mat-expansion-panel-header-title {
+    align-items: center;
+}

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/dashboard/dashboard.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/dashboard/dashboard.component.ts
@@ -1,0 +1,29 @@
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from "@angular/core";
+import { DashboardParticipant } from "ddp-sdk";
+import { filter, Observable, Subscription, tap } from "rxjs";
+import {DashboardRedesignedComponent} from '../../../../../toolkit/src/lib/components/dashboard/dashboard-redesigned.component';
+
+@Component({
+    selector: 'ddp-common-dashboard',
+    templateUrl: './dashboard.component.html',
+    styleUrls: ['./dashboard.component.scss'],
+})
+export class CommonDashboardComponent extends DashboardRedesignedComponent implements OnInit, OnDestroy {
+    @Input() participants$: Observable<DashboardParticipant[]> = new Observable<DashboardParticipant[]>();
+    @Output() openEditDialog: EventEmitter<DashboardParticipant>=new EventEmitter<DashboardParticipant>();
+    subscriptions$: Subscription[]=[];
+    
+    ngOnInit() {
+        super.ngOnInit();
+        let data = false;
+        this.subscriptions$.push(this.participants$.pipe(filter(elem=>!!elem && elem.length > 0),tap(item => data=true)).subscribe());
+        data && (this.dashboardParticipants$=this.participants$);
+    }
+    ngOnDestroy() {
+        super.ngOnDestroy();
+        this.subscriptions$.forEach((subscription) => subscription.unsubscribe());
+    }
+    openUserEditDialog(participant){
+        this.toolkitConfig.customOpenUserEditDialog ? this.openEditDialog.emit(participant) : super.openUserEditDialog(participant);
+    }
+}

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/user/activities/userActivities.component.html
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/user/activities/userActivities.component.html
@@ -1,0 +1,115 @@
+<div [hidden]="!statusesLoaded">
+    <mat-table [dataSource]="dataSource" data-ddp-test="activitiesTable" class="ddp-dashboard">
+        <!-- Dynamic Columns-->
+
+        <ng-container *ngFor="let dashboardColumn of toolkitConfig.dashboardDisplayedCustomColumns">
+            <ng-container [matColumnDef]="dashboardColumn.name">
+                <mat-header-cell class="padding-5" *matHeaderCellDef [innerHTML]="dashboardColumn.key | translate">
+                </mat-header-cell>
+                <ng-container [ngSwitch]="dashboardColumn.cellType">
+                    <ng-container *ngSwitchCase="'form'">
+                        <mat-cell *matCellDef="let element">
+                            <ng-container *ngTemplateOutlet="formCell;context: { element: element }">
+                            </ng-container>
+                        </mat-cell>
+                    </ng-container>
+                    <ng-container *ngSwitchCase="'date'">
+                        <mat-cell *matCellDef="let element" class="padding-5"
+                            [attr.data-ddp-test]="'activityDate::' + element.createdAt">
+                            <ng-container *ngTemplateOutlet="dateCell; context:{element:element}"></ng-container>
+                        </mat-cell>
+                    </ng-container>
+                    <ng-container *ngSwitchCase="'description'">
+                        <mat-cell *matCellDef="let element" class="padding-5"
+                            [attr.data-ddp-test]="'activitySummary::' + element.instanceGuid">
+                            <ng-container *ngTemplateOutlet="descriptionCell; context: {element:element}">
+                            </ng-container>
+                        </mat-cell>
+                    </ng-container>
+                    <ng-container *ngSwitchCase="'status'">
+                        <mat-cell *matCellDef="let element" class="padding-5"
+                            [attr.data-ddp-test]="'activityStatus::' + element.instanceGuid">
+                            <ng-container *ngTemplateOutlet="statusCell; context:{element:element}"></ng-container>
+                        </mat-cell>
+                    </ng-container>
+                    <ng-container *ngSwitchCase="'action'">
+                        <mat-cell *matCellDef="let element"
+                            [attr.data-ddp-test]="'activityActions::' + element.readonly">
+                           <ng-container *ngTemplateOutlet="actionCell; context:{element:element}"></ng-container>
+                        </mat-cell>
+                    </ng-container>
+                </ng-container>
+            </ng-container>
+        </ng-container>
+
+
+        <!-- Name Cell -->
+        <ng-template #formCell let-element="element">
+            <span class="dashboard-mobile-label" [innerHTML]="'SDK.UserActivities.ActivityName' | translate"></span>
+            <mat-icon *ngIf="element.isHidden" class="dashboard-hidden-icon"
+                matTooltip="{{ 'SDK.UserActivities.HiddenTooltip' | translate }}">
+                visibility_off
+            </mat-icon>
+            <button class="dashboard-activity-button Link"
+                [attr.data-ddp-test]="'activityName::' + element.instanceGuid"
+                (click)="openActivity(element.instanceGuid, element.activityCode)">
+                {{ element.activityName }}
+            </button>
+
+        </ng-template>
+
+        <!-- Summary Cell -->
+        <ng-template #descriptionCell let-element="element">
+            <span class="dashboard-mobile-label" [innerHTML]="'SDK.UserActivities.Summary' | translate"></span>
+            {{ element.activitySummary }}
+        </ng-template>
+
+        <!-- Date Cell -->
+        <ng-template #dateCell let-element="element">
+            <span class="dashboard-mobile-label" [innerHTML]="'SDK.UserActivities.ActivityDate' | translate"></span>
+            {{ element.createdAt | date: 'MM/dd/yyyy' }}
+        </ng-template>
+
+        <!-- Status Cell -->
+        <ng-template #statusCell let-element="element">
+                <span class="dashboard-mobile-label"
+                    [innerHTML]="'SDK.UserActivities.ActivityStatus' | translate"></span>
+                <div class="dashboard-status-container"
+                    [ngClass]="{'dashboard-status-container_summary': showSummary(element)}">
+                    <ng-container *ngIf="element.icon">
+                        <img class="dashboard-status-container__img"
+                            [attr.src]="domSanitizationService.bypassSecurityTrustUrl('data:image/svg+xml;base64,' + element.icon)"
+                            alt="">
+                    </ng-container>
+                    <ng-container *ngIf="showQuestionCount(element)">
+                        {{ 'SDK.UserActivities.ActivityQuestionCount' | translate: { 'questionsAnswered':
+                        element.numQuestionsAnswered, 'questionTotal': element.numQuestions } }}
+                    </ng-container>
+                    <ng-container *ngIf="showSummary(element)">
+                        {{ element.activitySummary }}
+                    </ng-container>
+                    <ng-container *ngIf="!showQuestionCount(element) && !showSummary(element)">
+                        {{ getState(element.statusCode) }}
+                    </ng-container>
+                </div>
+        </ng-template>
+
+        <!-- Actions Cell -->
+        <ng-template #actionCell let-element="element">
+                <span class="dashboard-mobile-label"
+                    [innerHTML]="'SDK.UserActivities.ActivityActions' | translate"></span>
+                <button *ngIf="!element.readonly" class="ButtonFilled Button--cell button button_small button_primary"
+                    (click)="openActivity(element.instanceGuid, element.activityCode)"
+                    [innerHTML]="getButtonTranslate(element) | translate">
+                </button>
+                <button *ngIf="element.readonly"
+                    class="ButtonBordered ButtonBordered--orange Button--cell button button_small button_secondary"
+                    (click)="openActivity(element.instanceGuid, element.activityCode)"
+                    [innerHTML]="'SDK.ReviewButton' | translate">
+                </button>
+        </ng-template>
+
+        <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
+        <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
+    </mat-table>
+</div>

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/user/activities/userActivities.component.scss
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/user/activities/userActivities.component.scss
@@ -1,0 +1,73 @@
+.mat-row {
+    min-height: auto;
+    padding: 5px 0;
+}
+
+.mat-cell,
+.mat-header-cell,
+.dashboard-mobile-label {
+    font-size: 0.9rem;
+}
+
+.mat-column-summary {
+    flex: 0 0 35%;
+}
+
+.mat-cell {
+    display: flex;
+    align-items: center;
+    overflow: unset;
+    min-height: auto;
+}
+
+.dashboard-mobile-label {
+    display: none;
+}
+
+.dashboard-status-container {
+    display: flex;
+    align-items: center;
+}
+
+.dashboard-status-container__img {
+    height: 36px;
+    width: 36px;
+}
+
+.dashboard-hidden-icon {
+    padding-right: 5px;
+}
+
+.padding-5 {
+    padding: 0 5px 0 0;
+}
+
+@media(max-width: 650px) {
+    .mat-cell {
+        align-items: flex-start;
+        padding: 0 0 12px 0;
+    }
+
+    .mat-header-row {
+        display: none;
+    }
+
+    .mat-column-status {
+        align-items: center;
+    }
+
+    .mat-row {
+        flex-direction: column;
+        align-items: flex-start;
+        padding: 12px 0 0 0;
+    }
+
+    .mat-row::after {
+        display: none;
+    }
+
+    .dashboard-mobile-label {
+        min-width: 75px;
+        display: inline-block;
+    }
+}

--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/user/activities/userActivities.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/user/activities/userActivities.component.ts
@@ -22,180 +22,12 @@ import { ActivityInstance } from '../../../models/activityInstance';
 import { ConfigurationService } from '../../../services/configuration.service';
 import { BehaviorSubject, Subscription, of } from 'rxjs';
 import { take } from 'rxjs/operators';
+import { ToolkitConfigurationService } from 'projects/toolkit/src/lib/services/toolkitConfiguration.service';
 
 @Component({
     selector: 'ddp-user-activities',
-    template: `
-        <div [hidden]="!statusesLoaded">
-            <mat-table [dataSource]="dataSource" data-ddp-test="activitiesTable" class="ddp-dashboard">
-                <!-- Name Column -->
-                <ng-container matColumnDef="name">
-                    <mat-header-cell class="padding-5" *matHeaderCellDef [innerHTML]="'SDK.UserActivities.ActivityName' | translate">
-                    </mat-header-cell>
-                    <mat-cell *matCellDef="let element" class="padding-5">
-                        <span class="dashboard-mobile-label" [innerHTML]="'SDK.UserActivities.ActivityName' | translate"></span>
-                        <mat-icon *ngIf="element.isHidden"
-                                  class="dashboard-hidden-icon"
-                                  matTooltip="{{ 'SDK.UserActivities.HiddenTooltip' | translate }}">
-                            visibility_off
-                        </mat-icon>
-                        <button class="dashboard-activity-button Link"
-                                [attr.data-ddp-test]="'activityName::' + element.instanceGuid"
-                                (click)="openActivity(element.instanceGuid, element.activityCode)">
-                            {{ element.activityName }}
-                        </button>
-                    </mat-cell>
-                </ng-container>
-
-                <!-- Summary Column -->
-                <ng-container matColumnDef="summary">
-                    <mat-header-cell class="padding-5" *matHeaderCellDef [innerHTML]="'SDK.UserActivities.Summary' | translate">
-                    </mat-header-cell>
-                    <mat-cell *matCellDef="let element"
-                              class="padding-5"
-                              [attr.data-ddp-test]="'activitySummary::' + element.instanceGuid" >
-                        <span class="dashboard-mobile-label" [innerHTML]="'SDK.UserActivities.Summary' | translate"></span>
-                        {{ element.activitySummary }}
-                    </mat-cell>
-                </ng-container>
-
-                <!-- Date Column -->
-                <ng-container matColumnDef="date">
-                    <mat-header-cell class="padding-5" *matHeaderCellDef [innerHTML]="'SDK.UserActivities.ActivityDate' | translate">
-                    </mat-header-cell>
-                    <mat-cell *matCellDef="let element"
-                              class="padding-5"
-                              [attr.data-ddp-test]="'activityDate::' + element.createdAt">
-                        <span class="dashboard-mobile-label" [innerHTML]="'SDK.UserActivities.ActivityDate' | translate"></span>
-                        {{ element.createdAt | date: 'MM/dd/yyyy' }}
-                    </mat-cell>
-                </ng-container>
-
-                <!-- Status Column -->
-                <ng-container matColumnDef="status">
-                    <mat-header-cell class="padding-5" *matHeaderCellDef [innerHTML]="'SDK.UserActivities.ActivityStatus' | translate">
-                    </mat-header-cell>
-                    <mat-cell *matCellDef="let element"
-                              class="padding-5"
-                              [attr.data-ddp-test]="'activityStatus::' + element.instanceGuid">
-                        <span class="dashboard-mobile-label" [innerHTML]="'SDK.UserActivities.ActivityStatus' | translate"></span>
-                        <div class="dashboard-status-container" [ngClass]="{'dashboard-status-container_summary': showSummary(element)}">
-                            <ng-container *ngIf="element.icon">
-                                <img class="dashboard-status-container__img"
-                                     [attr.src]="domSanitizationService.bypassSecurityTrustUrl('data:image/svg+xml;base64,' + element.icon)"
-                                     alt="">
-                            </ng-container>
-                            <ng-container *ngIf="showQuestionCount(element)">
-                                {{ 'SDK.UserActivities.ActivityQuestionCount' | translate: { 'questionsAnswered': element.numQuestionsAnswered, 'questionTotal': element.numQuestions } }}
-                            </ng-container>
-                            <ng-container *ngIf="showSummary(element)">
-                                {{ element.activitySummary }}
-                            </ng-container>
-                            <ng-container *ngIf="!showQuestionCount(element) && !showSummary(element)">
-                                {{ getState(element.statusCode) }}
-                            </ng-container>
-                        </div>
-                    </mat-cell>
-                </ng-container>
-
-                <!-- Actions Column -->
-                <ng-container matColumnDef="actions">
-                    <mat-header-cell *matHeaderCellDef [innerHTML]="'SDK.UserActivities.ActivityActions' | translate"></mat-header-cell>
-                    <mat-cell *matCellDef="let element"
-                              [attr.data-ddp-test]="'activityActions::' + element.readonly">
-                        <span class="dashboard-mobile-label" [innerHTML]="'SDK.UserActivities.ActivityActions' | translate"></span>
-                        <button *ngIf="!element.readonly"
-                                class="ButtonFilled Button--cell button button_small button_primary"
-                                (click)="openActivity(element.instanceGuid, element.activityCode)"
-                                [innerHTML]="getButtonTranslate(element) | translate">
-                        </button>
-                        <button *ngIf="element.readonly"
-                                class="ButtonBordered ButtonBordered--orange Button--cell button button_small button_secondary"
-                                (click)="openActivity(element.instanceGuid, element.activityCode)"
-                                [innerHTML]="'SDK.ReviewButton' | translate">
-                        </button>
-                    </mat-cell>
-                </ng-container>
-
-                <mat-header-row *matHeaderRowDef="displayedColumns"></mat-header-row>
-                <mat-row *matRowDef="let row; columns: displayedColumns;"></mat-row>
-            </mat-table>
-        </div>`,
-    styles: [`
-        .mat-row {
-            min-height: auto;
-            padding: 5px 0;
-        }
-
-        .mat-cell,
-        .mat-header-cell,
-        .dashboard-mobile-label {
-            font-size: 0.9rem;
-        }
-
-        .mat-column-summary {
-            flex: 0 0 35%;
-        }
-
-        .mat-cell {
-            display: flex;
-            align-items: center;
-            overflow: unset;
-            min-height: auto;
-        }
-
-        .dashboard-mobile-label {
-            display: none;
-        }
-
-        .dashboard-status-container {
-            display: flex;
-            align-items: center;
-        }
-
-        .dashboard-status-container__img {
-            height: 36px;
-            width: 36px;
-        }
-
-        .dashboard-hidden-icon {
-            padding-right: 5px;
-        }
-
-        .padding-5 {
-            padding: 0 5px 0 0;
-        }
-
-        @media(max-width: 650px) {
-            .mat-cell {
-                align-items: flex-start;
-                padding: 0 0 12px 0;
-            }
-
-            .mat-header-row {
-                display: none;
-            }
-
-            .mat-column-status {
-                align-items: center;
-            }
-
-            .mat-row {
-                flex-direction: column;
-                align-items: flex-start;
-                padding: 12px 0 0 0;
-            }
-
-            .mat-row::after {
-                display: none;
-            }
-
-            .dashboard-mobile-label {
-                min-width: 75px;
-                display: inline-block;
-            }
-        }
-    `]
+    templateUrl: './userActivities.component.html',
+    styleUrls: ['./userActivities.component.scss']
 })
 export class UserActivitiesComponent implements OnInit, OnDestroy, OnChanges, AfterContentInit {
     @Input() studyGuid: string;
@@ -215,7 +47,8 @@ export class UserActivitiesComponent implements OnInit, OnDestroy, OnChanges, Af
         private activityServiceAgent: ActivityServiceAgent,
         private analytics: AnalyticsEventsService,
         @Inject('ddp.config') private config: ConfigurationService,
-        public domSanitizationService: DomSanitizer) {}
+        public domSanitizationService: DomSanitizer,
+        @Inject('toolkit.toolkitConfig') public toolkitConfig: ToolkitConfigurationService) {}
 
     public ngOnInit(): void {
         this.statusesLoadingAnchor = this.statusesServiceAgent.getStatuses()

--- a/ddp-workspace/projects/ddp-sdk/src/lib/ddp.module.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/ddp.module.ts
@@ -223,6 +223,7 @@ import {
 } from './components/activityForm/answers/activity-equation-answer/activityEquationAnswer.component';
 import { TabularBlockComponent } from './components/activityForm/activity-blocks/tabularBlock/tabularBlock.component';
 import { FlexLayoutModule } from '@angular/flex-layout';
+import { CommonDashboardComponent } from './components/dashboard/dashboard.component';
 
 export function jwtOptionsFactory(sessionService: SessionMementoService): object {
     const getter: FuncType<string> = () => sessionService.token;
@@ -444,7 +445,8 @@ export function createTranslateLoader(http: HttpClient): TranslateHttpLoader {
         DropFileToUploadDirective,
         ActivityPicklistRemoteAutoCompleteOptionsComponent,
         ActivityEquationAnswerComponent,
-        TabularBlockComponent
+        TabularBlockComponent,
+        CommonDashboardComponent
     ],
     exports: [
         NetworkSnifferComponent,
@@ -521,7 +523,8 @@ export function createTranslateLoader(http: HttpClient): TranslateHttpLoader {
         ProgressIndicatorComponent,
         ActivityBlockComponent,
         ConfirmDialogComponent,
-        TabularBlockComponent
+        TabularBlockComponent,
+        CommonDashboardComponent
     ]
 })
 export class DdpModule {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/dashboardColumns.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/dashboardColumns.ts
@@ -1,1 +1,7 @@
 export type DashboardColumns = 'name' | 'summary' | 'date' | 'status' | 'actions';
+export type cellTypes = 'form' | 'description' | 'date' | 'status' | 'action';
+export interface CustomDashboardColumns {
+    name: String;
+    key: String;
+    cellType: cellTypes;
+}

--- a/ddp-workspace/projects/ddp-sdk/src/lib/models/participant.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/models/participant.ts
@@ -1,3 +1,4 @@
+import { ActivityInstance } from './activityInstance';
 import { UserProfile } from './userProfile';
 
 export interface Participant {
@@ -5,3 +6,11 @@ export interface Participant {
     userGuid: string;
     userProfile: UserProfile;
 }
+export interface DashboardParticipant {
+    firstName?: string;
+    lastName?: string;
+    guid: string;
+    activities: ActivityInstance[];
+    isOperator?: boolean;
+    label?: string;
+  }

--- a/ddp-workspace/projects/toolkit/src/lib/components/dashboard/dashboard-redesigned.component.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/components/dashboard/dashboard-redesigned.component.ts
@@ -17,18 +17,13 @@ import {
     UserManagementServiceAgent,
     LoggingService,
     UserPreferencesComponent,
-    Participant
+    Participant,
+    DashboardParticipant
 } from 'ddp-sdk';
 import { map, take, filter, switchMap, tap, mergeMap, finalize, catchError, mapTo } from 'rxjs/operators';
 import { combineLatest, forkJoin, Observable, of, Subject } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
 import { MatDialog } from '@angular/material/dialog';
-
-interface DashboardParticipant {
-    userGuid: string;
-    label: string;
-    activities: ActivityInstance[];
-}
 
 @Component({
     selector: 'toolkit-dashboard-redesigned',
@@ -233,7 +228,7 @@ export class DashboardRedesignedComponent extends DashboardComponent implements 
             .pipe(
                 switchMap(userActivities => userActivities.length ? this.userProfileService.profile : of(null)),
                 switchMap(operatorParticipant => operatorParticipant ? this.userActivities$.pipe(take(1), map((activities) => ({
-                        userGuid: this.session.session.userGuid,
+                        guid: this.session.session.userGuid,
                         label: (operatorParticipant.profile.firstName || operatorParticipant.profile.lastName)
                             ? `${operatorParticipant.profile.firstName} ${operatorParticipant.profile.lastName}`
                             : this.translate.instant('Toolkit.Dashboard.UserLabel'),
@@ -292,7 +287,7 @@ export class DashboardRedesignedComponent extends DashboardComponent implements 
         }
 
         const deleteUserObservableList: Observable<void>[] = accidentalParticipant
-            .map((participant) => this.deleteUser(participant.userGuid));
+            .map((participant) => this.deleteUser(participant.guid));
 
         return forkJoin(deleteUserObservableList)
             // return filtered participants once all deleting requests were done
@@ -314,12 +309,12 @@ export class DashboardRedesignedComponent extends DashboardComponent implements 
     }
 
     public trackById(_, participant: DashboardParticipant): string {
-        return participant.userGuid;
+        return participant.guid;
     }
 
     public openUserEditDialog(participant?: DashboardParticipant): void {
         if (participant) {
-            this.session.setParticipant(participant.userGuid);
+            this.session.setParticipant(participant.guid);
         }
         const dialogRef = this.dialog.open(UserPreferencesComponent, {
             width: '650px',

--- a/ddp-workspace/projects/toolkit/src/lib/services/toolkitConfiguration.service.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/services/toolkitConfiguration.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { DashboardColumns } from 'ddp-sdk';
+import { CustomDashboardColumns, DashboardColumns } from 'ddp-sdk';
 import { Cookies } from '../models/cookies/cookies';
 
 @Injectable()
@@ -79,8 +79,40 @@ export class ToolkitConfigurationService {
     showInfoForPhysicians: boolean;
     showBlog: boolean;
     agreeConsent: boolean;
+    // Dashboard layout settings
+    showTitleIcon:boolean;
     dashboardDisplayedColumns: Array<DashboardColumns> = ['name', 'summary', 'date', 'status', 'actions'];
+    dashboardDisplayedCustomColumns: Array<CustomDashboardColumns> = [{
+        name: 'name',
+        key: 'SDK.UserActivities.ActivityName',
+        cellType: 'form'
+    },
+    {
+        name: 'summary',
+        key: 'SDK.UserActivities.Summary',
+        cellType: 'description'
 
+    },
+    {
+        name: 'date',
+        key: 'SDK.UserActivities.ActivityDate',
+        cellType: 'date'
+
+    },
+    {
+        name: 'status',
+        key: 'SDK.UserActivities.ActivityStatus',
+        cellType: 'status'
+
+    },
+    {
+        name: 'actions',
+        key: 'SDK.UserActivities.ActivityActions',
+        cellType: 'action'
+
+    }];
+    // Dashboard custom events
+    customOpenUserEditDialog:boolean;
     // Keys and tokens
     recaptchaSiteClientKey: string;
     lightswitchInstagramWidgetId: string;


### PR DESCRIPTION
Some changes for creating new reusable dashboard component with some features to be customizable:

* Number of columns to be displayed -> we can use 'dashboardDisplayedCustomColumns' property from toolkitConfig to customize columns
* Announcements, titles and labels to be customized (take a look at 'CommonDashboardComponent')
* If necessary, a list of participants can be supplied as an @input.*
*  There are still some behaviors that can potentially be customized like different actions on buttons, links etc..
* Feel free to add comments or advice.