### PR TITLE
[Playwright] Bug fix circleci config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,14 @@ references:
   study_guids: &study_guids
     "basil NA CMI-OSTEO cmi-brain ANGIO cmi-mbc testboston cmi-mpc PRION atcp rarex RGP cmi-esc cgc circadia cmi-pancan singular brugada cmi-lms fon"
 
+  # Job runs for develop branch only
+  filter-develop-branch: &filter-develop-branch
+    filters:
+      tags:
+        ignore: /.*/
+      branches:
+        only: develop
+
 # Container for all the builds
 executors:
   build-executor:
@@ -33,14 +41,6 @@ executors:
     working_directory: *playwright_path
     environment:
       NODE_ENV: development # Needed if playwright is in devDependencies
-
-  # Job runs for main branch only
-  filter-develop-branch: &filter-develop-branch
-    filters:
-      tags:
-        ignore: /.*/
-      branches:
-        only: develop
 
 commands:
   app-build-and-store:


### PR DESCRIPTION
PEPPER-247

Fix one bug introduced by recent PR merge https://github.com/broadinstitute/ddp-angular/pull/1854. I missed error because it happens on develop branch only.

CI error message:
```
ERROR IN CONFIG FILE:
[#/executors/filter-develop-branch] 0 subschemas matched instead of one
1. [#/executors/filter-develop-branch] expected type: String, found: Mapping
|   Executor may be a string reference to another executor
2. [#/executors/filter-develop-branch] extraneous key [filters] is not permitted
|   Permitted keys:
|     - description
|     - macos
|     - resource_class
|     - docker
|     - working_directory
|     - machine
|     - environment
|     - shell
|     - parameters
|   Passed keys:
|     - filters
```