### PR TITLE
DSM-Dashboard-counts-into-separate-section

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/ALL-STUDIES/all-studies.module.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/ALL-STUDIES/all-studies.module.ts
@@ -121,6 +121,7 @@ import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 
 import * as PlotlyJS from 'plotly.js-dist-min';
 import { PlotlyModule } from 'angular-plotly.js';
+import {CardComponent} from "../dashboard-statistics/components/card.component";
 
 PlotlyModule.plotlyjs = PlotlyJS;
 
@@ -209,7 +210,8 @@ PlotlyModule.plotlyjs = PlotlyJS;
     SequencingOrderComponent,
     ClinicalPageComponent,
     FileDownloadComponent,
-    DashboardStatisticsComponent
+    DashboardStatisticsComponent,
+    CardComponent
   ],
   imports: [
     CommonModule,

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/ALL-STUDIES/all-studies.module.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/ALL-STUDIES/all-studies.module.ts
@@ -121,7 +121,7 @@ import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 
 import * as PlotlyJS from 'plotly.js-dist-min';
 import { PlotlyModule } from 'angular-plotly.js';
-import {CardComponent} from "../dashboard-statistics/components/card.component";
+import {CardComponent} from '../dashboard-statistics/components/card.component';
 
 PlotlyModule.plotlyjs = PlotlyJS;
 

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/components/card.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/components/card.component.html
@@ -1,0 +1,4 @@
+<main class="card" (click)="onCardClick()">
+  <h1 class="card-count">{{ data.count }}</h1>
+  <p class="card-title">{{ data.title }}</p>
+</main>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/components/card.component.scss
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/components/card.component.scss
@@ -1,0 +1,35 @@
+@import "../../../styles/fonts";
+@import "../../../styles/commonStyles";
+
+.card {
+  @include flexContainer(normal, normal, column);
+  max-width: inherit;
+  min-height: 20.75em;
+  padding: 2.75em 2.5em;
+  box-shadow: rgba(50, 50, 93, 0.25) 0px 2px 5px -1px, rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
+  border-radius: .5em;
+
+  &:hover {
+    background-color: #753BBD;
+    cursor: pointer;
+    h1, p {
+      color: white;
+    }
+
+    p {
+      border-color: white;
+    }
+  }
+
+  &-count {
+    font-family: Montserrat-Bold, sans-serif;
+    font-size: 3em;
+  }
+
+  &-title {
+    border-top: 3px solid #753BBD;
+    font-family: Montserrat-Regular, sans-serif;
+    font-size: 1.5em;
+  }
+
+}

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/components/card.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/components/card.component.ts
@@ -1,5 +1,5 @@
-import {Component, EventEmitter, Input, Output} from "@angular/core";
-import {cardData} from "./cardData.model";
+import {Component, EventEmitter, Input, Output} from '@angular/core';
+import {cardData} from './cardData.model';
 
 @Component({
   selector: 'app-card',

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/components/card.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/components/card.component.ts
@@ -1,0 +1,17 @@
+import {Component, EventEmitter, Input, Output} from "@angular/core";
+import {cardData} from "./cardData.model";
+
+@Component({
+  selector: 'app-card',
+  templateUrl: 'card.component.html',
+  styleUrls: ['card.component.scss']
+})
+
+export class CardComponent {
+  @Input() data: cardData;
+  @Output() cardClicked = new EventEmitter();
+
+  public onCardClick(): void {
+    this.cardClicked.emit(this.data);
+  }
+}

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/components/cardData.model.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/components/cardData.model.ts
@@ -1,0 +1,6 @@
+export interface cardData {
+  count: number;
+  type: string;
+  title: string;
+  size: string;
+}

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.html
@@ -1,9 +1,11 @@
 <h1>
   Statistics Dashboard
 </h1>
+
 <div class="dashboard">
-  <ng-container  *ngTemplateOutlet="charts, context: {
-    charts: Charts | async
+  <ng-container *ngTemplateOutlet="charts, context: {
+    charts: Charts | async,
+    counts: Counts | async
   }">
   </ng-container>
 </div>
@@ -12,20 +14,38 @@
   <mat-spinner></mat-spinner>
 </div>
 
-<ng-template let-Charts="charts" #charts>
+<ng-template let-Charts="charts" let-Counts="counts" #charts>
 
-  <ng-container *ngIf="Charts?.length < 1 && !loading; else chartsDisplay">
-    <p class="dashboard-noCharts">There are not available charts for this study</p>
+  <ng-container *ngIf="Charts?.length < 1 && Counts?.length < 1; else statistics">
+    <p *ngIf="!loading" class="dashboard-noCharts">There are not available charts and counts for this study</p>
   </ng-container>
 
-  <ng-template #chartsDisplay>
-    <section *ngFor="let chart of Charts" class="dashboard-chart" [ngClass]="chart.size">
-      <plotly-plot
-        [data]="chart.data"
-        [layout]="chart.layout"
-        [config]="getConfiguration"
-      ></plotly-plot>
-    </section>
+  <ng-template #statistics>
+
+    <div *ngIf="Counts.length > 1" class="dashboard-navigation">
+      <p (click)="scrollToVew(chartsView)" class="dashboard-navigation-chart">Charts</p>
+      <span class="dashboard-navigation-border"></span>
+      <p (click)="scrollToVew(countsView)" class="dashboard-navigation-count">Counts</p>
+    </div>
+
+
+    <div class="dashboard-charts" #chartsView>
+      <section *ngFor="let chart of Charts" class="dashboard-charts-chart" [ngClass]="[chart.size, chart.type]">
+        <plotly-plot
+          [data]="chart.data"
+          [layout]="chart.layout"
+          [config]="getConfiguration"
+        ></plotly-plot>
+      </section>
+    </div>
+
+    <hr>
+    <h1 *ngIf="Counts.length > 1">Counts</h1>
+    <div class="dashboard-counts" #countsView>
+      <app-card *ngFor="let count of Counts" [data]="count"></app-card>
+    </div>
+
   </ng-template>
+
 
 </ng-template>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.scss
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.scss
@@ -1,5 +1,11 @@
 @import "../../styles/fonts";
 @import "../../styles/commonStyles";
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@600;700&display=swap');
+
+p,h1,h2 {
+  margin: 0;
+  padding: 0;
+}
 
 h1 {
   font-family: Montserrat-Bold, sans-serif;
@@ -10,26 +16,93 @@ h1 {
   margin: 0 auto;
 }
 .dashboard {
-  @include flexContainer(normal, space-around);
-  width: 100%;
-  height: 100%;
-  flex-wrap: wrap;
   &-noCharts {
+    text-align: center;
     margin-top: 100px;
     font-family: Montserrat-Regular, sans-serif;
   }
-  &-chart {
-    background-color: #FFFFFF;
-    box-shadow: rgba(0, 0, 0, 0.12) 0px 1px 3px, rgba(0, 0, 0, 0.24) 0px 1px 2px;
-    overflow: auto;
-    margin: 24px 0 0 0;
-    padding: 12px;
+  &-charts {
+    @include flexContainer(normal, space-between);
+    width: 100%;
+    height: 100%;
+    flex-wrap: wrap;
+    &-chart {
+      background-color: #FFFFFF;
+      box-shadow: rgba(0, 0, 0, 0.12) 0px 1px 3px, rgba(0, 0, 0, 0.24) 0px 1px 2px;
+      overflow: auto;
+      margin: 24px 0 0 0;
+      padding: 12px;
 
-    &.LARGE, &.MEDIUM {
-      width: 100%;
+      &.DONUT_CHART {
+        @include flexContainer(normal, center);
+      }
+      &.LARGE, &.MEDIUM {
+        width: 100%;
+      }
+      &.SMALL {
+        width: 49%;
+      }
     }
-    &.SMALL {
-      width: 49%;
+  }
+
+  &-counts {
+    @include flexContainer(normal, space-between);
+    flex-wrap: wrap;
+    margin-top: 40px;
+    app-card {
+      width: 24%;
+    }
+  }
+
+  &-navigation {
+    @include flexContainer(center, space-evenly);
+    font-family: Montserrat-SemiBold, sans-serif;
+    font-size: 1.5em;
+    border-radius: .5em;
+    height: 3em;
+    width: 20em;
+    margin: 3em auto;
+    box-shadow: rgba(60, 64, 67, 0.3) 0px 1px 2px 0px, rgba(60, 64, 67, 0.15) 0px 1px 3px 1px;
+    &:hover {
+      cursor: pointer;
+    }
+    &-chart {
+      @include flexContainer(center, center);
+      padding: 10px;
+      color: white;
+      background-color: #749DC5;
+      height: 100%;
+      width: 100%;
+      border-top-left-radius: .5em;
+      border-bottom-left-radius: .5em;
+      font-family: inherit;
+      font-size: inherit;
+      &:hover  {
+        background-color: white;
+        color: #749DC5;
+      }
+    }
+    &-count {
+      @include flexContainer(center, center);
+      color: #753BBD;
+      padding: 10px;
+      font-family: inherit;
+      font-size: inherit;
+      height: 100%;
+      width: 100%;
+      border-top-right-radius: .5em;
+      border-bottom-right-radius: .5em;
+
+      &:hover  {
+        background-color: #753BBD;
+        color: white;
+      }
+    }
+
+    &-border {
+      border: 2px solid white;
+      width: 2px;
+      height: 100%;
     }
   }
 

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.ts
@@ -3,7 +3,7 @@ import {Observable, tap} from 'rxjs';
 import {DashboardStatisticsService} from '../services/dashboard-statistics.service';
 import {RoleService} from '../services/role.service';
 import {finalize} from 'rxjs/operators';
-import {dashboardType} from "../enums/dashboard.enums";
+import {dashboardType} from '../enums/dashboard.enums';
 
 @Component({
   selector: 'app-dashboard-statistics',
@@ -35,9 +35,9 @@ export class DashboardStatisticsComponent implements OnInit {
 
   public scrollToVew(divElement: HTMLDivElement): void {
     divElement.scrollIntoView({
-      behavior: "smooth",
-      block: "start",
-      inline: "nearest"
-    })
+      behavior: 'smooth',
+      block: 'start',
+      inline: 'nearest'
+    });
   }
 }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.ts
@@ -1,8 +1,9 @@
-import {Component, OnInit} from '@angular/core';
-import {Observable} from 'rxjs';
+import {Component, ElementRef, OnInit} from '@angular/core';
+import {Observable, tap} from 'rxjs';
 import {DashboardStatisticsService} from '../services/dashboard-statistics.service';
 import {RoleService} from '../services/role.service';
 import {finalize} from 'rxjs/operators';
+import {dashboardType} from "../enums/dashboard.enums";
 
 @Component({
   selector: 'app-dashboard-statistics',
@@ -12,6 +13,7 @@ import {finalize} from 'rxjs/operators';
 
 export class DashboardStatisticsComponent implements OnInit {
   Charts: Observable<any>;
+  Counts: Observable<any>;
   hasRequiredRole;
   loading = true;
 
@@ -21,6 +23,7 @@ export class DashboardStatisticsComponent implements OnInit {
   ngOnInit(): void {
     this.hasRequiredRole = this.roleService.allowedToViewEELData();
     this.Charts = this.dashboardStatisticsService.ChartFactory().pipe(finalize(() => this.loading = false));
+    this.Counts = this.dashboardStatisticsService.Counts;
   }
 
   get getConfiguration(): any {
@@ -28,5 +31,13 @@ export class DashboardStatisticsComponent implements OnInit {
       responsive: true,
       displaylogo: false
     };
+  }
+
+  public scrollToVew(divElement: HTMLDivElement): void {
+    divElement.scrollIntoView({
+      behavior: "smooth",
+      block: "start",
+      inline: "nearest"
+    })
   }
 }


### PR DESCRIPTION
### **Changes list:**

- Counts statistics moved into a separate section;
- On the top was added small navigation, in order to be able to fast scroll to the "Counts" section;

**Counts:**
<img width="1688" alt="Screenshot 2022-09-26 at 12 05 07" src="https://user-images.githubusercontent.com/77500504/192226148-84d4a874-ef21-4c08-8e3d-c4f760f15709.png">

**Navigation:**
<img width="1668" alt="Screenshot 2022-09-26 at 12 04 59" src="https://user-images.githubusercontent.com/77500504/192226170-0888a588-dadc-4e87-a768-c44ba2e51f7c.png">

