### PR TITLE
[Playwright] [PEPPER-246] Playwright test CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -703,14 +703,14 @@ jobs:
           working_directory: *playwright_path
           name: Copy junit results.xml
           command: |
-            mkdir -p /tmp/junit
-            cp test-results/junit/results.xml /tmp/junit
+            mkdir -p /tmp/log/junit
+            cp test-results/junit/results.xml /tmp/log/junit
           when: always
       - store_test_results:
-          path: /tmp/junit
+          path: /tmp/log
       - store_artifacts:
-          path: /tmp/junit
-          destination: junit
+          path: playwright-e2e/test-results
+          destination: test-results
       - store_artifacts:
           path: playwright-e2e/html-test-results
           destination: html-test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -695,16 +695,19 @@ jobs:
       - run:
           working_directory: *playwright_path
           command: npx playwright install --with-deps chromium # Only need Chrome browser
-      - run:
-          name: "Running Playwright tests"
-          working_directory: *playwright_path
-          command: |
-            shopt -s globstar
-            TESTFILES=$(circleci tests glob "tests/**/*.spec.ts" | circleci tests split --split-by=timings --show-counts)
-            npm run test:ci $TESTFILES
+      # Sharding allows you to run different parts of tests across different VM
+      - run: SHARD="$((${CIRCLE_NODE_INDEX}+1))"; npm run test:ci -- --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
+
+      #- run:
+      #    name: "Running Playwright tests"
+      #    working_directory: *playwright_path
+      #    command: |
+      #      shopt -s globstar
+      #      TESTFILES=$(circleci tests glob "tests/**/*.spec.ts" | circleci tests split --split-by=timings --show-counts)
+      #      npm run test:ci $TESTFILES
             # TODO: Can't use --grep when splitting tests
             # npx playwright test --grep << parameters.test_suite >>
-          no_output_timeout: 3m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
+      #    no_output_timeout: 3m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
       # File paths are relative and defined in playwright.config.ts Reporter section
       # Fails to load traces in CircleCI. See https://github.com/microsoft/playwright/issues/18108
       #- run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -671,6 +671,10 @@ jobs:
       - attach_workspace:
           at: .
       - run:
+          name: Inspect previous test metadata
+          command: |
+            cat "${CIRCLE_INTERNAL_TASK_DATA}/circle-test-results/results.json" | jq .
+      - run:
           name: "Export environment variables to BASH_ENV"
           command: |
             cp "playwright-e2e/config/.env.<< parameters.env >>" .env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -665,7 +665,7 @@ jobs:
         default: ".*"
       parallel_num:
         type: integer
-        default: 2
+        default: 3
     parallelism: << parameters.parallel_num >>
     steps:
       - halt-playwright-test-check:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -893,10 +893,6 @@ workflows:
               only:
                 - develop
     jobs:
-      - playwright-e2e-test:
-          name: playwright-e2e-nightly-test
-          env_name: test
-          test_suite: nightly
       - build-and-deploy-job:
           name: basil-nightly
           study_key: basil

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -694,7 +694,7 @@ jobs:
           command: |
             set -e
             TESTFILES=$(circleci tests glob "tests/**/*.spec.ts")
-            npm test:ci $TESTFILES  --grep << parameters.test_suite >>
+            npm run test:ci $TESTFILES --grep << parameters.test_suite >>
             # npx playwright test --grep << parameters.test_suite >>
           no_output_timeout: 3m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
       # File paths are relative and defined in playwright.config.ts Reporter section

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -709,6 +709,9 @@ jobs:
       - store_test_results:
           path: /tmp/log
       - store_artifacts:
+          path: /tmp/log/junit
+          destination: junit
+      - store_artifacts:
           path: playwright-e2e/test-results
           destination: test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -477,8 +477,6 @@ commands:
                 echo "Build for <<parameters.study_key>> found at URL: ${TAR_FILE_URL}. No new build will be initiated"
             fi
 
-
-
   halt-playwright-test-check:
     description: "Stop running Playwright e2e tests if halt conditions are met"
     parameters:
@@ -494,9 +492,8 @@ commands:
               - equal: [ prod, << parameters.env >> ]
           steps:
             - run:
-                command: |
-                  echo "Stop run tests because ENV=<< parameters.env >>"
-                  circleci-agent step halt
+                name: Step halt ENV=<< parameters.env >>
+                command: circleci-agent step halt
 
 jobs:
   build-and-deploy-job:
@@ -668,43 +665,37 @@ jobs:
         default: 2
     parallelism: << parameters.parallel_num >>
     steps:
-      - when:
-          # TO REMOVE when. half-playwright-test-check?
-          condition:
-            or:
-              - equal: [ dev, << parameters.env >> ]
-              - equal: [ test, << parameters.env >> ]
-              - equal: [ staging, << parameters.env >> ]
-          steps:
-            - attach_workspace:
-                at: .
-            - run:
-                name: "Export environment variables to BASH_ENV"
-                command: |
-                  # File was created in build-playwright-job
-                  cat playwright-env/envvars | awk '{print "export " $0}' >> "$BASH_ENV"
-                  cp "playwright-e2e/config/.env.<< parameters.env >>" .env
-                  cat .env | awk '{print "export " $0}' >> "$BASH_ENV"
-                  source "$BASH_ENV"
-            - run:
-                working_directory: *playwright_path
-                name: Install NPM packages
-                command: npm install --quiet
-            - run:
-                working_directory: *playwright_path
-                name: Install Playwright browsers dependencies
-                command: npx playwright install --with-deps chromium # Only need Chrome browser
-            - run:
-                working_directory: *playwright_path
-                name: Run targeted test suites
-                command: npx playwright test --grep << parameters.test_suite >>
-            # File paths are relative and defined in playwright.config.ts Reporter section
-            - store_test_results:
-                path: playwright-e2e/test-results/junit
-            - store_artifacts:
-                path: playwright-e2e/test-results
-            - store_artifacts:
-                path: playwright-e2e/html-test-results
+      - halt-playwright-test-check:
+          env: << parameters.env >>
+      - attach_workspace:
+          at: .
+      - run:
+          name: "Export environment variables to BASH_ENV"
+          command: |
+            # File was created in build-playwright-job
+            cat playwright-env/envvars | awk '{print "export " $0}' >> "$BASH_ENV"
+            cp "playwright-e2e/config/.env.<< parameters.env >>" .env
+            cat .env | awk '{print "export " $0}' >> "$BASH_ENV"
+            source "$BASH_ENV"
+      - run:
+          working_directory: *playwright_path
+          name: Install NPM packages
+          command: npm install --quiet
+      - run:
+          working_directory: *playwright_path
+          name: Install Playwright browsers dependencies
+          command: npx playwright install --with-deps chromium # Only need Chrome browser
+      - run:
+          working_directory: *playwright_path
+          name: Run targeted test suites
+          command: npx playwright test --grep << parameters.test_suite >>
+      # File paths are relative and defined in playwright.config.ts Reporter section
+      - store_test_results:
+          path: playwright-e2e/test-results/junit
+      - store_artifacts:
+          path: playwright-e2e/test-results
+      - store_artifacts:
+          path: playwright-e2e/html-test-results
 
 
 parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -694,14 +694,11 @@ jobs:
           command: |
             set -e
             ls
-            TESTFILES=$(circleci tests glob "tests/*.spec.ts")
+            TESTFILES=$(circleci tests glob "tests/**/*.spec.ts")
             echo $TESTFILES
             # npm test:ci $TESTFILES
+            # npx playwright test --grep << parameters.test_suite >>
           no_output_timeout: 3m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
-      - run:
-          working_directory: *playwright_path
-          name: Run targeted test suites
-          command: npx playwright test --grep << parameters.test_suite >>
       # File paths are relative and defined in playwright.config.ts Reporter section
       # Fails to load traces in CircleCI. See https://github.com/microsoft/playwright/issues/18108
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -695,7 +695,7 @@ jobs:
           command: |
             set -e
 
-            TESTFILES=$(find $(pwd) -wholename "**/*.spec.ts" | circleci tests split --split-by=timings)
+            TESTFILES=$(circleci tests glob "tests/**/*.spec.ts" | circleci tests split --split-by=timings)
             echo $TESTFILES
             echo "/end"
 
@@ -707,12 +707,14 @@ jobs:
       # Fails to load traces in CircleCI. See https://github.com/microsoft/playwright/issues/18108
       - run:
           working_directory: *playwright_path
-          command: cp test-results/junit/results.xml ~/junit/
+          command: |
+            mkdir -p /tmp/junit
+            cp test-results/junit/results.xml /tmp/junit
           when: always
       - store_test_results:
-          path: ~/junit
+          path: /tmp/junit
       - store_artifacts:
-          path: ~/junit
+          path: /tmp/junit
       - store_artifacts:
           path: playwright-e2e/test-results
           destination: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -611,7 +611,7 @@ jobs:
       - setup-shared-env
       - run:
           # Reading Vault secrets because build-executor provides Vault set-up
-          name: Save Vault secrets to a file to persist across jobs
+          name: Save Vault secrets to file to persist across jobs
           command: |
             mkdir -p playwright-env
 
@@ -672,10 +672,13 @@ jobs:
       - run:
           name: "Export environment variables to BASH_ENV"
           command: |
