### PR TITLE
DSM-PEPPER-78-setting-word-breaking

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.css
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.css
@@ -4,6 +4,10 @@
   margin-bottom: 0;
 }
 
+td.breakWords {
+  white-space: normal;
+  overflow-wrap: break-word;
+}
 
 .NO-PADDING-START{
   padding-inline-start: 0;

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.html
@@ -271,7 +271,7 @@
             <!--profile values or dsm values-->
             <ng-container *ngFor="let alias of getKeys()">
               <td *ngFor="let col of selectedColumns[alias]"
-                  (click)="openParticipant(pt, alias)">
+                  (click)="openParticipant(pt, alias)" class="breakWords">
                 <ng-container *ngIf="col.participantColumn.esData && pt.proxyData != null">
                   <ng-container *ngIf="col.participantColumn.tableAlias === 'proxy'">
                     <ul class="NO-PADDING-START">


### PR DESCRIPTION
[PEPPER-78](https://broadworkbench.atlassian.net/browse/PEPPER-78)

Fixed displaying too long strings in the horizon, instead, words will be broken and the container will be extended to the bottom.

Just see how it looks:

https://user-images.githubusercontent.com/77500504/200800317-8537de32-64ff-446d-bc6e-71f58a3a9755.mov

