### PR TITLE
[DSS] PEPPER-24 - Activity not updating language in A-T

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/components/internationalization/languageSelector.component.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/components/internationalization/languageSelector.component.ts
@@ -59,7 +59,7 @@ import { ActivatedRoute, Router } from '@angular/router';
                 <button
                     mat-menu-item
                     *ngFor="let lang of getUnselectedLanguages()"
-                    (click)="changeLanguage(lang); shouldUpdateQueryParam ? updateURLParam() : clearURLParam();"
+                    (click)="changeLanguage(lang, true); shouldUpdateQueryParam ? updateURLParam() : clearURLParam();"
                 >
                     {{lang.displayName}}
                 </button>
@@ -174,7 +174,7 @@ export class LanguageSelectorComponent implements OnInit, OnDestroy {
             || (language.languageCode !== this.currentLanguage.languageCode));
     }
 
-    public changeLanguage(lang: StudyLanguage): void {
+    public changeLanguage(lang: StudyLanguage, fromButton = false): void {
         if (this.currentLanguage && this.currentLanguage.languageCode === lang.languageCode) {
             return;
         }
@@ -186,7 +186,7 @@ export class LanguageSelectorComponent implements OnInit, OnDestroy {
                 const langObs: Observable<any> = this.language.changeLanguageObservable(lang.languageCode);
                 let sub;
                 // not update user profile language if language was taken from URL
-                if (this.hasUserProfile() && !this.route.snapshot.queryParamMap.get(this.languageQueryParam)) {
+                if (this.hasUserProfile() && (fromButton || !this.route.snapshot.queryParamMap.get(this.languageQueryParam))) {
                     sub = this.launchPopup();
                     const sub2 = this.updateProfileLanguage().pipe(concatMap(() => langObs)).subscribe();
                     this.anchor.addNew(sub2);


### PR DESCRIPTION
Code for managing language changes has gotten completely out of hand.
But tried to find the simplest solution to the current problem.

Essentially, the activity was not being reloaded after a language change.
The way the code is setup to reload the activity after a language change (I hate it, but it is what it is):

https://github.com/broadinstitute/ddp-angular/blob/10b0681727f77d2a9d19ed368a945d52c309ce07/ddp-workspace/projects/ddp-sdk/src/lib/services/serviceAgents/activityServiceAgent.service.ts#L39-L48


So `this.__language.getProfileLanguageUpdateNotifier()`  if it emits an observable will initiate getting an updated activity with the current user profiles language.

The problem is that the `getProfileLanguageUpdateNotifier()` will only emit if the user profile language is updated.

And there is a piece of code that prevents updating the profile:

https://github.com/broadinstitute/ddp-angular/blob/feb25b33596a3623790b2a7e7882d66eb1d4e720/ddp-workspace/projects/ddp-sdk/src/lib/components/internationalization/languageSelector.component.ts#L182-L194

Line 189 tries to check that the language choice is not coming from the URL. If IT IS coming from the URL, then it blocks the the profile change.
And if the profile change is blocked, the activity does not refresh.

Turns out that sometimes the UI will set the query param. This what UI looks like after selecting a language. Notice that the URL IS being updated:

![Screen Shot 2022-12-01 at 9 24 18 AM](https://user-images.githubusercontent.com/29984380/205078373-db473ad9-1858-462e-9a48-7bfe3459cf27.png)

So fix is simply to be explicit that the selection of language is coming from the UI button and not from URL.