+            cp "playwright-e2e/config/.env.<< parameters.env >>" .env
+            # cat .env | awk '{print "export " $0}' >> "$BASH_ENV"
+            cat .env | awk '/^[^#]/ {print "export " $0}' >> "$BASH_ENV"
+
             # File was created in build-playwright-job
             cat playwright-env/envvars | awk '{print "export " $0}' >> "$BASH_ENV"
-            cp "playwright-e2e/config/.env.<< parameters.env >>" .env
-            cat .env | awk '{print "export " $0}' >> "$BASH_ENV"
+
             source "$BASH_ENV"
       - run:
           working_directory: *playwright_path

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -699,23 +699,26 @@ jobs:
           no_output_timeout: 3m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
       # File paths are relative and defined in playwright.config.ts Reporter section
       # Fails to load traces in CircleCI. See https://github.com/microsoft/playwright/issues/18108
-      - run:
-          working_directory: *playwright_path
-          name: Copy junit results.xml
-          command: |
-            mkdir -p /tmp/log/junit
-            cp test-results/junit/results.xml /tmp/log/junit
-          when: always
-      - store_test_results:
-          path: /tmp/log
+      #- run:
+      #    working_directory: *playwright_path
+      #    name: Copy junit results.xml
+      #    command: |
+      #      mkdir -p /tmp/log/junit
+      #      cp junit/results/results.xml /tmp/junit
+      #    when: always
+      #- store_test_results:
+      #    path: /tmp/junit
+      #- store_artifacts:
+      #    path: /tmp/junit
+      #    destination: junit
       - store_artifacts:
-          path: /tmp/log/junit
+          path: ../junit
           destination: junit
       - store_artifacts:
-          path: playwright-e2e/test-results
+          path: ../test-results
           destination: test-results
       - store_artifacts:
-          path: playwright-e2e/html-test-results
+          path: ../html-test-results
           destination: html-test-results
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -759,9 +759,6 @@ workflows:
               equal: ["UNKNOWN", << pipeline.parameters.study_key >>]
       jobs:
         - app-run-tests-job
-        - playwright-e2e-test: # Test out new job. Remove before merge
-            env_name: "test"
-            test_suite: "all"
 
   playwright-e2e-test-workflow:
     # Triggered by CI API (for example, run_ci.sh)
@@ -775,7 +772,7 @@ workflows:
       - run-playwright-test-job:
           env: << pipeline.parameters.deploy_env >>
           requires:
-            - build-playwright-job
+            - build-playwright-test-job
 
   build-and-deploy-all-apps-workflow:
     unless: << pipeline.parameters.do-builds >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -613,7 +613,7 @@ jobs:
           path: *repo_path
       - setup-shared-env
       - run:
-          # Reading Vault secrets because build-executor provides Vault set-up
+          # Reading Vault secrets here because build-executor provides Vault set-up
           name: Save Vault secrets to file to persist across jobs
           command: |
             mkdir -p playwright-env
@@ -645,7 +645,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - playwright-env # dir contains env-variables file
+            - playwright-env # dir which contains env-variables file
             - playwright-e2e
 
   run-playwright-test-job:
@@ -657,12 +657,6 @@ jobs:
         default: dev
         type: enum
         enum: [ dev, test, staging, prod, UNKNOWN ]
-      test_suite:
-        # Not used currently
-        description: Test group. For example, @singular
-        type: string
-        # Empty string is treated as a falsy value in evaluation of when clauses
-        default: ".*"
       parallel_num:
         type: integer
         default: 3
@@ -680,7 +674,7 @@ jobs:
             # See https://support.circleci.com/hc/en-us/articles/360000376788-How-to-troubleshoot-Test-Splitting
             cat "${CIRCLE_INTERNAL_TASK_DATA}/circle-test-results/results.json" | jq .
       - run:
-          name: "Export environment variables to BASH_ENV"
+          name: Export env variables to BASH_ENV
           command: |
             cp "playwright-e2e/config/.env.<< parameters.env >>" .env
             cat .env | awk '/^[^#]/ {print "export " $0}' >> "$BASH_ENV"
@@ -696,10 +690,10 @@ jobs:
           working_directory: *playwright_path
           command: npx playwright install --with-deps chromium # Only need Chrome browser
       - run:
-          name: "Running Playwright tests"
+          name: Running Playwright tests
           working_directory: *playwright_path
           command: |
-            SHARD="$((${CIRCLE_NODE_INDEX}+1))"; npm run test:ci -- --shard=${SHARD}/${CIRCLE_NODE_TOTAL} --grep << parameters.test_suite >>
+            SHARD="$((${CIRCLE_NODE_INDEX}+1))"; npm run test:ci -- --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
           no_output_timeout: 3m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
       - store_test_results:
           path: playwright-e2e/junit
@@ -897,7 +891,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 22 * * *"
+          cron: "0 22 * * *" # daily around 6 PM EST
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -763,10 +763,10 @@ workflows:
     jobs:
       - build-playwright-test-job:
           env: << pipeline.parameters.deploy_env >>
-      #- run-playwright-test-job:
-          #env: << pipeline.parameters.deploy_env >>
-          #requires:
-            #- build-playwright-test-job
+      - run-playwright-test-job:
+          env: << pipeline.parameters.deploy_env >>
+          requires:
+            - build-playwright-test-job
 
   build-and-deploy-all-apps-workflow:
     unless: << pipeline.parameters.do-builds >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -707,7 +707,7 @@ jobs:
       # Fails to load traces in CircleCI. See https://github.com/microsoft/playwright/issues/18108
       - run:
           working_directory: *playwright_path
-          command: cp test-results/junit.xml ~/junit/
+          command: cp test-results/junit/junit.xml ~/junit/
           when: always
       - store_test_results:
           path: ~/junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -695,19 +695,18 @@ jobs:
       - run:
           working_directory: *playwright_path
           command: npx playwright install --with-deps chromium # Only need Chrome browser
-      # Sharding allows you to run different parts of tests across different VM
-      - run: SHARD="$((${CIRCLE_NODE_INDEX}+1))"; npm run test:ci -- --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
+      - run:
+          name: "Running Playwright tests"
+          working_directory: *playwright_path
+          command: |
+            SHARD="$((${CIRCLE_NODE_INDEX}+1))"; npm run test:ci -- --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
 
-      #- run:
-      #    name: "Running Playwright tests"
-      #    working_directory: *playwright_path
-      #    command: |
       #      shopt -s globstar
       #      TESTFILES=$(circleci tests glob "tests/**/*.spec.ts" | circleci tests split --split-by=timings --show-counts)
       #      npm run test:ci $TESTFILES
             # TODO: Can't use --grep when splitting tests
             # npx playwright test --grep << parameters.test_suite >>
-      #    no_output_timeout: 3m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
+          no_output_timeout: 3m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
       # File paths are relative and defined in playwright.config.ts Reporter section
       # Fails to load traces in CircleCI. See https://github.com/microsoft/playwright/issues/18108
       #- run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -703,8 +703,9 @@ jobs:
           name: Run targeted test suites
           command: npx playwright test --grep << parameters.test_suite >>
       # File paths are relative and defined in playwright.config.ts Reporter section
+      # Fails to load traces in CircleCI. See https://github.com/microsoft/playwright/issues/18108
       - store_test_results:
-          path: playwright-e2e/test-results/junit
+          path: playwright-e2e/test-results
       - store_artifacts:
           path: playwright-e2e/test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -657,6 +657,7 @@ jobs:
         enum: [ dev, test, staging, prod, UNKNOWN ]
       test_suite:
         description: Test group. For example, @singular
+        type: string
         # Empty string is treated as a falsy value in evaluation of when clauses
         default: ""
       parallel_num:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,20 +21,6 @@ references:
   study_guids: &study_guids
     "basil NA CMI-OSTEO cmi-brain ANGIO cmi-mbc testboston cmi-mpc PRION atcp rarex RGP cmi-esc cgc circadia cmi-pancan singular brugada cmi-lms fon"
 
-  # Filter for PR branch only
-  filter-pr-branch: &filter-pr-branch
-    filters:
-      tags:
-        ignore: /.*/
-      branches:
-        ignore: develop
-
-  # Filter for develop branch only
-  filter-develop-branch: &filter-develop-branch
-    filters:
-      branches:
-        only: develop
-
 # Container for all the builds
 executors:
   build-executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -481,12 +481,19 @@ commands:
 
   halt-playwright-test-check:
     description: "Stop running Playwright e2e tests if halt conditions are met"
+    parameters:
+      env:
+        default: dev
+        type: enum
+        enum: [ dev, test, staging, prod, UNKNOWN ]
     steps:
-      - run:
-          working_directory: *repo_path
-          name: Checks to see if need to run Playwright tests
-          command: |
-            .circleci/skip-e2e-checks.sh
+      - when:
+          condition:
+            or:
+              - equal: [ UNKNOWN, << parameters.env >> ]
+              - equal: [ prod, << parameters.env >> ]
+          steps:
+            - run: exit 0
 
 jobs:
   build-and-deploy-job:
@@ -588,72 +595,63 @@ jobs:
       - run-linter-check
       - run-tests
 
