### PR TITLE
[PEPPER-317] [Playwright] Synchronization improvement: wait for request to finish for input and checkbox

### DIFF
--- a/playwright-e2e/.gitignore
+++ b/playwright-e2e/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 **/playwright-report/
 **/playwright/.cache/
 build/
+junit/
 
 **/.env
 

--- a/playwright-e2e/data/fake-user.json
+++ b/playwright-e2e/data/fake-user.json
@@ -83,7 +83,7 @@
       "DD": "20",
       "YYYY": "2019"
     },
-    "age": "03",
+    "age": "3",
     "country": {
       "name": "UNITED STATES",
       "abbreviation": "US"

--- a/playwright-e2e/lib/component/Question.ts
+++ b/playwright-e2e/lib/component/Question.ts
@@ -107,7 +107,7 @@ export default class Question {
       const responsePromise = waitRequestAfter
         ? this.page.waitForResponse(
             (response) => response.url().includes(requestURL) && response.status() === requestStatus,
-            { timeout: 30 * 1000 } // More time for retries. UI will resend failed requests
+            { timeout: 10 * 1000 } // More time for retries. UI will resend failed requests
           )
         : Promise.resolve();
 

--- a/playwright-e2e/lib/widget/Input.ts
+++ b/playwright-e2e/lib/widget/Input.ts
@@ -37,7 +37,7 @@ export default class Input {
             const includeValue = requestData ? requestData : false;
             return response.url().includes(requestURL) && response.status() === requestStatus && includeValue;
           },
-          { timeout: 30 * 1000 } // More time for retries. UI will resend failed requests
+          { timeout: 10 * 1000 } // More time for retries. UI will resend failed requests
         )
       : Promise.resolve();
 

--- a/playwright-e2e/pages/singular/enrollment/medical-record-release-form.ts
+++ b/playwright-e2e/pages/singular/enrollment/medical-record-release-form.ts
@@ -89,10 +89,10 @@ export default class MedicalRecordReleaseForm extends SingularPage {
       specialty = user.doctor.specialty
     } = opts;
 
-    await this.physicianName().fill(name);
-    await this.physicianHospital().fill(hospital);
-    await this.physicianAddress().fill(address);
-    await this.physicianPhone().fill(phone);
+    await this.physicianName().fill(name, { waitRequestAfter: false });
+    await this.physicianHospital().fill(hospital, { waitRequestAfter: false });
+    await this.physicianAddress().fill(address, { waitRequestAfter: false });
+    await this.physicianPhone().fill(phone, { waitRequestAfter: false });
     await this.physicianSpecialty().selectOption(specialty);
 
     // Wait for /answer request to finish

--- a/playwright-e2e/tests/singular/enrollment/adult-dependent-enrollment-visual.spec.ts
+++ b/playwright-e2e/tests/singular/enrollment/adult-dependent-enrollment-visual.spec.ts
@@ -49,7 +49,7 @@ test.describe('Adult Dependent visual tests', () => {
     // Clear the error message by select `The dependant being enrolled`
     await whoHasVentricleHeartDefect.uncheck(WHO.SomeoneElse);
     await whoHasVentricleHeartDefect.check(WHO.TheDependantBeingEnrolled);
-    await page.waitForResponse((resp) => resp.url().includes('/answers') && resp.status() === 200);
+    await expect(whoHasVentricleHeartDefect.errorMessage()).toBeHidden();
     const screenshotSuccess = await whoHasVentricleHeartDefect.toLocator().screenshot();
     expect(screenshotSuccess).toMatchSnapshot('whoHasVentricleHeartDefect-no-errors.png');
   });
@@ -66,11 +66,12 @@ test.describe('Adult Dependent visual tests', () => {
     // Enter an invalid age
     await age.fill('2');
     await enrollMyAdultDependentPage.next();
+    await expect(age.errorMessage()).toBeVisible();
     const screenshotInvalidAge = await age.toQuestion().screenshot();
     expect(screenshotInvalidAge).toMatchSnapshot('age-invalid-error-message.png');
     // Enter a valid age
     await age.fill('58');
-    await page.waitForResponse((resp) => resp.url().includes('/answers') && resp.status() === 200);
+    await expect(age.errorMessage()).toBeHidden();
     const screenshotValidAge = await age.toQuestion().screenshot();
     expect(screenshotValidAge).toMatchSnapshot('age-valid.png');
   });
@@ -89,16 +90,19 @@ test.describe('Adult Dependent visual tests', () => {
     const cognitiveImpairmentQuestion = enrollMyAdultDependentPage.doesDependentHaveCognitiveImpairment();
 
     await cognitiveImpairmentQuestion.check('No');
-    await page.waitForResponse((resp) => resp.url().includes('/answers') && resp.status() === 200);
+    await expect(age.errorMessage()).toBeVisible();
     const screenshotAgeOfMajorityError = await age.toQuestion().screenshot();
     expect(screenshotAgeOfMajorityError).toMatchSnapshot('age-of-majority-error-message.png');
+
     const screenshotCognitiveImpairmentNoAnswer = await cognitiveImpairmentQuestion.toLocator().screenshot();
     expect(screenshotCognitiveImpairmentNoAnswer).toMatchSnapshot('cognitive-impairment-no-answer.png');
 
     await cognitiveImpairmentQuestion.check('Yes');
-    await page.waitForResponse((resp) => resp.url().includes('/answers') && resp.status() === 200);
+    await expect(age.errorMessage()).toBeHidden();
     const screenshotCognitiveImpairment = await age.toQuestion().screenshot();
     expect(screenshotCognitiveImpairment).toMatchSnapshot('age-without-errors.png');
+
+    await expect(cognitiveImpairmentQuestion.errorMessage()).toBeHidden();
     const screenshotCognitiveImpairmentYesAnswer = await cognitiveImpairmentQuestion.toLocator().screenshot();
     expect(screenshotCognitiveImpairmentYesAnswer).toMatchSnapshot('cognitive-impairment-yes-answer.png');
   });

--- a/playwright-e2e/tests/singular/enrollment/adult-dependent-enrollment.spec.ts
+++ b/playwright-e2e/tests/singular/enrollment/adult-dependent-enrollment.spec.ts
@@ -101,7 +101,6 @@ test.describe('Enrol an adult dependent', () => {
     await medicalRecordReleaseForm.patientName().fill(`${user.adultDependent.firstName} ${dependentLastName}`);
     await medicalRecordReleaseForm.dependentParentName().fill(`${user.patient.firstName} ${user.patient.lastName}`);
     await medicalRecordReleaseForm.parentSignature().fill(`${user.patient.firstName} ${user.patient.lastName}`);
-    await page.waitForResponse((resp) => resp.url().includes('/answers') && resp.status() === 200);
     await medicalRecordReleaseForm.submit();
 
     // Medical Record File Upload

--- a/playwright-e2e/tests/singular/enrollment/adult-self-enrollment.spec.ts
+++ b/playwright-e2e/tests/singular/enrollment/adult-self-enrollment.spec.ts
@@ -98,7 +98,6 @@ test.describe('Enroll myself as adult', () => {
     await assertActivityProgress(page, 'Page 3 of 3');
     await medicalRecordReleaseForm.name().fill(`${user.patient.firstName} ${lastName}`);
     await medicalRecordReleaseForm.signature().fill(`${user.patient.firstName} ${lastName}`);
-    await page.waitForResponse((resp) => resp.url().includes('/answers') && resp.status() === 200);
     await medicalRecordReleaseForm.submit();
 
     // Medical Record File Upload

--- a/playwright-e2e/tests/singular/enrollment/child-enrollment.spec.ts
+++ b/playwright-e2e/tests/singular/enrollment/child-enrollment.spec.ts
@@ -123,7 +123,6 @@ test.describe('Enroll my child', () => {
     await assertActivityProgress(page, 'Page 3 of 3');
     await medicalRecordReleaseForm.parentName().fill(`${user.patient.firstName} ${user.patient.lastName}`);
     await medicalRecordReleaseForm.parentSignature().fill(`${user.patient.firstName} ${user.patient.lastName}`);
-    await page.waitForResponse((resp) => resp.url().includes('/answers') && resp.status() === 200);
     await medicalRecordReleaseForm.submit();
 
     // Medical Record File Upload

--- a/playwright-e2e/tests/singular/enrollment/child-non-assenting-enrollement.spec.ts
+++ b/playwright-e2e/tests/singular/enrollment/child-non-assenting-enrollement.spec.ts
@@ -39,7 +39,7 @@ test.describe('Enroll my child', () => {
     await assertActivityHeader(page, 'Enroll my child');
     const enrollMyChildPage = new EnrollMyChildPage(page);
     await enrollMyChildPage.whoInChildFamilyHasVentricleHeartDefect().check(WHO.TheChildBeingEnrolled);
-    await enrollMyChildPage.howOldIsYourChild().fill(user.secondChild.age);
+    await enrollMyChildPage.howOldIsYourChild().fill(user.secondChild.age, { waitRequestAfter: false });
     await myDashboardPage.next();
 
     // On "Consent Form for Minor Dependent" page


### PR DESCRIPTION
Occasionally, after click a button to finish one page and go to the next new page, the expected page navigation does not happen because one or more PATCH /answers requests have not complete successfully.

This PR attempts to address issue by checking and waiting for any triggered requests to finish successfully (**status = 200**) when entering text in Input and checking a checkbox.

Other types of UI fields (Select, Button, etc.) are not considered at this time.

Ran all tests on localhost a dozen time without any failures.

<img width="822" alt="Screen Shot 2022-11-14 at 3 29 53 PM" src="https://user-images.githubusercontent.com/35533885/201759723-a46c219b-317b-48be-a6a0-7c382ff0887c.png">
