### PR TITLE
Dsm dashboard improvement no extra loading

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.html
@@ -2,7 +2,7 @@
   Statistics Dashboard
 </h1>
 
-<div class="dashboard">
+<div *ngIf="canView" class="dashboard">
   <app-date-range [disabled]="isLoading" [initDates]="dateRange" (dateChanged)="dateChanged($event)" ></app-date-range>
 
   <div class="dashboard-chartsAndCounts">

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.html
@@ -3,55 +3,71 @@
 </h1>
 
 <div class="dashboard">
-
-  <app-date-range [disabled]="loading" [initDates]="dateRange" (dateChanged)="dateChanged($event)" ></app-date-range>
+  <app-date-range [disabled]="isLoading" [initDates]="dateRange" (dateChanged)="dateChanged($event)" ></app-date-range>
 
   <div class="dashboard-chartsAndCounts">
-
     <mat-tab-group [selectedIndex]="selectedTabIndex" mat-stretch-tabs  (selectedTabChange)="getStatisticsFor($event)" mat-align-tabs="center" >
-
-      <mat-tab *ngFor="let statistics of statisticsCollection" [disabled]="loading" [aria-label]="statistics.name">
+      <mat-tab *ngFor="let statistics of statisticsCollection" [disabled]="isLoading" [aria-label]="statistics.name">
         <ng-template mat-tab-label>
           <mat-icon>{{statistics.matIconName}}</mat-icon>
           {{statistics.name | titlecase}}
         </ng-template>
 
-        <ng-container *ngIf="!loading; else loadingSpinner">
-
-          <ng-container *ngIf="errorHas[statistics.name]">
-            <ng-container *ngTemplateOutlet="errorTemplate; context: {erroredStatistics: statistics.name}"></ng-container>
-          </ng-container>
-
-          <!--If you want new statistics to be displayed, add in this container as well-->
-          <ng-container [ngSwitch]="statistics.name">
-            <app-plotly-charts *ngSwitchCase="'charts'" [chartData]="statistics.data"></app-plotly-charts>
-            <app-counts-table  *ngSwitchCase="'counts'" [counts]="statistics.data"></app-counts-table>
-          </ng-container>
+        <!--Error notifier-->
+        <ng-container *ngIf="errorHas[statistics.name]">
+          <ng-container *ngTemplateOutlet="errorTemplate; context: {erroredStatistics: statistics.name}"></ng-container>
         </ng-container>
+
+        <!--Statistics container-->
+        <ng-container
+          *ngTemplateOutlet="displayStatistics; context: {name: statistics.name, data: statistics.data}">
+        </ng-container>
+
       </mat-tab>
-
     </mat-tab-group>
-
-
-    <!-- Templates-->
-
-    <ng-template  #loadingSpinner>
-      <div class="spinner">
-        <mat-spinner></mat-spinner>
-      </div>
-    </ng-template>
-
-    <ng-template #errorTemplate let-erroredStatistics="erroredStatistics">
-      <div class="errorContent">
-        <p class="errorContent-message">An error occurred while gathering the {{erroredStatistics.slice(0, -1)}} data</p>
-        <button
-          class="errorContent-button"
-          matTooltip="Retry again in the selected dates range"
-          mat-flat-button color="warn"
-          (click)="retry()">Try Again</button>
-      </div>
-    </ng-template>
-
   </div>
-
 </div>
