### PR TITLE
[Playwright] Set up CI cron job to run playwright tests against Test env Mon-Fri

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -865,18 +865,32 @@ workflows:
           <<: *deploy_branch_filters
           study_key: fon
 
-  test-nightly:
+  nightly-deploy:
     triggers:
       - schedule:
-          cron: "0 22 * * *" # daily around 6 PM EST
+          cron: "0 22 * * *" # UTC time. daily around 6 PM EST
           filters:
             branches:
               only:
-                - pepper-247-nightly-run-playwright-test #  develop
+                - develop
     jobs:
       - build-and-deploy-job:
-          name: nightly-build-deploy-<< matrix.study_key >>
+          name: build-deploy-<< matrix.study_key >>
           matrix:
             alias: nightly-build-deploy
             parameters:
               study_key: [ basil, osteo, angio, brain, mbc, testboston, mpc, atcp, rarex, rgp, esc, prion, cgc, circadia, pancan, singular, brugada, lms, fon ]
+
+  nightly-playwright-test:
+    # Triggered at 7 PM EST on every day-of-week from Sunday through Friday
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ nightly-playwright-test, << pipeline.schedule.name >> ]
+    jobs:
+      - build-playwright-test-job:
+          env: << pipeline.parameters.env >>
+      - run-playwright-test-job:
+          env: << pipeline.parameters.env >>
+          requires:
+            - build-playwright-test-job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -889,8 +889,8 @@ workflows:
         - equal: [ nightly-playwright-test, << pipeline.schedule.name >> ]
     jobs:
       - build-playwright-test-job:
-          env: << pipeline.parameters.env >>
+          env: << pipeline.parameters.deploy_env >>
       - run-playwright-test-job:
-          env: << pipeline.parameters.env >>
+          env: << pipeline.parameters.deploy_env >>
           requires:
             - build-playwright-test-job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,5 @@
 version: 2.1
 
-orbs:
-  jq: circleci/jq@2.2.0
-
 references:
   repo_path: &repo_path
       /home/circleci/repo
@@ -652,13 +649,6 @@ jobs:
           env: << parameters.env >>
       - attach_workspace:
           at: .
-      - jq/install
-      - run:
-          name: Inspect previous test metadata
-          command: |
-            # aut-detect timing does not work because CircleCI CLI expects both filenames and classnames to be present in JUnit xml.
-            # See https://support.circleci.com/hc/en-us/articles/360000376788-How-to-troubleshoot-Test-Splitting
-            cat "${CIRCLE_INTERNAL_TASK_DATA}/circle-test-results/results.json" | jq .
       - run:
           name: Export env variables to BASH_ENV
           command: |
@@ -679,6 +669,7 @@ jobs:
           name: Running Playwright tests
           working_directory: *playwright_path
           command: |
+            # CI aut-detect by timing does not work because CircleCI CLI expects both filenames and classnames to be present in JUnit xml
             SHARD="$((${CIRCLE_NODE_INDEX}+1))"; npm run test:ci -- --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
           no_output_timeout: 3m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
       - store_test_results:
@@ -874,69 +865,18 @@ workflows:
           <<: *deploy_branch_filters
           study_key: fon
 
-  nightly:
+  test-nightly:
     triggers:
       - schedule:
-          cron: "0 22 * * *" # daily around 6 PM EST
+          cron: "* * * * *" # daily around 6 PM EST
           filters:
             branches:
               only:
-                - develop
+                - pepper-247-nightly-run-playwright-test #  develop
     jobs:
       - build-and-deploy-job:
-          name: basil-nightly
-          study_key: basil
-      - build-and-deploy-job:
-          name: osteo-nightly
-          study_key: osteo
-      - build-and-deploy-job:
-          name: angio-nightly
-          study_key: angio
-      - build-and-deploy-job:
-          name: brain-nightly
-          study_key: brain
-      - build-and-deploy-job:
-          name: mbc-nightly
-          study_key: mbc
-      - build-and-deploy-job:
-          name: testboston-nightly
-          study_key: testboston
-      - build-and-deploy-job:
-          name: mpc-nightly
-          study_key: mpc
-      - build-and-deploy-job:
-          name: atcp-nightly
-          study_key: atcp
-      - build-and-deploy-job:
-          name: rarex-nightly
-          study_key: rarex
-      - build-and-deploy-job:
-          name: rgp-nightly
-          study_key: rgp
-      - build-and-deploy-job:
-          name: esc-nightly
-          study_key: esc
-      - build-and-deploy-job:
-          name: prion-nightly
-          study_key: prion
-      - build-and-deploy-job:
-          name: cgc-nightly
-          study_key: cgc
-      - build-and-deploy-job:
-          name: circadia-nightly
-          study_key: circadia
-      - build-and-deploy-job:
-          name: pancan-nightly
-          study_key: pancan
-      - build-and-deploy-job:
-          name: singular-nightly
-          study_key: singular
-      - build-and-deploy-job:
-          name: brugada-nightly
-          study_key: brugada
-      - build-and-deploy-job:
-          name: lms-nightly
-          study_key: lms
-      - build-and-deploy-job:
-          name: fon-nightly
-          study_key: fon
+          name: nightly-build-deploy-<< matrix.study_key >>
+          matrix:
+            alias: nightly-build-deploy-<< matrix.study_key >>
+            parameters:
+              study_key: [ basil, osteo, angio, brain, mbc, testboston, mpc, atcp, rarex, rgp, esc, prion, cgc, circadia, pancan, singular, brugada, lms, fon ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -874,22 +874,8 @@ workflows:
           <<: *deploy_branch_filters
           study_key: fon
 
-  nightly-deploy:
-    # Triggered at 6 PM EST everyday, every month
-    when:
-      and:
-        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-        - equal: [ nightly-build-deploy, << pipeline.schedule.name >> ]
-    jobs:
-      - build-and-deploy-job:
-          name: build-deploy-<< matrix.study_key >>
-          matrix:
-            alias: nightly-build-deploy
-            parameters:
-              study_key: [ basil, osteo, angio, brain, mbc, testboston, mpc, atcp, rarex, rgp, esc, prion, cgc, circadia, pancan, singular, brugada, lms, fon ]
-
-  nightly-playwright-test:
-    # Triggered at 7 PM EST on Sunday through Friday
+  scheduled-playwright-test:
+    # Triggered every 4 hours on Monday through Friday
     when:
       and:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -877,6 +877,6 @@ workflows:
       - build-and-deploy-job:
           name: nightly-build-deploy-<< matrix.study_key >>
           matrix:
-            alias: nightly-build-deploy-<< matrix.study_key >>
+            alias: nightly-build-deploy
             parameters:
               study_key: [ basil, osteo, angio, brain, mbc, testboston, mpc, atcp, rarex, rgp, esc, prion, cgc, circadia, pancan, singular, brugada, lms, fon ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -866,13 +866,11 @@ workflows:
           study_key: fon
 
   nightly-deploy:
-    triggers:
-      - schedule:
-          cron: "0 22 * * *" # UTC time. daily around 6 PM EST
-          filters:
-            branches:
-              only:
-                - develop
+    # Triggered at 6 PM EST everyday, every month
+    when:
+      and:
+        - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - equal: [ nightly-build-deploy, << pipeline.schedule.name >> ]
     jobs:
       - build-and-deploy-job:
           name: build-deploy-<< matrix.study_key >>
@@ -882,7 +880,7 @@ workflows:
               study_key: [ basil, osteo, angio, brain, mbc, testboston, mpc, atcp, rarex, rgp, esc, prion, cgc, circadia, pancan, singular, brugada, lms, fon ]
 
   nightly-playwright-test:
-    # Triggered at 7 PM EST on every day-of-week from Sunday through Friday
+    # Triggered at 7 PM EST on Sunday through Friday
     when:
       and:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -868,7 +868,7 @@ workflows:
   test-nightly:
     triggers:
       - schedule:
-          cron: "* * * * *" # daily around 6 PM EST
+          cron: "0 22 * * *" # daily around 6 PM EST
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,6 +34,14 @@ executors:
     environment:
       NODE_ENV: development # Needed if playwright is in devDependencies
 
+  # Job runs for main branch only
+  filter-develop-branch: &filter-develop-branch
+    filters:
+      tags:
+        ignore: /.*/
+      branches:
+        only: develop
+
 commands:
   app-build-and-store:
     description: Run build and store archive of it
@@ -669,7 +677,8 @@ jobs:
           name: Running Playwright tests
           working_directory: *playwright_path
           command: |
-            # CI aut-detect by timing does not work because CircleCI CLI expects both filenames and classnames to be present in JUnit xml
+            # CI split by auto-detect timing does not work because CircleCI CLI expects both filenames and classnames to be present in JUnit xml.
+            # Playwright generated JUnit xml does not have filenames.
             SHARD="$((${CIRCLE_NODE_INDEX}+1))"; npm run test:ci -- --shard=${SHARD}/${CIRCLE_NODE_TOTAL}
           no_output_timeout: 3m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
       - store_test_results:
@@ -887,8 +896,10 @@ workflows:
         - equal: [ nightly-playwright-test, << pipeline.schedule.name >> ]
     jobs:
       - build-playwright-test-job:
+          <<: *filter-develop-branch
           env: << pipeline.parameters.deploy_env >>
       - run-playwright-test-job:
+          <<: *filter-develop-branch
           env: << pipeline.parameters.deploy_env >>
           requires:
             - build-playwright-test-job

--- a/playwright-e2e/playwright.config.ts
+++ b/playwright-e2e/playwright.config.ts
@@ -66,9 +66,9 @@ const testConfig: PlaywrightTestConfig = {
     // baseURL: 'http://localhost:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'retain-on-failure',
+    trace: process.env.CI ? 'on-first-retry' : 'retain-on-failure',
     screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
+    video: process.env.CI ? 'on-first-retry' : 'retain-on-failure', // Limit load on CI system because trace and video add load
 
     userAgent:
       'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) ' +


### PR DESCRIPTION
Created new `nightly-playwright-test` pipeline which runs Playwright tests on schedule (Mon-Fri every 4 hours) against the Test (Dev env is less stable) env.
In addition, fixed existing schedule for the `nightly` build-deploy pipeline because scheduled Workflow will stop working at the end of year. Also removed boilerplate code by using matrix. See https://circleci.com/docs/workflows/#scheduling-a-workflow

Project Settings => Triggers:
https://app.circleci.com/settings/project/github/broadinstitute/ddp-angular/triggers?return-to=https%3A%2F%2Fapp.circleci.com%2Fpipelines%2Fgithub%2Fbroadinstitute%2Fddp-angular

<img width="1479" alt="Screen Shot 2022-11-04 at 12 32 08 PM" src="https://user-images.githubusercontent.com/35533885/200027641-23141da1-f1e1-487f-b6f5-6c34d819ec8f.png">