-
   build-playwright-test-job:
     executor: build-executor
     working_directory: *repo_path
     parameters:
-      env_name:
+      env:
         default: dev
         type: enum
         enum: [ dev, test, staging, prod, UNKNOWN ]
     steps:
-      - when:
-          condition:
-            or:
-              - equal: [ dev, << parameters.env_name >> ]
-              - equal: [ test, << parameters.env_name >> ]
-              - equal: [ staging, << parameters.env_name >> ]
-          steps:
-            - checkout:
-                path: *repo_path
-            - setup-shared-env
-            - run:
-                # Reading Vault secrets because build-executor provides Vault set-up
-                name: Save Vault secrets to a file to persist across jobs
-                command: |
-                  mkdir -p playwright-env
+      - halt-playwright-test-check:
+          env: << parameters.env >>
+      - checkout:
+          path: *repo_path
+      - setup-shared-env
+      - run:
+          # Reading Vault secrets because build-executor provides Vault set-up
+          name: Save Vault secrets to a file to persist across jobs
+          command: |
+            mkdir -p playwright-env
 
-                  export sitePwd=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.sitePassword")
-                  export googleUser=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[0] | select(.app==\"google\") | .userName")
-                  export dsmUser=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[] | select(.app==\"dsm\") | .userName")
-                  export userPwd=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[] | select(.app==\"dsm\") | .password")
+            export sitePwd=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.sitePassword")
+            export googleUser=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[0] | select(.app==\"google\") | .userName")
+            export dsmUser=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[] | select(.app==\"dsm\") | .userName")
+            export userPwd=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[] | select(.app==\"dsm\") | .password")
 
-                  echo "export SITE_PASSWORD=$sitePwd" >> playwright-env/envvars
-                  echo "export SINGULAR_USER_EMAIL=$googleUser" >> playwright-env/envvars
-                  echo "export DSM_USER_EMAIL=$dsmUser" >> playwright-env/envvars
-                  # DSM and SINGULAR user passwords are same
-                  echo "export DSM_USER_PASSWORD=$userPwd" >> playwright-env/envvars
-                  echo "export SINGULAR_USER_PASSWORD=$userPwd" >> playwright-env/envvars
-            - run:
-                working_directory: *playwright_path
-                name: Install NPM packages
-                command: |
-                  ls && npm --version
-                  npm install --quiet
-            - run:
-                working_directory: *playwright_path
-                name: Run eslint
-                command: npm run lint -- --max-warnings 0
-            - run:
-                working_directory: *playwright_path
-                name: Compile project
-                command: npm run build
-            - persist_to_workspace:
-                root: .
-                paths:
-                  - playwright-env # dir contains env-variables file
-                  - playwright-e2e
+            echo "export SITE_PASSWORD=$sitePwd" >> playwright-env/envvars
+            echo "export SINGULAR_USER_EMAIL=$googleUser" >> playwright-env/envvars
+            echo "export DSM_USER_EMAIL=$dsmUser" >> playwright-env/envvars
+            # DSM and SINGULAR user passwords are same
+            echo "export DSM_USER_PASSWORD=$userPwd" >> playwright-env/envvars
+            echo "export SINGULAR_USER_PASSWORD=$userPwd" >> playwright-env/envvars
+      - run:
+          working_directory: *playwright_path
+          name: Install NPM packages
+          command: |
+            ls && npm --version
+            npm install --quiet
+      - run:
+          working_directory: *playwright_path
+          name: Run eslint
+          command: npm run lint -- --max-warnings 0
+      - run:
+          working_directory: *playwright_path
+          name: Compile project
+          command: npm run build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - playwright-env # dir contains env-variables file
+            - playwright-e2e
 
   run-playwright-test-job:
     # Run Playwright tests only for targeted env: Dev, Test or Staging.
     executor: playwright-test-executor
     working_directory: *repo_path
     parameters:
-      study_key:
-        type: string
-        default: singular
-      env_name:
+      env:
         default: dev
         type: enum
         enum: [ dev, test, staging, prod, UNKNOWN ]
@@ -667,11 +665,12 @@ jobs:
     parallelism: << parameters.parallel_num >>
     steps:
       - when:
+          # TO REMOVE when. half-playwright-test-check?
           condition:
             or:
-              - equal: [ dev, << parameters.env_name >> ]
-              - equal: [ test, << parameters.env_name >> ]
-              - equal: [ staging, << parameters.env_name >> ]
+              - equal: [ dev, << parameters.env >> ]
+              - equal: [ test, << parameters.env >> ]
+              - equal: [ staging, << parameters.env >> ]
           steps:
             - attach_workspace:
                 at: .
@@ -680,7 +679,7 @@ jobs:
                 command: |
                   # File was created in build-playwright-job
                   cat playwright-env/envvars | awk '{print "export " $0}' >> "$BASH_ENV"
-                  cp "playwright-e2e/config/.env.<< parameters.env_name >>" .env
+                  cp "playwright-e2e/config/.env.<< parameters.env >>" .env
                   cat .env | awk '{print "export " $0}' >> "$BASH_ENV"
                   source "$BASH_ENV"
             - run:
@@ -690,21 +689,21 @@ jobs:
             - run:
                 working_directory: *playwright_path
                 name: Install Playwright browsers dependencies
-                command: npx playwright install --with-deps chromium # Chrome browser only
+                command: npx playwright install --with-deps chromium # Only need Chrome browser
             - when:
                 condition: [ << parameters.test_suite >> ]
                 steps:
                   - run:
                       working_directory: *playwright_path
-                      name: Run all tests with matching tag
-                      command: npx playwright test --config=playwright-ci.config.ts --grep << parameters.test_suite >>
+                      name: Run targeted test suites
+                      command: npx playwright test --grep << parameters.test_suite >>
             - unless:
                 condition:[ << parameters.test_suite >> ]
                 steps:
                   - run:
                       working_directory: *playwright_path
                       name: Run all tests
-                      command: npx playwright test --config=playwright-ci.config.ts
+                      command: npx playwright test
             # File paths are relative and defined in playwright.config.ts Reporter section
             - store_test_results:
                 path: playwright-e2e/test-results/junit
@@ -779,18 +778,11 @@ workflows:
     when:
       and:
         - equal: [ "run-e2e-tests", << pipeline.parameters.api_call >> ]
-        - not:
-            equal: [ "UNKNOWN", << pipeline.parameters.study_key >> ]
-        - and:
-            - not:
-                equal: [ "UNKNOWN", << pipeline.parameters.deploy_env >> ]
-            - not:
-                equal: [ "prod", << pipeline.parameters.deploy_env >> ]
     jobs:
-      - build-playwright-test-job
+      - build-playwright-test-job:
+          env: << pipeline.parameters.deploy_env >>
       - run-playwright-test-job:
-          env_name: << pipeline.parameters.deploy_env >>
-          study_key: << pipeline.parameters.study_key >>
+          env: << pipeline.parameters.deploy_env >>
           requires:
             - build-playwright-job
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -676,6 +676,7 @@ jobs:
       - run:
           name: Inspect previous test metadata
           command: |
+            # aut-detect timing does not work: CircleCI CLI expects both filenames and classnames to be present in the timing data (JUnit xml) produced by the test suite.
             cat "${CIRCLE_INTERNAL_TASK_DATA}/circle-test-results/results.json" | jq .
       - run:
           name: "Export environment variables to BASH_ENV"
@@ -706,20 +707,24 @@ jobs:
           no_output_timeout: 3m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
       # File paths are relative and defined in playwright.config.ts Reporter section
       # Fails to load traces in CircleCI. See https://github.com/microsoft/playwright/issues/18108
-      #- run:
-      #    working_directory: *playwright_path
-      #    name: Copy junit results.xml
-      #    command: |
-      #      mkdir -p /tmp/junit/results
-      #      cp junit/results/results.xml /tmp/junit/results
-      #    when: always
-      #- store_test_results:
-      #    path: /tmp/junit
+      - run:
+          working_directory: *playwright_path
+          name: Copy junit results.xml
+          command: |
+            mkdir -p /tmp/junit/results
+            cp junit/results/results.xml /tmp/junit/results
+          when: always
       - store_test_results:
-          path: playwright-e2e/junit
+          path: /tmp/junit
       - store_artifacts:
-          path: playwright-e2e/junit
+          path: /tmp/junit
           destination: junit
+
+      #- store_test_results:
+      #    path: playwright-e2e/junit
+      #- store_artifacts:
+      #    path: playwright-e2e/junit
+      #    destination: junit
       - store_artifacts:
           path: playwright-e2e/test-results
           destination: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -707,7 +707,7 @@ jobs:
       # Fails to load traces in CircleCI. See https://github.com/microsoft/playwright/issues/18108
       - run:
           working_directory: *playwright_path
-          command: cp test-results/junit/junit.xml ~/junit/
+          command: cp test-results/junit/results.xml ~/junit/
           when: always
       - store_test_results:
           path: ~/junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -692,9 +692,11 @@ jobs:
           name: "Running Playwright tests"
           working_directory: *playwright_path
           command: |
