### PR TITLE
[Playwright] [PEPPER-378] Refine clickAndWaitForNav function

### DIFF
--- a/playwright-e2e/pages/page-base.ts
+++ b/playwright-e2e/pages/page-base.ts
@@ -73,8 +73,20 @@ export default abstract class PageBase implements PageInterface {
     return this.page.goto(`${this.baseUrl}${urlPath}`, { waitUntil: 'load' });
   }
 
-  protected async clickAndWaitForNav(locator: Locator, opts: { waitForNav?: boolean } = {}): Promise<void> {
-    const { waitForNav = false } = opts;
+  /**
+   *
+   * @param {Locator} locator
+   * @param {{waitForNav?: boolean, forceClick?: boolean}} opts
+   *  <br> - forceClick: Whether to skip error message check before click. If set to true, click regardless any error on page. Defaults to false.
+   *  <br> - waitForNav: Whether to wait for page navigation to complete after click. Defaults to false.
+   * @returns {Promise<void>}
+   * @protected
+   */
+  protected async clickAndWaitForNav(locator: Locator, opts: { waitForNav?: boolean; forceClick?: boolean } = {}): Promise<void> {
+    const { waitForNav = false, forceClick = false } = opts;
+    if (!forceClick && waitForNav) {
+      await expect(this.page.locator('.error-message')).toBeHidden();
+    }
     waitForNav ? await this.waitForNavAfter(() => locator.click()) : await locator.click();
   }
 


### PR DESCRIPTION
Make `clickAndWaitForNav()` more resilient, make tests lesser flaky.

Keep form fields (e.g. input/checkbox/radiobutton) validation and click a button to navigate page in sync. Navigation to next page on a button click will fail to work while form fields validation check have not passed (one or more validation error messages are still visible on page).

Passed `build` and `eslint` checks.

<img width="377" alt="Screen Shot 2022-12-06 at 11 22 39 AM" src="https://user-images.githubusercontent.com/35533885/205972409-15ed6a61-28f7-4020-a2f2-00b0df823297.png">
