### PR TITLE
*DON'T MERGE!*  [SINGULAR] DDP-8828: Implement a feature flag as to show/hide a captcha

### DIFF
--- a/ddp-workspace/projects/ddp-singular/src/app/components/activity/activity.component.html
+++ b/ddp-workspace/projects/ddp-singular/src/app/components/activity/activity.component.html
@@ -84,9 +84,12 @@
         <span class="last-updated">{{ model.lastUpdatedText }} </span>
       </section>
 
-      <section *ngIf="isPrequal" class="section section--captcha">
-        <re-captcha [siteKey]="captchaSiteKey" (resolved)="onCaptchaResolve()"></re-captcha>
-      </section>
+      <!-- we can hide captcha for testing purposes by the feature flag -->
+      <ng-container *ngIf="featureFlag_DDP_8828 | async">
+        <section *ngIf="isPrequal" class="section section--captcha">
+          <re-captcha [siteKey]="captchaSiteKey" (resolved)="onCaptchaResolve()"></re-captcha>
+        </section>
+      </ng-container>
     </div>
 
     <section class="section section--buttons">
@@ -94,7 +97,7 @@
         <button
           #submitButton
           class="button button--primary pull-right"
-          [disabled]="dataEntryDisabled || (isPageBusy | async) || !isCaptchaResolved"
+          [disabled]="dataEntryDisabled || (isPageBusy | async) || ( (featureFlag_DDP_8828 | async) && !isCaptchaResolved )"
           (click)="flush()"
           (mouseenter)="mouseEnterOnSubmit()"
         >

--- a/ddp-workspace/projects/ddp-singular/src/app/components/activity/activity.component.ts
+++ b/ddp-workspace/projects/ddp-singular/src/app/components/activity/activity.component.ts
@@ -1,8 +1,13 @@
 import { Component, Input } from '@angular/core';
+import { map } from 'rxjs/operators';
+
+import { ActivityRedesignedComponent, SubmissionManager, SubmitAnnouncementService } from 'ddp-sdk';
 import { Route } from '../../constants/route';
 import { ActivityCode } from '../../constants/activity-code';
 import { isConsentActivity, isMedicalRecordReleaseActivity } from '../../utils';
-import { ActivityRedesignedComponent, SubmissionManager, SubmitAnnouncementService } from 'ddp-sdk';
+import { getFeatureFlags$ } from '../../config/feature-flags/feature-flags-setup';
+import { FeatureFlags } from '../../config/feature-flags/feature-flags';
+import { FeatureFlagsEnum } from '../../config/feature-flags/feature-flags.enum';
 
 declare const DDP_ENV: Record<string, any>;
 
@@ -16,6 +21,10 @@ export class ActivityComponent extends ActivityRedesignedComponent {
   @Input('isLastOfMultipleActivities') isLastOfActivities = false;
   Route = Route;
   isCaptchaResolved = false;
+
+  readonly featureFlag_DDP_8828 = getFeatureFlags$().pipe(
+    map((flags: FeatureFlags) => flags[FeatureFlagsEnum.ShowDDP8828Captcha])
+  );
 
   get isPrequal(): boolean {
     return this.model && this.model.activityCode === ActivityCode.Prequal;

--- a/ddp-workspace/projects/ddp-singular/src/app/components/feature-flags-toggle/feature-flags-toggle.component.html
+++ b/ddp-workspace/projects/ddp-singular/src/app/components/feature-flags-toggle/feature-flags-toggle.component.html
@@ -3,6 +3,7 @@
 
   <ng-container *ngFor="let control of (featureFlagsGroup.controls | keyvalue)">
     <mat-slide-toggle color="primary" class="toggle"
+                      [id]="control.key"
                       [formControlName]="control.key">{{control.key}}
     </mat-slide-toggle>
   </ng-container>

--- a/ddp-workspace/projects/ddp-singular/src/app/config/feature-flags/feature-flags-setup.ts
+++ b/ddp-workspace/projects/ddp-singular/src/app/config/feature-flags/feature-flags-setup.ts
@@ -5,7 +5,8 @@ import { FeatureFlagsEnum} from './feature-flags.enum';
 
 const initialFlags: FeatureFlags = {
   [FeatureFlagsEnum.ShowDDP8404HomePageUpdate] : true,
-  [FeatureFlagsEnum.ShowDDP8560DashboardPageUpdate] : true
+  [FeatureFlagsEnum.ShowDDP8560DashboardPageUpdate] : true,
+  [FeatureFlagsEnum.ShowDDP8828Captcha] : true
 };
 
 const featureFlags: BehaviorSubject<FeatureFlags> = new BehaviorSubject(initialFlags);

--- a/ddp-workspace/projects/ddp-singular/src/app/config/feature-flags/feature-flags.enum.ts
+++ b/ddp-workspace/projects/ddp-singular/src/app/config/feature-flags/feature-flags.enum.ts
@@ -1,4 +1,5 @@
 export enum FeatureFlagsEnum {
   ShowDDP8404HomePageUpdate = 'feature DDP-8404 Home Page update',
-  ShowDDP8560DashboardPageUpdate = 'feature DDP-8560 Dashboard Page update'
+  ShowDDP8560DashboardPageUpdate = 'feature DDP-8560 Dashboard Page update',
+  ShowDDP8828Captcha = 'feature DDP-8828 Show captcha'
 }


### PR DESCRIPTION
Implemented a new feature flag for a possibility to show/hide our catcha on **Prequal** form.

By default, the feature flag is true (means the captcha is visible).
We can switch/trigger it manually - press `Ctrl+Alt+7` (Windows) / `Control+Option+7` (MacOS) 
and toggle the feature. 

![captcha1](https://user-images.githubusercontent.com/7396837/191360677-d2c33c06-9cf9-451c-bd2c-1997ce89083b.png)
![captcha2](https://user-images.githubusercontent.com/7396837/191360691-601608e9-f687-4fbf-85fe-36edfff6c478.png)