-            TESTS=$(circleci tests glob "tests/*.spec.ts" | circleci tests split --split-by=timings)
-            echo $TESTS
-            npx playwright test $TESTS
+            set -e
+            ls
+            TESTFILES=$(circleci tests glob "tests/*.spec.ts" | circleci tests split --split-by=timings)
+            echo $TESTFILES
+            # npm test:ci $TESTFILES
           no_output_timeout: 3m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
       - run:
           working_directory: *playwright_path

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -707,24 +707,24 @@ jobs:
           no_output_timeout: 3m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
       # File paths are relative and defined in playwright.config.ts Reporter section
       # Fails to load traces in CircleCI. See https://github.com/microsoft/playwright/issues/18108
-      - run:
-          working_directory: *playwright_path
-          name: Copy junit results.xml
-          command: |
-            mkdir -p /tmp/junit/results
-            cp junit/results/results.xml /tmp/junit/results
-          when: always
-      - store_test_results:
-          path: /tmp/junit
-      - store_artifacts:
-          path: /tmp/junit
-          destination: junit
-
+      #- run:
+      #    working_directory: *playwright_path
+      #    name: Copy junit results.xml
+      #    command: |
+      #      mkdir -p /tmp/junit/results
+      #      cp junit/results/results.xml /tmp/junit/results
+      #    when: always
       #- store_test_results:
-      #    path: playwright-e2e/junit
+      #    path: /tmp/junit
       #- store_artifacts:
-      #    path: playwright-e2e/junit
+      #    path: /tmp/junit
       #    destination: junit
+
+      - store_test_results:
+          path: playwright-e2e/junit
+      - store_artifacts:
+          path: playwright-e2e/junit
+          destination: junit
       - store_artifacts:
           path: playwright-e2e/test-results
           destination: test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -694,7 +694,7 @@ jobs:
           command: |
             set -e
 
-            TESTFILES=$(circleci tests glob "tests/**/*.spec.ts" | circleci tests split --split-by=timings)
+            TESTFILES=$(circleci tests glob "**/*.spec.ts" | circleci tests split --split-by=timings)
             echo $TESTFILES
             echo "/end"
 
@@ -703,12 +703,19 @@ jobs:
           no_output_timeout: 3m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
       # File paths are relative and defined in playwright.config.ts Reporter section
       # Fails to load traces in CircleCI. See https://github.com/microsoft/playwright/issues/18108
+      - run:
+          command: cp playwright-e2e/test-results/junit.xml ~/junit/
+          when: always
       - store_test_results:
-          path: playwright-e2e/test-results/junit
+          path: ~/junit
+      - store_artifacts:
+          path: ~/junit
       - store_artifacts:
           path: playwright-e2e/test-results
+          destination: test-results
       - store_artifacts:
           path: playwright-e2e/html-test-results
+          destination: test-results
 
 
 parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -683,11 +683,9 @@ jobs:
             source "$BASH_ENV"
       - run:
           working_directory: *playwright_path
-          name: Install NPM packages
           command: npm install --quiet
       - run:
           working_directory: *playwright_path
-          name: Install Playwright browsers dependencies
           command: npx playwright install --with-deps chromium # Only need Chrome browser
       - run:
           name: "Running Playwright tests"
@@ -714,8 +712,8 @@ jobs:
       #    path: /tmp/junit
       #    destination: junit
       - store_artifacts:
-          path: playwright-e2e/test-results
-          destination: test-results
+          path: playwright-e2e/test-results/junit
+          destination: junit
       - store_artifacts:
           path: playwright-e2e/html-test-results
           destination: html-test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -701,24 +701,24 @@ jobs:
           no_output_timeout: 3m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
       # File paths are relative and defined in playwright.config.ts Reporter section
       # Fails to load traces in CircleCI. See https://github.com/microsoft/playwright/issues/18108
-      - run:
-          working_directory: *playwright_path
-          name: Copy junit results.xml
-          command: |
-            mkdir -p /tmp/junit
-            cp test-results/junit/results.xml /tmp/junit
-          when: always
-      - store_test_results:
-          path: /tmp/junit
-      - store_artifacts:
-          path: /tmp/junit
-          destination: junit
+      #- run:
+      #    working_directory: *playwright_path
+      #    name: Copy junit results.xml
+      #    command: |
+      #      mkdir -p /tmp/junit
+      #      cp test-results/junit/results.xml /tmp/junit
+      #    when: always
+      #- store_test_results:
+      #    path: /tmp/junit
+      #- store_artifacts:
+      #    path: /tmp/junit
+      #    destination: junit
       - store_artifacts:
           path: playwright-e2e/test-results
           destination: test-results
       - store_artifacts:
           path: playwright-e2e/html-test-results
-          destination: test-results
+          destination: html-test-results
 
 
 parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -493,7 +493,7 @@ commands:
               - equal: [ UNKNOWN, << parameters.env >> ]
               - equal: [ prod, << parameters.env >> ]
           steps:
-            - run: exit 0
+            - run: circleci-agent step halt
 
 jobs:
   build-and-deploy-job:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -702,11 +702,11 @@ jobs:
       # File paths are relative and defined in playwright.config.ts Reporter section
       # Fails to load traces in CircleCI. See https://github.com/microsoft/playwright/issues/18108
       - store_test_results:
-          path: playwright-e2e/test-results
+          path: test-results
       - store_artifacts:
-          path: playwright-e2e/test-results
+          path: test-results
       - store_artifacts:
-          path: playwright-e2e/html-test-results
+          path: html-test-results
 
 
 parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -493,7 +493,10 @@ commands:
               - equal: [ UNKNOWN, << parameters.env >> ]
               - equal: [ prod, << parameters.env >> ]
           steps:
-            - run: circleci-agent step halt
+            - run:
+                command: |
+                  echo "Stop run tests because ENV=<< parameters.env >>"
+                  circleci-agent step halt
 
 jobs:
   build-and-deploy-job:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -699,20 +699,17 @@ jobs:
           no_output_timeout: 3m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
       # File paths are relative and defined in playwright.config.ts Reporter section
       # Fails to load traces in CircleCI. See https://github.com/microsoft/playwright/issues/18108
-      #- run:
-      #    working_directory: *playwright_path
-      #    name: Copy junit results.xml
-      #    command: |
-      #      mkdir -p /tmp/junit
-      #      cp test-results/junit/results.xml /tmp/junit
-      #    when: always
-      #- store_test_results:
-      #    path: /tmp/junit
-      #- store_artifacts:
-      #    path: /tmp/junit
-      #    destination: junit
+      - run:
+          working_directory: *playwright_path
+          name: Copy junit results.xml
+          command: |
+            mkdir -p /tmp/junit
+            cp test-results/junit/results.xml /tmp/junit
+          when: always
+      - store_test_results:
+          path: /tmp/junit
       - store_artifacts:
-          path: playwright-e2e/test-results/junit
+          path: /tmp/junit
           destination: junit
       - store_artifacts:
           path: playwright-e2e/html-test-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -478,6 +478,16 @@ commands:
             fi
 
 
+
+  halt-playwright-test-check:
+    description: "Stop running Playwright e2e tests if halt conditions are met"
+    steps:
+      - run:
+          working_directory: *repo_path
+          name: Checks to see if need to run Playwright tests
+          command: |
+            .circleci/skip-e2e-checks.sh
+
 jobs:
   build-and-deploy-job:
     working_directory: *ng_workspace_path
@@ -578,8 +588,8 @@ jobs:
       - run-linter-check
       - run-tests
 
-  build-playwright-job:
-    # Set up Playwright test environment for the targeted env: dev, test or staging.
+
+  build-playwright-test-job:
     executor: build-executor
     working_directory: *repo_path
     parameters:
@@ -599,38 +609,44 @@ jobs:
                 path: *repo_path
             - setup-shared-env
             - run:
-                name: Save vault secrets to a file to persist across jobs
+                # Reading Vault secrets because build-executor provides Vault set-up
+                name: Save Vault secrets to a file to persist across jobs
                 command: |
                   mkdir -p playwright-env
+
                   export sitePwd=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.sitePassword")
                   export googleUser=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[0] | select(.app==\"google\") | .userName")
                   export dsmUser=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[] | select(.app==\"dsm\") | .userName")
                   export userPwd=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[] | select(.app==\"dsm\") | .password")
-                  echo "export singularSitePassword=$sitePwd" >> playwright-env/envvars
-                  echo "export singularUserEmail=$googleUser" >> playwright-env/envvars
-                  echo "export dsmUserEmail=$dsmUser" >> playwright-env/envvars
-                  echo "export dsmUserPassword=$userPwd" >> playwright-env/envvars
-                  echo "export singularUserPassword=$userPwd" >> playwright-env/envvars
+
+                  echo "export SITE_PASSWORD=$sitePwd" >> playwright-env/envvars
+                  echo "export SINGULAR_USER_EMAIL=$googleUser" >> playwright-env/envvars
+                  echo "export DSM_USER_EMAIL=$dsmUser" >> playwright-env/envvars
+                  # DSM and SINGULAR user passwords are same
+                  echo "export DSM_USER_PASSWORD=$userPwd" >> playwright-env/envvars
+                  echo "export SINGULAR_USER_PASSWORD=$userPwd" >> playwright-env/envvars
             - run:
                 working_directory: *playwright_path
                 name: Install NPM packages
                 command: |