+
+
+
+
+<!-- Templates-->
+
+<ng-template #displayStatistics let-name="name" let-data="data">
+  <!--If you want new statistics to be displayed, add in this container as well-->
+  <ng-container [ngSwitch]="name">
+
+    <ng-container  *ngSwitchCase="'charts'">
+      <ng-container *ngIf="!getLoadingStateFor(name); else loadingSpinner">
+        <app-plotly-charts [chartData]="data"></app-plotly-charts>
+      </ng-container>
+    </ng-container>
+
+    <ng-container *ngSwitchCase="'counts'" >
+      <ng-container *ngIf="!getLoadingStateFor(name); else loadingSpinner">
+        <app-counts-table [counts]="data"></app-counts-table>
+      </ng-container>
+    </ng-container>
+
+  </ng-container>
+
+</ng-template>
+
+<!--Loading template-->
+<ng-template  #loadingSpinner>
+  <div class="spinner">
+    <mat-spinner></mat-spinner>
+  </div>
+</ng-template>
+
+<!--Error notifier template-->
+<ng-template #errorTemplate let-erroredStatistics="erroredStatistics">
+  <div class="errorContent">
+    <p class="errorContent-message">An error occurred while gathering the {{erroredStatistics.slice(0, -1)}} data</p>
+    <button
+      class="errorContent-button"
+      matTooltip="Retry again in the selected dates range"
+      mat-flat-button color="warn"
+      (click)="retry()">Try Again</button>
+  </div>
+</ng-template>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.ts
@@ -7,6 +7,7 @@ import {StatisticsEnum} from './enums/statistics.enum';
 import {EMPTY, Observable, Subject, Subscription, tap} from 'rxjs';
 import {MatTabChangeEvent} from '@angular/material/tabs';
 import {ErrorsService} from '../services/errors.service';
+import {RoleService} from "../services/role.service";
 
 /**
  * For type safety, add new statistics name here as well
@@ -64,7 +65,11 @@ export class DashboardStatisticsComponent implements OnInit, OnDestroy {
   private readonly statisticsSubject$: Subject<void> = new Subject<void>();
   private readonly statisticsSubjectSubscription$: Subscription;
 
-  constructor(private dashboardStatisticsService: DashboardStatisticsService, private errorService: ErrorsService) {
+  constructor(
+    private dashboardStatisticsService: DashboardStatisticsService,
+    private errorService: ErrorsService,
+    private roleService: RoleService,
+  ) {
     this.statisticsSubjectSubscription$ = this.statisticsSubject$
       .pipe(
         tap(() => this.loading = true),
@@ -87,6 +92,10 @@ export class DashboardStatisticsComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.statisticsSubjectSubscription$.unsubscribe();
+  }
+
+  public get canView(): boolean {
+    return this.roleService.viewStatisticsDashboard;
   }
 
   public getStatisticsFor({tab}: MatTabChangeEvent): void {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.ts
@@ -7,7 +7,7 @@ import {StatisticsEnum} from './enums/statistics.enum';
 import {EMPTY, Observable, Subject, Subscription, tap} from 'rxjs';
 import {MatTabChangeEvent} from '@angular/material/tabs';
 import {ErrorsService} from '../services/errors.service';
-import {RoleService} from "../services/role.service";
+import {RoleService} from '../services/role.service';
 
 /**
  * For type safety, add new statistics name here as well

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.ts
@@ -98,14 +98,14 @@ export class DashboardStatisticsComponent implements OnInit, OnDestroy {
   }
 
   public dateChanged(dateRange: IDateRange): void {
-    this.loading = true
+    this.loading = true;
     this.isDateChanged = true;
     this.dateRange = dateRange;
     this.statisticsSubject$.next();
   }
 
   public retry(): void {
-    this.loading = true
+    this.loading = true;
     this.statisticsSubject$.next();
   }
 
@@ -113,7 +113,7 @@ export class DashboardStatisticsComponent implements OnInit, OnDestroy {
     return this.statisticsCollection.findIndex(statistics => statistics.name === this.activeTab);
   }
 
-  public getLoadingStateFor(tabName: string) {
+  public getLoadingStateFor(tabName: string): boolean {
     return this['loading_' + tabName];
   }
 

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.ts
@@ -135,7 +135,7 @@ export class DashboardStatisticsComponent implements OnInit, OnDestroy {
   }
 
   private get allowStatisticsUpdate(): boolean {
-    return (!this.activeTabStatObj.data || this.isDateChanged || this.errorHas[this.activeTab]) && !this['loading' + this.activeTab];
+    return (!this.activeTabStatObj.data || this.isDateChanged || this.errorHas[this.activeTab]) && !this.isLoading;
   }
 
   private get enumeratedActiveTab(): StatisticsEnum {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard-statistics/dashboard-statistics.component.ts
@@ -46,13 +46,19 @@ export class DashboardStatisticsComponent implements OnInit, OnDestroy {
   public errorHas: IErrorHas = {charts: false, counts: false};
 
   public dateRange: IDateRange = {startDate: null, endDate: null};
-  public loading = false;
 
   /**
    * Add here name of the statistics you want to be selected
    * and initialized for the first time
    */
