### PR TITLE
Dsm charts better error handling

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.html
@@ -46,8 +46,8 @@
 
     <ng-template #errorText>
       <p class="errorText">An error occurred while fetching dashboard data.
-        <br/>Error message: <span>{{ Error.statusText }}</span>
-        <br/>Error status code: <span>{{ Error.status }}</span></p>
+        <br/>Message: <span>{{ Error.statusText }}</span>
+        <br/>Status code: <span>{{ Error.status }}</span></p>
     </ng-template>
 
   </div>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.html
@@ -19,7 +19,7 @@
   <div class="dashboard-chartsAndCounts" *ngIf="!loading">
 
 
-      <mat-tab-group mat-align-tabs="center" *ngIf="Charts.length > 0 || Counts.length > 0; else noCharts">
+      <mat-tab-group mat-align-tabs="center" *ngIf="Charts?.length > 0 || Counts?.length > 0; else noCharts">
         <mat-tab>
           <ng-template mat-tab-label>
             <mat-icon class="example-tab-icon">bar_chart</mat-icon>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.html
@@ -47,7 +47,7 @@
     <ng-template #errorText>
       <p class="errorText">An error occurred while fetching dashboard data.
         <br/>Error message: <span>{{ Error.statusText }}</span>
-        <br/>Error status: <span>{{ Error.status }}</span></p>
+        <br/>Error status code: <span>{{ Error.status }}</span></p>
     </ng-template>
 
   </div>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.html
@@ -5,7 +5,8 @@
 <div class="dashboard">
   <ng-container *ngTemplateOutlet="charts, context: {
     charts: Charts | async,
-    counts: Counts | async
+    counts: Counts | async,
+    error: errorMessage | async
   }">
   </ng-container>
 </div>
@@ -14,32 +15,39 @@
   <mat-spinner></mat-spinner>
 </div>
 
-<ng-template let-Charts="charts" let-Counts="counts" #charts>
+<ng-template let-Charts="charts" let-Error="error" let-Counts="counts" #charts>
 
   <div class="dashboard-chartsAndCounts" *ngIf="!loading">
 
+  <ng-container *ngIf="!Error; else errorText">
+    <mat-tab-group mat-align-tabs="center" *ngIf="Charts?.length > 0 || Counts?.length > 0; else noCharts">
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="example-tab-icon">bar_chart</mat-icon>
+          Charts
+        </ng-template>
+        <app-plotly-charts [chartData]="Charts" [config]="getConfiguration"></app-plotly-charts>
+      </mat-tab>
 
-      <mat-tab-group mat-align-tabs="center" *ngIf="Charts?.length > 0 || Counts?.length > 0; else noCharts">
-        <mat-tab>
-          <ng-template mat-tab-label>
-            <mat-icon class="example-tab-icon">bar_chart</mat-icon>
-            Charts
-          </ng-template>
-          <app-plotly-charts [chartData]="Charts" [config]="getConfiguration"></app-plotly-charts>
-        </mat-tab>
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon class="example-tab-icon">score</mat-icon>
+          Counts
+        </ng-template>
+        <app-counts [countsData]="Counts"></app-counts>
+      </mat-tab>
+    </mat-tab-group>
+  </ng-container>
 
-        <mat-tab>
-          <ng-template mat-tab-label>
-            <mat-icon class="example-tab-icon">score</mat-icon>
-            Counts
-          </ng-template>
-          <app-counts [countsData]="Counts"></app-counts>
-        </mat-tab>
-
-      </mat-tab-group>
 
     <ng-template #noCharts>
       <p class="noCharts">There are not available charts and counts for this study</p>
+    </ng-template>
+
+    <ng-template #errorText>
+      <p class="errorText">An error occurred while fetching dashboard data.
+        <br/>Error message: <span>{{ Error.statusText }}</span>
+        <br/>Error status: <span>{{ Error.status }}</span></p>
     </ng-template>
 
   </div>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.scss
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.scss
@@ -21,6 +21,15 @@ h1 {
   font-family: Montserrat-Regular, sans-serif;
 }
 
+.errorText {
+  @extend .noCharts;
+  color: red;
+  font-size: 2em;
+    span {
+      font-weight: bold;
+    }
+}
+
 .dashboard {
 
   margin-bottom: 50px;

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.ts
@@ -1,8 +1,9 @@
 import {Component, OnInit} from '@angular/core';
-import {Observable} from 'rxjs';
+import {Observable, Subject} from 'rxjs';
 import {DashboardStatisticsService} from '../services/dashboard-statistics.service';
 import {RoleService} from '../services/role.service';
-import {finalize} from 'rxjs/operators';
+import {catchError, finalize} from 'rxjs/operators';
+import {HttpErrorResponse} from "@angular/common/http";
 
 @Component({
   selector: 'app-dashboard-statistics',
@@ -13,6 +14,7 @@ import {finalize} from 'rxjs/operators';
 export class DashboardStatisticsComponent implements OnInit {
   Charts: Observable<any>;
   Counts: Observable<any>;
+  errorMessage = new Subject();
   hasRequiredRole;
   loading = true;
 
@@ -21,7 +23,8 @@ export class DashboardStatisticsComponent implements OnInit {
 
   ngOnInit(): void {
     this.hasRequiredRole = this.roleService.allowedToViewEELData();
-    this.Charts = this.dashboardStatisticsService.ChartFactory().pipe(finalize(() => this.loading = false));
+    this.Charts = this.dashboardStatisticsService.ChartFactory()
+      .pipe(catchError(this.catchErrorAndReturnArray.bind(this)), finalize(() => this.loading = false));
     this.Counts = this.dashboardStatisticsService.Counts;
   }
 
@@ -30,5 +33,10 @@ export class DashboardStatisticsComponent implements OnInit {
       responsive: true,
       displaylogo: false
     };
+  }
+
+  private catchErrorAndReturnArray(error: HttpErrorResponse): [] {
+    this.errorMessage.next(error);
+    return [];
   }
 }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.ts
@@ -31,12 +31,4 @@ export class DashboardStatisticsComponent implements OnInit {
       displaylogo: false
     };
   }
-
-  public scrollToVew(divElement: HTMLDivElement): void {
-    divElement.scrollIntoView({
-      behavior: 'smooth',
-      block: 'start',
-      inline: 'nearest'
-    });
-  }
 }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.ts
@@ -3,7 +3,7 @@ import {Observable, Subject} from 'rxjs';
 import {DashboardStatisticsService} from '../services/dashboard-statistics.service';
 import {RoleService} from '../services/role.service';
 import {catchError, finalize} from 'rxjs/operators';
-import {HttpErrorResponse} from "@angular/common/http";
+import {HttpErrorResponse} from '@angular/common/http';
 
 @Component({
   selector: 'app-dashboard-statistics',


### PR DESCRIPTION
Improved error handling on the dashboard page.

Already displaying the following text, if any error was thrown while fetching data:
<img width="761" alt="Screenshot 2022-10-21 at 15 57 23" src="https://user-images.githubusercontent.com/77500504/197190490-31d81e54-378e-44a6-bfe6-ecd886a4e316.png">