-                  npm --version
+                  ls && npm --version
                   npm install --quiet
             - run:
                 working_directory: *playwright_path
-                command: ls && npm run lint -- --max-warnings 0
+                name: Run eslint
+                command: npm run lint -- --max-warnings 0
             - run:
                 working_directory: *playwright_path
+                name: Compile project
                 command: npm run build
             - persist_to_workspace:
                 root: .
                 paths:
-                  - playwright-env # env variables
-                  - playwright-e2e # project dir
+                  - playwright-env # dir contains env-variables file
+                  - playwright-e2e
 
   run-playwright-test-job:
-    # Run Playwright tests only for targeted env: dev, test or staging.
+    # Run Playwright tests only for targeted env: Dev, Test or Staging.
     executor: playwright-test-executor
     working_directory: *repo_path
     parameters:
@@ -758,20 +774,23 @@ workflows:
             test_suite: "all"
 
   playwright-e2e-test-workflow:
-    # Trigger manually by calling run_ci.sh
-    # Run Playwright tests against deploy_env
+    # Triggered by CI API (for example, run_ci.sh)
+    # Run Playwright tests against Dev, Test and Staging but not for Prod
     when:
       and:
         - equal: [ "run-e2e-tests", << pipeline.parameters.api_call >> ]
+        - not:
+            equal: [ "UNKNOWN", << pipeline.parameters.study_key >> ]
         - and:
             - not:
                 equal: [ "UNKNOWN", << pipeline.parameters.deploy_env >> ]
             - not:
                 equal: [ "prod", << pipeline.parameters.deploy_env >> ]
     jobs:
-      - build-playwright-job
+      - build-playwright-test-job
       - run-playwright-test-job:
           env_name: << pipeline.parameters.deploy_env >>
+          study_key: << pipeline.parameters.study_key >>
           requires:
             - build-playwright-job
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -769,10 +769,10 @@ workflows:
     jobs:
       - build-playwright-test-job:
           env: << pipeline.parameters.deploy_env >>
-      - run-playwright-test-job:
-          env: << pipeline.parameters.deploy_env >>
-          requires:
-            - build-playwright-test-job
+      #- run-playwright-test-job:
+          #env: << pipeline.parameters.deploy_env >>
+          #requires:
+            #- build-playwright-test-job
 
   build-and-deploy-all-apps-workflow:
     unless: << pipeline.parameters.do-builds >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -689,6 +689,13 @@ jobs:
           name: Install Playwright browsers dependencies
           command: npx playwright install --with-deps chromium # Only need Chrome browser
       - run:
+          name: "Running Playwright tests"
+          working_directory: *playwright_path
+          command: |
+            TESTS=$(circleci tests glob "tests/*.spec.ts" | circleci tests split --split-by=timings)
+            npx playwright test $TESTS
+          no_output_timeout: 3m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
+      - run:
           working_directory: *playwright_path
           name: Run targeted test suites
           command: npx playwright test --grep << parameters.test_suite >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -693,10 +693,8 @@ jobs:
           working_directory: *playwright_path
           command: |
             set -e
-            ls
             TESTFILES=$(circleci tests glob "tests/**/*.spec.ts")
-            echo $TESTFILES
-            # npm test:ci $TESTFILES
+            npm test:ci $TESTFILES  --grep << parameters.test_suite >>
             # npx playwright test --grep << parameters.test_suite >>
           no_output_timeout: 3m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
       # File paths are relative and defined in playwright.config.ts Reporter section

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -711,14 +711,16 @@ jobs:
       #- store_artifacts:
       #    path: /tmp/junit
       #    destination: junit
+      - store_test_results:
+          path: playwright-e2e/junit
       - store_artifacts:
-          path: ../junit
+          path: playwright-e2e/junit
           destination: junit
       - store_artifacts:
-          path: ../test-results
+          path: playwright-e2e/test-results
           destination: test-results
       - store_artifacts:
-          path: ../html-test-results
+          path: playwright-e2e/html-test-results
           destination: html-test-results
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -659,7 +659,7 @@ jobs:
         description: Test group. For example, @singular
         type: string
         # Empty string is treated as a falsy value in evaluation of when clauses
-        default: ""
+        default: ".*"
       parallel_num:
         type: integer
         default: 2
@@ -691,20 +691,10 @@ jobs:
                 working_directory: *playwright_path
                 name: Install Playwright browsers dependencies
                 command: npx playwright install --with-deps chromium # Only need Chrome browser
-            - when:
-                condition: [ << parameters.test_suite >> ]
-                steps:
-                  - run:
-                      working_directory: *playwright_path
-                      name: Run targeted test suites
-                      command: npx playwright test --grep << parameters.test_suite >>
-            - unless:
-                condition: [ << parameters.test_suite >> ]
-                steps:
-                  - run:
-                      working_directory: *playwright_path
-                      name: Run all tests
-                      command: npx playwright test
+            - run:
+                working_directory: *playwright_path
+                name: Run targeted test suites
+                command: npx playwright test --grep << parameters.test_suite >>
             # File paths are relative and defined in playwright.config.ts Reporter section
             - store_test_results:
                 path: playwright-e2e/test-results/junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -703,14 +703,11 @@ jobs:
       #    working_directory: *playwright_path
       #    name: Copy junit results.xml
       #    command: |
-      #      mkdir -p /tmp/log/junit
-      #      cp junit/results/results.xml /tmp/junit
+      #      mkdir -p /tmp/junit/results
+      #      cp junit/results/results.xml /tmp/junit/results
       #    when: always
       #- store_test_results:
       #    path: /tmp/junit
-      #- store_artifacts:
-      #    path: /tmp/junit
-      #    destination: junit
       - store_test_results:
           path: playwright-e2e/junit
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -694,7 +694,7 @@ jobs:
           command: |
             set -e
 
-            TESTFILES=$(circleci tests glob "**/*.spec.ts" | circleci tests split --split-by=timings)
+            TESTFILES=$(find $(pwd) -wholename "**/*.spec.ts" | circleci tests split --split-by=timings)
             echo $TESTFILES
             echo "/end"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -676,16 +676,16 @@ jobs:
       - run:
           name: Inspect previous test metadata
           command: |
-            # aut-detect timing does not work: CircleCI CLI expects both filenames and classnames to be present in the timing data (JUnit xml) produced by the test suite.
+            # aut-detect timing does not work because CircleCI CLI expects both filenames and classnames to be present in JUnit xml.
+            # See https://support.circleci.com/hc/en-us/articles/360000376788-How-to-troubleshoot-Test-Splitting
             cat "${CIRCLE_INTERNAL_TASK_DATA}/circle-test-results/results.json" | jq .
       - run:
           name: "Export environment variables to BASH_ENV"
           command: |
             cp "playwright-e2e/config/.env.<< parameters.env >>" .env
-            # cat .env | awk '{print "export " $0}' >> "$BASH_ENV"
             cat .env | awk '/^[^#]/ {print "export " $0}' >> "$BASH_ENV"
 
-            # File was created in build-playwright-job
+            # export env from file (created in build-playwright-job)
             cat playwright-env/envvars | awk '{print "export " $0}' >> "$BASH_ENV"
 
             source "$BASH_ENV"
@@ -699,29 +699,8 @@ jobs:
           name: "Running Playwright tests"
           working_directory: *playwright_path
           command: |
-            SHARD="$((${CIRCLE_NODE_INDEX}+1))"; npm run test:ci -- --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
-
-      #      shopt -s globstar
-      #      TESTFILES=$(circleci tests glob "tests/**/*.spec.ts" | circleci tests split --split-by=timings --show-counts)
-      #      npm run test:ci $TESTFILES
-            # TODO: Can't use --grep when splitting tests
-            # npx playwright test --grep << parameters.test_suite >>
+            SHARD="$((${CIRCLE_NODE_INDEX}+1))"; npm run test:ci -- --shard=${SHARD}/${CIRCLE_NODE_TOTAL} --grep << parameters.test_suite >>
           no_output_timeout: 3m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
-      # File paths are relative and defined in playwright.config.ts Reporter section
-      # Fails to load traces in CircleCI. See https://github.com/microsoft/playwright/issues/18108
-      #- run:
-      #    working_directory: *playwright_path
-      #    name: Copy junit results.xml
-      #    command: |
-      #      mkdir -p /tmp/junit/results
-      #      cp junit/results/results.xml /tmp/junit/results
-      #    when: always
-      #- store_test_results:
-      #    path: /tmp/junit
-      #- store_artifacts:
-      #    path: /tmp/junit
-      #    destination: junit
-
       - store_test_results:
           path: playwright-e2e/junit
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -698,7 +698,7 @@ jobs:
                       name: Run targeted test suites
                       command: npx playwright test --grep << parameters.test_suite >>
             - unless:
-                condition:[ << parameters.test_suite >> ]
+                condition: [ << parameters.test_suite >> ]
                 steps:
                   - run:
                       working_directory: *playwright_path

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -693,6 +693,7 @@ jobs:
           working_directory: *playwright_path
           command: |
             TESTS=$(circleci tests glob "tests/*.spec.ts" | circleci tests split --split-by=timings)
+            echo $TESTS
             npx playwright test $TESTS
           no_output_timeout: 3m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  jq: circleci/jq@2.2.0
