### PR TITLE
DSM-PEPPER-107-display-question

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/activity-data/activity-data.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/activity-data/activity-data.component.html
@@ -105,7 +105,7 @@
 
   <ng-container *ngIf="type === 'COMPOSITE'">
       <div *ngFor="let compose of composite">
-        <p *ngIf="compose.answer"><b>{{compose.answer}}</b>  (<span *ngIf="compose.question">{{compose.question}}</span>)</p>
+        <p *ngIf="compose.answer"><b>{{compose.answer}}</b>  (<span>{{compose.question || compose.questionStableId}}</span>)</p>
       </div>
   </ng-container>
 

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/activity-data/models/question-type-models.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/activity-data/models/question-type-models.ts
@@ -9,7 +9,7 @@ export interface QuestionTypeModel {
   // Answer Types
   answer?: string | number;
   picklistAnswer?: Partial<PicklistAnswersModel>;
-  compositeAnswer?: MutualModel[];
+  compositeAnswer?: CompositeModel[];
   matrixAnswer?: MatrixAnswer[];
 }
 
@@ -20,10 +20,11 @@ export interface MatrixAnswer {
 
 /* Models will be added as necessary */
 
-// Composite Matrix Model
-interface MutualModel {
+// Composite Model
+interface CompositeModel {
   question: string;
   answer: string;
+  questionStableId: string;
 }
 
 // Picklist

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/activity-data/services/buildingFactory.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/activity-data/services/buildingFactory.service.ts
@@ -129,7 +129,7 @@ export class BuildingFactoryService {
           default:
             endAnswer = this.getNiceUserText(compAnswer[index]);
         }
-        compositeAnswer.push({question: endQuestion, answer: endAnswer});
+        compositeAnswer.push({question: endQuestion, answer: endAnswer, questionStableId: childQuestion.stableId});
       });
     });
 


### PR DESCRIPTION
[PEPPER-107](https://broadworkbench.atlassian.net/browse/PEPPER-107)

_The reason for this bug is simple:_ the `questionText` field is empty in the `activityDefinitions` object

**Solution:**
In case of `questionText` is empty, we display `questionStableId`:
<img width="479" alt="Screenshot 2022-11-10 at 14 56 35" src="https://user-images.githubusercontent.com/77500504/201073895-2e4e577c-ab5b-48eb-b64c-4bba34720a1a.png">


