### PR TITLE
[DSM] PEPPER-28 cohort tag duplicate detection

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -1681,6 +1681,9 @@ export class ParticipantListComponent implements OnInit {
         if (maybeParticipant) {
           const existingCohortTags = maybeParticipant.data.dsm[CohortTagComponent.COHORT_TAG] as CohortTag[];
           if (existingCohortTags) {
+            if (existingCohortTags.find(tag => tag.cohortTagName === cohortTag.cohortTagName)) {
+              continue;
+            }
             existingCohortTags.push(cohortTag);
           } else {
             maybeParticipant.data.dsm[CohortTagComponent.COHORT_TAG] = [cohortTag];

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/tags/cohort-tag/bulk-cohort-tag-modal/bulk-cohort-tag-modal.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/tags/cohort-tag/bulk-cohort-tag-modal/bulk-cohort-tag-modal.component.html
@@ -14,6 +14,7 @@
              (matChipInputTokenEnd)="add($event)">
     </mat-chip-list>
   </mat-form-field>
+<div class="Color--warn" *ngIf="duplicateError">Duplicate tag!</div>
 <mat-radio-group aria-label="Select an option"
     [(ngModel)]="selectedOption">
     <br/>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/tags/cohort-tag/bulk-cohort-tag-modal/bulk-cohort-tag-modal.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/tags/cohort-tag/bulk-cohort-tag-modal/bulk-cohort-tag-modal.component.ts
@@ -17,6 +17,7 @@ import { Subject } from 'rxjs';
 export class BulkCohortTagModalComponent implements OnInit  {
 
   readonly OPTIONS = OPTIONS;
+  public duplicateError: boolean;
 
   constructor(
     @Inject(MAT_DIALOG_DATA) public data: { manualFilter: string; savedFilter: ViewFilter; selectedPatients: [] },
@@ -37,9 +38,14 @@ export class BulkCohortTagModalComponent implements OnInit  {
   }
 
   add(event: MatChipInputEvent): void {
+    this.duplicateError = false;
     const value = (event.value || '').trim();
 
     if (value) {
+      if (this.tags.find(tag => tag === value)){
+        this.duplicateError = true;
+        return;
+      }
       this.tags.push(value);
     }
 

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/tags/cohort-tag/cohort-tag.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/tags/cohort-tag/cohort-tag.component.html
@@ -14,3 +14,4 @@
            (matChipInputTokenEnd)="add($event)">
   </mat-chip-list>
 </mat-form-field>
+<div class="Color--warn" *ngIf="duplicateError">Duplicate tag! Not saved!</div>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/tags/cohort-tag/cohort-tag.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/tags/cohort-tag/cohort-tag.component.ts
@@ -20,7 +20,7 @@ export class CohortTagComponent implements OnInit {
   tags: CohortTag[];
 
   public static readonly COHORT_TAG = 'cohortTag';
-  public duplicateError: boolean = false;
+  public duplicateError = false;
 
   constructor(private compService: ComponentService, private dsmService: DSMService) { }
 
@@ -59,7 +59,7 @@ export class CohortTagComponent implements OnInit {
             event.chipInput!.clear();
           },
           error: (error) => {
-            if(error.status == 500){
+            if (error.status === 500){
               this.duplicateError = true;
             }
           }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/tags/cohort-tag/cohort-tag.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/tags/cohort-tag/cohort-tag.component.ts
@@ -20,6 +20,7 @@ export class CohortTagComponent implements OnInit {
   tags: CohortTag[];
 
   public static readonly COHORT_TAG = 'cohortTag';
+  public duplicateError: boolean = false;
 
   constructor(private compService: ComponentService, private dsmService: DSMService) { }
 
@@ -39,23 +40,30 @@ export class CohortTagComponent implements OnInit {
   }
 
   add(event: MatChipInputEvent): void {
+    this.duplicateError = false;
     const value = (event.value || '').trim();
 
     if (value) {
       const newTag = new CohortTag(value, this.ddpParticipantId);
+      if (this.getTags().find(tag => tag.cohortTagName === value)){
+        this.duplicateError = true;
+        return;
+      }
       this.dsmService.createCohortTag(JSON.stringify(newTag), this.compService.getRealm())
         .subscribe({
           next: cohortTagId => {
             newTag.cohortTagId = parseInt(cohortTagId);
+            this.getTags().push(newTag);
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            // Clear the input value
+            event.chipInput!.clear();
           },
-          error: () => {
-            this.remove(newTag);
+          error: (error) => {
+            if(error.status == 500){
+              this.duplicateError = true;
+            }
           }
         });
-      this.getTags().push(newTag);
-
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      event.chipInput!.clear();  // Clear the input value
     }
   }
 


### PR DESCRIPTION
When entering a cohort tag, frontend detects if it is a duplicate and stops it from getting saved (there is also extra check in the backend, [PR #2372](https://github.com/broadinstitute/ddp-study-server/pull/2372) )
<img width="1680" alt="Screen Shot 2022-10-25 at 1 46 29 PM" src="https://user-images.githubusercontent.com/47120870/197845509-fe3ec9e0-bd5f-4e7b-a85b-b8c5353326a6.png">
<img width="1680" alt="Screen Shot 2022-10-25 at 1 47 17 PM" src="https://user-images.githubusercontent.com/47120870/197845510-3a520830-29f6-4d0a-8fd6-eb67395317dd.png">