+
 references:
   repo_path: &repo_path
       /home/circleci/repo
@@ -628,13 +631,12 @@ jobs:
             echo "export SINGULAR_USER_PASSWORD=$userPwd" >> playwright-env/envvars
       - run:
           working_directory: *playwright_path
-          name: Install NPM packages
+          name: npm install
           command: |
             ls && npm --version
             npm install --quiet
       - run:
           working_directory: *playwright_path
-          name: Run eslint
           command: npm run lint -- --max-warnings 0
       - run:
           working_directory: *playwright_path
@@ -670,6 +672,7 @@ jobs:
           env: << parameters.env >>
       - attach_workspace:
           at: .
+      - jq/install
       - run:
           name: Inspect previous test metadata
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -694,7 +694,7 @@ jobs:
           command: |
             set -e
             ls
-            TESTFILES=$(circleci tests glob "tests/*.spec.ts" | circleci tests split --split-by=timings)
+            TESTFILES=$(circleci tests glob "tests/*.spec.ts")
             echo $TESTFILES
             # npm test:ci $TESTFILES
           no_output_timeout: 3m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -656,6 +656,7 @@ jobs:
         type: enum
         enum: [ dev, test, staging, prod, UNKNOWN ]
       test_suite:
+        # Not used currently
         description: Test group. For example, @singular
         type: string
         # Empty string is treated as a falsy value in evaluation of when clauses
@@ -698,13 +699,15 @@ jobs:
             echo $TESTFILES
             echo "/end"
 
-            npm run test:ci $TESTFILES --grep << parameters.test_suite >>
+            npm run test:ci $TESTFILES
+            # TODO: Can't use --grep when splitting tests
             # npx playwright test --grep << parameters.test_suite >>
           no_output_timeout: 3m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
       # File paths are relative and defined in playwright.config.ts Reporter section
       # Fails to load traces in CircleCI. See https://github.com/microsoft/playwright/issues/18108
       - run:
-          command: cp playwright-e2e/test-results/junit.xml ~/junit/
+          working_directory: *playwright_path
+          command: cp test-results/junit.xml ~/junit/
           when: always
       - store_test_results:
           path: ~/junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ references:
   ng_workspace_path: &ng_workspace_path
       /home/circleci/repo/ddp-workspace
   playwright_path: &playwright_path
-      /home/circleci/repo/playwright-e2e/tests/<< pipeline.parameters.study_key >>
+      /home/circleci/repo/playwright-e2e
   npm_cache_key: &npm_cache_key
     v1-dependency-npm2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
   npm_cache_restore_key: &npm_cache_restore_key
@@ -18,6 +18,20 @@ references:
   study_guids: &study_guids
     "basil NA CMI-OSTEO cmi-brain ANGIO cmi-mbc testboston cmi-mpc PRION atcp rarex RGP cmi-esc cgc circadia cmi-pancan singular brugada cmi-lms fon"
 
+  # Filter for PR branch only
+  filter-pr-branch: &filter-pr-branch
+    filters:
+      tags:
+        ignore: /.*/
+      branches:
+        ignore: develop
+
+  # Filter for develop branch only
+  filter-develop-branch: &filter-develop-branch
+    filters:
+      branches:
+        only: develop
+
 # Container for all the builds
 executors:
   build-executor:
@@ -28,8 +42,9 @@ executors:
   playwright-test-executor:
     resource_class: medium+
     docker:
+      # Playwright docker image version MUST match Playwright version in project
       - image: mcr.microsoft.com/playwright:v1.25.0-focal
-    working_directory: *ng_workspace_path
+    working_directory: *playwright_path
     environment:
       NODE_ENV: development # Needed if playwright is in devDependencies
 
@@ -563,67 +578,125 @@ jobs:
       - run-linter-check
       - run-tests
 
-  playwright-e2e-test:
-    executor: playwright-test-executor
+  build-playwright-job:
+    # Set up Playwright test environment for the targeted env: dev, test or staging.
+    executor: build-executor
+    working_directory: *repo_path
     parameters:
       env_name:
-        description: Must be one of "dev", "test", "staging" (in future)
-        default: "test"
+        default: dev
         type: enum
-        enum: [ "test" ]
+        enum: [ dev, test, staging, prod, UNKNOWN ]
+    steps:
+      - when:
+          condition:
+            or:
+              - equal: [ dev, << parameters.env_name >> ]
+              - equal: [ test, << parameters.env_name >> ]
+              - equal: [ staging, << parameters.env_name >> ]
+          steps:
+            - checkout:
+                path: *repo_path
+            - setup-shared-env
+            - run:
+                name: Save vault secrets to a file to persist across jobs
+                command: |
+                  mkdir -p playwright-env
+                  export sitePwd=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.sitePassword")
+                  export googleUser=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[0] | select(.app==\"google\") | .userName")
+                  export dsmUser=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[] | select(.app==\"dsm\") | .userName")
+                  export userPwd=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[] | select(.app==\"dsm\") | .password")
+                  echo "export singularSitePassword=$sitePwd" >> playwright-env/envvars
+                  echo "export singularUserEmail=$googleUser" >> playwright-env/envvars
+                  echo "export dsmUserEmail=$dsmUser" >> playwright-env/envvars
+                  echo "export dsmUserPassword=$userPwd" >> playwright-env/envvars
+                  echo "export singularUserPassword=$userPwd" >> playwright-env/envvars
+            - run:
+                working_directory: *playwright_path
+                name: Install NPM packages
+                command: |
+                  npm --version
+                  npm install --quiet
+            - run:
+                working_directory: *playwright_path
+                command: ls && npm run lint -- --max-warnings 0
+            - run:
+                working_directory: *playwright_path
+                command: npm run build
+            - persist_to_workspace:
+                root: .
+                paths:
+                  - playwright-env # env variables
+                  - playwright-e2e # project dir
+
+  run-playwright-test-job:
+    # Run Playwright tests only for targeted env: dev, test or staging.
+    executor: playwright-test-executor
+    working_directory: *repo_path
+    parameters:
+      study_key:
+        type: string
+        default: singular
+      env_name:
+        default: dev
+        type: enum
+        enum: [ dev, test, staging, prod, UNKNOWN ]
       test_suite:
-        description: Must be one of "nightly", "all".
-        default: "all"
-        type: enum
-        enum: [ "all", "nightly" ]
+        description: Test group. For example, @singular
+        # Empty string is treated as a falsy value in evaluation of when clauses
+        default: ""
       parallel_num:
         type: integer
-        default: 1
+        default: 2
     parallelism: << parameters.parallel_num >>
     steps:
-      - setup-build-workspace
-      - setup-shared-env:
-          study_key: << pipeline.parameters.study_key >>
-      - run:
-          working_directory: *playwright_path
-          name: "Set playwright-e2e .env and export environment variables"
-          command: |
-            pwd
-            ls
-            cp ".env.<< pipeline.parameters.study_key >>.<< parameters.env_name >>" .env
-            cat .env | awk '{print "export " $0}' >> $BASH_ENV
-            source $BASH_ENV
-      - run:
-          working_directory: *playwright_path
-          name: Install NPM packages
-          command: npm install --force --quiet
-      - run:
-          working_directory: *playwright_path
-          name: Install Playwright browsers and dependencies
-          command: npx playwright install --with-deps "chromium"
       - when:
           condition:
-            equal: [ "all", << parameters.test_suite >> ]
+            or:
+              - equal: [ dev, << parameters.env_name >> ]
+              - equal: [ test, << parameters.env_name >> ]
+              - equal: [ staging, << parameters.env_name >> ]
           steps:
+            - attach_workspace:
+                at: .
+            - run:
+                name: "Export environment variables to BASH_ENV"
+                command: |
+                  # File was created in build-playwright-job
+                  cat playwright-env/envvars | awk '{print "export " $0}' >> "$BASH_ENV"
+                  cp "playwright-e2e/config/.env.<< parameters.env_name >>" .env
+                  cat .env | awk '{print "export " $0}' >> "$BASH_ENV"
+                  source "$BASH_ENV"
             - run:
                 working_directory: *playwright_path
-                name: Run all Playwright tests except nightly tests
-                command: npx playwright test --config=playwright-ci.config.ts --grep-invert "/nightly/|/examples/"
-      - when:
-          condition:
-            equal: [ "nightly", << parameters.test_suite >> ]
-          steps:
+                name: Install NPM packages
+                command: npm install --quiet
             - run:
                 working_directory: *playwright_path
-                name: Run all Playwright nightly tests
-                command: npx playwright test --config=playwright-ci.config.ts --grep "nightly/"
-      # Paths are relative and defined in playwright.config.ts Reporter section
-      - store_test_results:
-          path: ../playwright-e2e/tests/<< pipeline.parameters.study_key >>/test-results/junit
-      - store_artifacts:
-          path: ../playwright-e2e/tests/<< pipeline.parameters.study_key >>/test-results
-      - store_artifacts:
-          path: ../playwright-e2e/tests/<< pipeline.parameters.study_key >>/html-test-results
+                name: Install Playwright browsers dependencies
+                command: npx playwright install --with-deps chromium # Chrome browser only
+            - when:
+                condition: [ << parameters.test_suite >> ]
+                steps:
+                  - run:
+                      working_directory: *playwright_path
+                      name: Run all tests with matching tag
+                      command: npx playwright test --config=playwright-ci.config.ts --grep << parameters.test_suite >>
+            - unless:
+                condition:[ << parameters.test_suite >> ]
+                steps:
+                  - run:
+                      working_directory: *playwright_path
+                      name: Run all tests
+                      command: npx playwright test --config=playwright-ci.config.ts
+            # File paths are relative and defined in playwright.config.ts Reporter section
+            - store_test_results:
+                path: playwright-e2e/test-results/junit
+            - store_artifacts:
+                path: playwright-e2e/test-results
+            - store_artifacts:
+                path: playwright-e2e/html-test-results
+
 
 parameters:
   study_key:
