### PR TITLE
DSM---Dashboard---PieChart---textInside

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dashboard-statistics.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dashboard-statistics.service.ts
@@ -294,7 +294,7 @@ export class DashboardStatisticsService {
           size: 13
         },
 
-        textposition: 'outside',
+        textposition: 'inside',
       }
     ];
 


### PR DESCRIPTION
Moving text position into chart sections, in order to get rid of 0% in case of no data.

<img width="478" alt="Screenshot 2022-09-19 at 10 51 43" src="https://user-images.githubusercontent.com/77500504/190963530-86581a44-95f4-47b0-9473-23c5c79512fb.png">