-  private activeTab: StatisticsName = 'charts';
+  public activeTab: StatisticsName = 'charts';
+
+  /**
+   * Loading states for each type of statistics
+   */
+  private loading_charts = false;
+  private loading_counts = false;
+
   private isDateChanged = false;
 
   private readonly statisticsSubject$: Subject<void> = new Subject<void>();
@@ -92,14 +98,14 @@ export class DashboardStatisticsComponent implements OnInit, OnDestroy {
   }
 
   public dateChanged(dateRange: IDateRange): void {
-    this.loading = true;
+    this.loading = true
     this.isDateChanged = true;
     this.dateRange = dateRange;
     this.statisticsSubject$.next();
   }
 
   public retry(): void {
-    this.loading = true;
+    this.loading = true
     this.statisticsSubject$.next();
   }
 
@@ -107,8 +113,20 @@ export class DashboardStatisticsComponent implements OnInit, OnDestroy {
     return this.statisticsCollection.findIndex(statistics => statistics.name === this.activeTab);
   }
 
+  public getLoadingStateFor(tabName: string) {
+    return this['loading_' + tabName];
+  }
+
+  public get isLoading(): boolean {
+    return this.loading_charts || this.loading_counts;
+  }
+
+  private set loading(isLoading: boolean) {
+    this['loading_' + this.activeTab] = isLoading;
+  }
+
   private get allowStatisticsUpdate(): boolean {
-    return (!this.activeTabStatObj.data || this.isDateChanged || this.errorHas[this.activeTab]) && !this.loading;
+    return (!this.activeTabStatObj.data || this.isDateChanged || this.errorHas[this.activeTab]) && !this['loading' + this.activeTab];
   }
 
   private get enumeratedActiveTab(): StatisticsEnum {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/navigation/navigation.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/navigation/navigation.component.html
@@ -63,7 +63,7 @@
           <span class="caret"></span></a>
         <ul class="dropdown-menu">
           <li><a href="#" [routerLink]="['medicalRecordDashboard']"> Dashboard </a></li>
-          <li><a [routerLink]="['statisticsDashboard']"> Statistics Dashboard </a></li>
+          <li><a *ngIf="hasRole().viewStatisticsDashboard" [routerLink]="['statisticsDashboard']"> Statistics Dashboard </a></li>
           <hr>
           <li *ngIf="hasRole().allowedToViewMedicalRecords() || hasRole().allowedParticipantListView()"><a href="#" [routerLink]="['participantList']"> Participant List </a></li>
           <li *ngIf="hasRole().allowedToViewMedicalRecords()"><a href="#" [routerLink]="['tissueList']"> Tissue List </a></li>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/role.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/role.service.ts
@@ -138,7 +138,7 @@ export class RoleService {
           } else if(entry === 'view_only_dss_data') {
             this._viewOnlyDssData = true;
           }
-          else if(entry === "dashboard_view") {
+          else if(entry === 'dashboard_view') {
             this._viewStatisticsDashboard = true;
           }
         }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/role.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/role.service.ts
@@ -33,6 +33,7 @@ export class RoleService {
   private _isDownloadParticipantFile = false;
   private _hasKitSequencingOrder = false;
   private _viewOnlyDssData = false;
+  private _viewStatisticsDashboard = false;
 
   private _userId: string;
   private _user: string;
@@ -136,6 +137,9 @@ export class RoleService {
             this._isDownloadParticipantFile = true;
           } else if(entry === 'view_only_dss_data') {
             this._viewOnlyDssData = true;
+          }
+          else if(entry === "dashboard_view") {
+            this._viewStatisticsDashboard = true;
           }
         }
       }
@@ -280,5 +284,9 @@ export class RoleService {
 
   public get viewOnlyDSSData(): boolean {
     return this._viewOnlyDssData;
+  }
+
+  public get viewStatisticsDashboard(): boolean {
+    return this._viewStatisticsDashboard;
   }
 }


### PR DESCRIPTION
There was one issue while loading the dashboards page:
As the loading state was shared, it was rendering a non-active tab as well, which was an extra load. 

Solution:
Each statistics tab will have its own loading state.