@@ -634,7 +707,7 @@ parameters:
     default: "UNKNOWN"
   api_call:
     type: enum
-    enum: ["build-and-store","deploy", "run-tests", "UNKNOWN"]
+    enum: ["build-and-store","deploy", "run-tests", "run-e2e-tests", "UNKNOWN"]
     default: "UNKNOWN"
   deploy_env:
     type: enum
@@ -683,6 +756,24 @@ workflows:
         - playwright-e2e-test: # Test out new job. Remove before merge
             env_name: "test"
             test_suite: "all"
+
+  playwright-e2e-test-workflow:
+    # Trigger manually by calling run_ci.sh
+    # Run Playwright tests against deploy_env
+    when:
+      and:
+        - equal: [ "run-e2e-tests", << pipeline.parameters.api_call >> ]
+        - and:
+            - not:
+                equal: [ "UNKNOWN", << pipeline.parameters.deploy_env >> ]
+            - not:
+                equal: [ "prod", << pipeline.parameters.deploy_env >> ]
+    jobs:
+      - build-playwright-job
+      - run-playwright-test-job:
+          env_name: << pipeline.parameters.deploy_env >>
+          requires:
+            - build-playwright-job
 
   build-and-deploy-all-apps-workflow:
     unless: << pipeline.parameters.do-builds >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -693,18 +693,22 @@ jobs:
           working_directory: *playwright_path
           command: |
             set -e
-            TESTFILES=$(circleci tests glob "tests/**/*.spec.ts")
+
+            TESTFILES=$(circleci tests glob "tests/**/*.spec.ts" | circleci tests split --split-by=timings)
+            echo $TESTFILES
+            echo "/end"
+
             npm run test:ci $TESTFILES --grep << parameters.test_suite >>
             # npx playwright test --grep << parameters.test_suite >>
           no_output_timeout: 3m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
       # File paths are relative and defined in playwright.config.ts Reporter section
       # Fails to load traces in CircleCI. See https://github.com/microsoft/playwright/issues/18108
       - store_test_results:
-          path: test-results
+          path: playwright-e2e/test-results/junit
       - store_artifacts:
-          path: test-results
+          path: playwright-e2e/test-results
       - store_artifacts:
-          path: html-test-results
+          path: playwright-e2e/html-test-results
 
 
 parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -693,12 +693,8 @@ jobs:
           name: "Running Playwright tests"
           working_directory: *playwright_path
           command: |
-            set -e
-
-            TESTFILES=$(circleci tests glob "tests/**/*.spec.ts" | circleci tests split --split-by=timings)
-            echo $TESTFILES
-            echo "/end"
-
+            shopt -s globstar
+            TESTFILES=$(circleci tests glob "tests/**/*.spec.ts" | circleci tests split --split-by=timings --show-counts)
             npm run test:ci $TESTFILES
             # TODO: Can't use --grep when splitting tests
             # npx playwright test --grep << parameters.test_suite >>
@@ -707,6 +703,7 @@ jobs:
       # Fails to load traces in CircleCI. See https://github.com/microsoft/playwright/issues/18108
       - run:
           working_directory: *playwright_path
+          name: Copy junit results.xml
           command: |
             mkdir -p /tmp/junit
             cp test-results/junit/results.xml /tmp/junit
@@ -715,6 +712,7 @@ jobs:
           path: /tmp/junit
       - store_artifacts:
           path: /tmp/junit
+          destination: junit
       - store_artifacts:
           path: playwright-e2e/test-results
           destination: test-results

--- a/.circleci/skip-e2e-checks.sh
+++ b/.circleci/skip-e2e-checks.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-set -xv

--- a/.circleci/skip-e2e-checks.sh
+++ b/.circleci/skip-e2e-checks.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+set -xv

