### PR TITLE
DSM-PEPPER-296-RGP-resetting-columns-fixed

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -1020,11 +1020,14 @@ export class ParticipantListComponent implements OnInit {
               }
             } else {
               // if selected columns are not set, set to default columns
+              const selectedStudy = localStorage.getItem(ComponentService.MENU_SELECTED_REALM);
               if ((this.selectedColumns['data'] && this.selectedColumns['data'].length === 0)
                 || (!this.selectedColumns['data'] && this.isSelectedColumnsNotEmpty())) {
-                this.dataSources.forEach((value: string, key: string) => {
-                  this.selectedColumns[key] = [];
-                });
+                if(selectedStudy !== 'RGP') {
+                  this.dataSources.forEach((value: string, key: string) => {
+                    this.selectedColumns[key] = [];
+                  });
+                }
                 this.refillWithDefaultColumns();
               }
             }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -133,6 +133,7 @@ export class ParticipantListComponent implements OnInit {
   selectAll = false;
   selectAllColumnsLabel = 'Select all';
   selectedPatients: string[] = [];
+  searchForRGP: boolean = false;
 
   constructor(private role: RoleService, private dsmService: DSMService, private compService: ComponentService,
                private router: Router, private auth: Auth, private route: ActivatedRoute, private util: Utils,
@@ -1027,8 +1028,11 @@ export class ParticipantListComponent implements OnInit {
                   this.dataSources.forEach((value: string, key: string) => {
                     this.selectedColumns[key] = [];
                   });
+                  this.refillWithDefaultColumns();
                 }
-                this.refillWithDefaultColumns();
+                if(selectedStudy === 'RGP' && !this.searchForRGP) {
+                  this.refillWithDefaultColumns();
+                }
               }
             }
             const date = new Date();
@@ -1439,6 +1443,10 @@ export class ParticipantListComponent implements OnInit {
       this.deselectQuickFilters();
       // TODO - can be changed later to all using the same - after all studies are migrated!
       // check if it was a tableAlias data filter -> filter client side
+      const selectedStudy = localStorage.getItem(ComponentService.MENU_SELECTED_REALM);
+      if(selectedStudy === 'RGP') {
+        this.searchForRGP = true;
+      }
       this.selectFilter(null);
     }
   }


### PR DESCRIPTION
[PEPPER-296](https://broadworkbench.atlassian.net/browse/PEPPER-296)

This error probably appears only for RGP study and the reason is the `data` field in `selectedColumns` object, so-called - "Participant Columns", which is empty by default:
Whenever we select something that doesn't include in the above-mentioned column and we don't specify `viewFilter`, code execution flow drops into `else` block (line 1021), where it checks for the length of the `data` field, which is 0, therefore all selected columns are reset back to the default selection.

**Solution:**
I have inserted a check for resetting selected columns to an empty array. It will only happen if the selected study is not **RGP**.
Not sure yet If it can break anything, didn't spot any bugs up until now.

**Another solution would be:**
If the `data` field was not empty by default.

**After fix:**

https://user-images.githubusercontent.com/77500504/201032349-679fae14-3a41-4b0e-b512-135984c07c04.mov