--- a/build-utils/run_ci.sh
+++ b/build-utils/run_ci.sh
@@ -24,7 +24,7 @@ if [[ -z $COMMAND || -z $STUDY_KEY || -z $BRANCH || ($COMMAND == "deploy" && -z 
   echo "        Run tests for given study and given branch"
   echo "    run-e2e-tests"
   echo "        Run Playwright E2E tests for given branch against specified TARGET_ENV (dev, test or staging)"
-  echo "        Specified STUDY_KEY is unused. CI API call will run all tests"
+  echo "        STUDY_KEY is unused. CI API call will run all tests"
   echo "        Example: ./run_ci.sh run-e2e-tests singular pepper-227-test dev"
   echo ""
   exit 1

--- a/build-utils/run_ci.sh
+++ b/build-utils/run_ci.sh
@@ -22,6 +22,11 @@ if [[ -z $COMMAND || -z $STUDY_KEY || -z $BRANCH || ($COMMAND == "deploy" && -z 
   echo "        Deploy saved build of corresponding to given branch to specified TARGET_ENV"
   echo "    run-tests"
   echo "        Run tests for given study and given branch"
+  echo "    run-e2e-tests"
+  echo "        Run Playwright E2E tests for given branch against specified TARGET_ENV (dev, test or staging)"
+  echo "        Given study is ignored"
+  echo "        Example: ./run_ci.sh run-e2e-tests singular pepper-227-circleci-playwright-test dev"
+  echo ""
   exit 1
 fi
 

--- a/build-utils/run_ci.sh
+++ b/build-utils/run_ci.sh
@@ -24,8 +24,8 @@ if [[ -z $COMMAND || -z $STUDY_KEY || -z $BRANCH || ($COMMAND == "deploy" && -z 
   echo "        Run tests for given study and given branch"
   echo "    run-e2e-tests"
   echo "        Run Playwright E2E tests for given branch against specified TARGET_ENV (dev, test or staging)"
-  echo "        Given study is ignored"
-  echo "        Example: ./run_ci.sh run-e2e-tests singular pepper-227-circleci-playwright-test dev"
+  echo "        Specified STUDY_KEY is unused. CI API call will run all tests"
+  echo "        Example: ./run_ci.sh run-e2e-tests singular pepper-227-test dev"
   echo ""
   exit 1
 fi

--- a/playwright-e2e/README.md
+++ b/playwright-e2e/README.md
@@ -112,10 +112,11 @@ In **/tests/singular** dir, run Singular tests only:
   - CI workflow name is `playwright-e2e-test-workflow`. Trigger this workflow via `build-utils/run_ci.sh`.
     - If this is the first time, set personal CI token in `$HOME/.circleci-token` file. To know how to generate a personal token, see https://app.circleci.com/settings/user/tokens
     - `<STUDY_NAME>` Any study name. It's required parameter by the shell script, but it's not used to run Playwright tests for targeted study. All tests will run.
-    - `<GITHUB_BRANCH_NAME>` Your branch name
+    - `<BRANCH_NAME>` Your branch name
+    - `<ENV_NAME>` One of the following: dev, test, staging
     ```
     cd build-utils
-    ./run_ci.sh run-e2e-tests <STUDY_NAME> <GITHUB_BRANCH_NAME>
+    ./run_ci.sh run-e2e-tests <STUDY_NAME> <BRANCH_NAME> <ENV_NAME>
     ```
   
 ### Debugging in Intellij

--- a/playwright-e2e/README.md
+++ b/playwright-e2e/README.md
@@ -108,6 +108,19 @@ In **/tests/singular** dir, run Singular tests only:
   * For example, to run `login-visual.spec.ts` test:
   > npx cross-env SITE_PASSWORD=<SITE_PASSWORD> SINGULAR_USER_EMAIL=<EMAIL> SINGULAR_USER_PASSWORD=<YOUR_PASSWORD> SINGULAR_BASE_URL=<HOME_URL> npx playwright test --config=playwright.config.ts login-visual.spec.ts
 
+### Running tests on CI
+- Checking new or/and modified Playwright tests pass in CI.
+  - Trigger Playwright tests workflow by call to `build-utils/run_ci.sh`.
+    - If this is the first time, set personal CI token in `$HOME/.circleci-token` file. To see how to generate a personal token: https://app.circleci.com/settings/user/tokens
+    - `<STUDY_NAME>` Any study name. It's required parameter by the shell script `run_ci.sh` but it's not used to run Playwright tests for a study. All tests will run against the `dev` env to ensure all tests are working fine.
+    - `<GITHUB_BRANCH_NAME>` Your branch name
+    ```
+    cd build-utils
+    ./run_ci.sh run-e2e-tests <STUDY_NAME> <GITHUB_BRANCH_NAME>
+    ```
+
+- When PR is merged, Playwright tests will run automatically after deploy has finished successfully
+### Debugging in Intellij
 ### Debugging in Intellij
 
 - [TODO]

--- a/playwright-e2e/README.md
+++ b/playwright-e2e/README.md
@@ -109,18 +109,15 @@ In **/tests/singular** dir, run Singular tests only:
   > npx cross-env SITE_PASSWORD=<SITE_PASSWORD> SINGULAR_USER_EMAIL=<EMAIL> SINGULAR_USER_PASSWORD=<YOUR_PASSWORD> SINGULAR_BASE_URL=<HOME_URL> npx playwright test --config=playwright.config.ts login-visual.spec.ts
 
 ### Running tests on CI
-- Checking new or/and modified Playwright tests pass in CI.
-  - Trigger Playwright tests workflow by call to `build-utils/run_ci.sh`.
-    - If this is the first time, set personal CI token in `$HOME/.circleci-token` file. To see how to generate a personal token: https://app.circleci.com/settings/user/tokens
-    - `<STUDY_NAME>` Any study name. It's required parameter by the shell script `run_ci.sh` but it's not used to run Playwright tests for a study. All tests will run against the `dev` env to ensure all tests are working fine.
+  - CI workflow name is `playwright-e2e-test-workflow`. Trigger this workflow via `build-utils/run_ci.sh`.
+    - If this is the first time, set personal CI token in `$HOME/.circleci-token` file. To know how to generate a personal token, see https://app.circleci.com/settings/user/tokens
+    - `<STUDY_NAME>` Any study name. It's required parameter by the shell script, but it's not used to run Playwright tests for targeted study. All tests will run.
     - `<GITHUB_BRANCH_NAME>` Your branch name
     ```
     cd build-utils
     ./run_ci.sh run-e2e-tests <STUDY_NAME> <GITHUB_BRANCH_NAME>
     ```
-
-- When PR is merged, Playwright tests will run automatically after deploy has finished successfully
-### Debugging in Intellij
+  
 ### Debugging in Intellij
 
 - [TODO]

--- a/playwright-e2e/package.json
+++ b/playwright-e2e/package.json
@@ -9,7 +9,7 @@
     "build": "npx tsc --build",
     "format": "prettier --config .prettierrc.js --write --ignore-unknown \"**/*.{ts,js}\"",
     "test:e2e:singular": "npx playwright test --config=tests/singular/playwright.config.ts --grep-invert \"/nightly/|/examples/\"",
-    "test:e2e:ci:singular:all": "npx playwright test --config=tests/singular/playwright-ci.config.ts --grep-invert \"nightly/|examples/\"",
+    "test:ci": "npx playwright test",
     "test:e2e:ci:singuarl:nightly": "npx playwright test --config=tests/singular/playwright-ci.config.ts --grep \"nightly/\"",
     "lint": "eslint ./ --ext .js,.ts",
     "lint:fix": "eslint --fix --ext .js,.ts ."

--- a/playwright-e2e/pages/page-base.ts
+++ b/playwright-e2e/pages/page-base.ts
@@ -1,4 +1,4 @@
-import { Locator, Page, Response } from '@playwright/test';
+import { expect, Locator, Page, Response } from '@playwright/test';
 import { PageInterface } from './page-interface';
 
 export default abstract class PageBase implements PageInterface {
@@ -92,6 +92,7 @@ export default abstract class PageBase implements PageInterface {
 
   /** Click "Agree" button */
   async agree(): Promise<void> {
+    await expect(this.getIAgreeButton()).toBeEnabled();
     await this.clickAndWaitForNav(this.getIAgreeButton(), { waitForNav: true });
   }
 

--- a/playwright-e2e/playwright.config.ts
+++ b/playwright-e2e/playwright.config.ts
@@ -14,7 +14,8 @@ dotenv.config({ path: path.resolve(__dirname, '.env') });
  */
 const testConfig: PlaywrightTestConfig = {
   globalSetup: require.resolve('./fixtures/global-setup'),
-  // testDir: './tests',
+  testDir: '.',
+  testMatch: '**/*.spec.ts',
   /* Maximum time one test can run for. Test should be short and takes less than 2 minutes to run */
   timeout: 120 * 1000,
   /* For expect() calls */

--- a/playwright-e2e/playwright.config.ts
+++ b/playwright-e2e/playwright.config.ts
@@ -48,7 +48,7 @@ const testConfig: PlaywrightTestConfig = {
   reporter: [
     ['html', { open: 'never', outputFolder: 'html-test-results' }],
     ['list'],
-    ['junit', { outputFile: 'test-results/junit/results.xml' }]
+    ['junit', { outputFile: 'junit/results.xml' }]
   ],
   /* Folder for test artifacts such as screenshots, videos, traces, etc. */
   outputDir: 'test-results',

--- a/playwright-e2e/playwright.config.ts
+++ b/playwright-e2e/playwright.config.ts
@@ -48,7 +48,7 @@ const testConfig: PlaywrightTestConfig = {
   reporter: [
     ['html', { open: 'never', outputFolder: 'html-test-results' }],
     ['list'],
-    ['junit', { outputFile: 'junit/results.xml' }]
+    ['junit', { outputFile: 'test-results/junit/results.xml' }]
   ],
   /* Folder for test artifacts such as screenshots, videos, traces, etc. */
   outputDir: 'test-results',

--- a/playwright-e2e/playwright.config.ts
+++ b/playwright-e2e/playwright.config.ts
@@ -15,7 +15,7 @@ dotenv.config({ path: path.resolve(__dirname, '.env') });
 const testConfig: PlaywrightTestConfig = {
   globalSetup: require.resolve('./fixtures/global-setup'),
   testDir: './tests',
-  /* Maximum time one test can run for. */
+  /* Maximum time one test can run for. Test should be short and takes less than 2 minutes to run */
   timeout: 120 * 1000,
   /* For expect() calls */
   expect: {

--- a/playwright-e2e/playwright.config.ts
+++ b/playwright-e2e/playwright.config.ts
@@ -49,7 +49,7 @@ const testConfig: PlaywrightTestConfig = {
   reporter: [
     ['html', { open: 'never', outputFolder: 'html-test-results' }],
     ['list'],
-    ['junit', { outputFile: 'junit/results.xml' }]
+    ['junit', { outputFile: 'junit/results/results.xml' }]
   ],
   /* Folder for test artifacts such as screenshots, videos, traces, etc. */
   outputDir: 'test-results',

--- a/playwright-e2e/playwright.config.ts
+++ b/playwright-e2e/playwright.config.ts
@@ -49,7 +49,7 @@ const testConfig: PlaywrightTestConfig = {
   reporter: [
     ['html', { open: 'never', outputFolder: 'html-test-results' }],
     ['list'],
-    ['junit', { outputFile: 'test-results/junit/results.xml' }]
+    ['junit', { outputFile: 'junit/results/results.xml' }]
   ],
   /* Folder for test artifacts such as screenshots, videos, traces, etc. */
   outputDir: 'test-results',

--- a/playwright-e2e/playwright.config.ts
+++ b/playwright-e2e/playwright.config.ts
@@ -14,7 +14,7 @@ dotenv.config({ path: path.resolve(__dirname, '.env') });
  */
 const testConfig: PlaywrightTestConfig = {
   globalSetup: require.resolve('./fixtures/global-setup'),
-  testDir: './tests',
+  // testDir: './tests',
   /* Maximum time one test can run for. Test should be short and takes less than 2 minutes to run */
   timeout: 120 * 1000,
   /* For expect() calls */

--- a/playwright-e2e/playwright.config.ts
+++ b/playwright-e2e/playwright.config.ts
@@ -51,7 +51,7 @@ const testConfig: PlaywrightTestConfig = {
     ['junit', { outputFile: 'test-results/junit/results.xml' }]
   ],
   /* Folder for test artifacts such as screenshots, videos, traces, etc. */
-  outputDir: 'test-results/',
+  outputDir: 'test-results',
 
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {

--- a/playwright-e2e/playwright.config.ts
+++ b/playwright-e2e/playwright.config.ts
@@ -49,7 +49,7 @@ const testConfig: PlaywrightTestConfig = {
   reporter: [
     ['html', { open: 'never', outputFolder: 'html-test-results' }],
     ['list'],
-    ['junit', { outputFile: 'junit/results/results.xml' }]
+    ['junit', { outputFile: 'junit/results.xml' }]
   ],
   /* Folder for test artifacts such as screenshots, videos, traces, etc. */
   outputDir: 'test-results',


### PR DESCRIPTION
Goal: 
Able to run all Playwright tests in CirlcleCI by API call. Allows tests to run against Dev, Test and Staging env, but not against Prod env.

- Parallism: 3
- Read secrets from file in Vault, exported them as env variables
- Project compile and eslint checks are prerequisites before running tests

Example:
`./run_ci.sh run-e2e-tests singular pepper-246-playwright-circleci dev`

[CI run](https://app.circleci.com/pipelines/github/broadinstitute/ddp-angular/20817/workflows/b66da933-aa18-4404-ae1b-92841ba077ff).

<img width="745" alt="Screen Shot 2022-11-02 at 9 31 57 PM" src="https://user-images.githubusercontent.com/35533885/199632589-626bed5e-e4ca-4781-9f56-317c2cd207e7.png">