### PR TITLE
[Playwright] [PEPPER-374] Make calls to Auth0 API to set *email_verified* field

### DIFF
--- a/playwright-e2e/data/constants.ts
+++ b/playwright-e2e/data/constants.ts
@@ -81,3 +81,7 @@ export const STATES = [
   'Wisconsin',
   'Wyoming'
 ];
+
+export enum APP {
+  RPG = 'RGP'
+}

--- a/playwright-e2e/utils/api-utils.ts
+++ b/playwright-e2e/utils/api-utils.ts
@@ -1,0 +1,141 @@
+import { promises as fsPromises } from 'fs';
+import path from 'path';
+import { APP } from 'data/constants';
+
+// Stores AUTH0 access token for targeted app.
+// Created automatically when the authorization flow completes for the first time.
+const getTokenPath = (app: APP) => path.join(process.cwd(), app, 'token.txt');
+
+/**
+ * Reads previously authorized credentials from the save file.
+ */
+async function loadSavedAccessTokenIfExist(app: APP): Promise<string | null> {
+  try {
+    const contents = await fsPromises.readFile(getTokenPath(app), { encoding: 'utf-8' });
+    return contents.toString();
+  } catch (err) {
+    return null;
+  }
+}
+
+/**
+ * Build Auth0 client credentials
+ * @param {APP} app
+ * @returns {string} JSON
+ */
+function buildAuth0ClientCredentials(app: APP): string {
+  let clientId;
+  let clientSecret;
+  let audience;
+  let domain;
+
+  switch (app) {
+    case 'RGP':
+      clientId = process.env.RGP_AUTH0_CLIENT_ID;
+      clientSecret = process.env.RGP_AUTH0_CLIENT_SECRET;
+      audience = process.env.RGP_AUTH0_AUDIENCE;
+      domain = process.env.RGP_AUTH0_DOMAIN;
+      break;
+    default:
+      throw Error(`Undefined app name: ${app}`);
+  }
+
+  return JSON.stringify({
+    client_id: clientId,
+    client_secret: clientSecret,
+    audience,
+    domain
+  });
+}
+
+/**
+ * Get access token by client secrets
+ * See https://auth0.com/docs/secure/tokens/access-tokens/get-access-tokens
+ * @param {APP} app
+ * @returns {Promise<void>}
+ */
+export async function getAuth0AccessToken(app: APP): Promise<string> {
+  const savedAccessToken = await loadSavedAccessTokenIfExist(app);
+  if (savedAccessToken) {
+    return savedAccessToken;
+  }
+
+  const credentials = JSON.parse(buildAuth0ClientCredentials(app));
+
+  return fetch(`https://${credentials.domain}/oauth/token`, {
+    method: 'POST',
+    headers: { 'content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'client_credentials',
+      client_id: `${credentials.client_id}`,
+      client_secret: `${credentials.client_secret}`,
+      audience: `${credentials.audience}`
+    })
+  })
+    .then((res) => res.json())
+    .then((json) => {
+      return json.access_token;
+    })
+    .catch((err) => {
+      console.error(`ERROR: POST /oauth/token:\n`, err);
+      throw err;
+    });
+}
+
+/**
+ * Get user_id by email
+ * @param {APP} app
+ * @param email
+ * @param accessToken
+ * @returns {Promise<string>}
+ */
+export async function getAuth0UserByEmail(app: APP, email: string, accessToken: string): Promise<string> {
+  const credentials = JSON.parse(buildAuth0ClientCredentials(app));
+
+  return fetch(`https://${credentials.domain}/api/v2/users-by-email?${new URLSearchParams({ email })}`, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${accessToken}` }
+  })
+    .then(async (res) => {
+      if (res.ok) {
+        return res.json();
+      }
+      return Promise.reject(JSON.stringify(await res.json()));
+    })
+    .then((json) => {
+      // return json[0].user_id;
+      return json[0];
+    })
+    .catch((err) => {
+      console.error(`ERROR: GET /api/v2/users-by-email?${email}:\n`, err);
+      throw err;
+    });
+}
+
+export async function setAuth0UserEmailVerified(
+  app: APP,
+  email: string,
+  opts: { isEmailVerified?: boolean; accessToken?: string }
+): Promise<string> {
+  const credentials = JSON.parse(buildAuth0ClientCredentials(app));
+  const { isEmailVerified = true, accessToken = await getAuth0AccessToken(app) } = opts;
+  const user = await getAuth0UserByEmail(app, email, accessToken);
+
+  const userId = JSON.parse(JSON.stringify(user)).user_id;
+
+  return fetch(`https://${credentials.domain}/api/v2/users/${userId}`, {
+    method: 'PATCH',
+    headers: { authorization: `Bearer ${accessToken}`, 'Content-type': 'application/json; charset=UTF-8' },
+    body: JSON.stringify({ email_verified: isEmailVerified })
+  })
+    .then(async (res) => {
+      if (res.ok) {
+        return res.json();
+      }
+      return Promise.reject(JSON.stringify(await res.json()));
+    })
+    .catch((err) => {
+      console.error(`ERROR: PATCH /api/v2/users/${userId}\n`, err);
+      throw err;
+    });
+}


### PR DESCRIPTION
RGP Auth0 client credentials are saved in vault: `vault read --format=json secret/pepper/test/v1/e2e`.

Sample curl cmd to call Auth0 API to change value of "email_verified".

```
curl -X PATCH \
 --url "https://rgp-test.us.auth0.com/api/v2/users/auth0|60fad0534a94bd007186d1cc" \
 --header "Content-type: application/json" \
 --header "Authorization: Bearer ${ACCESS_TOKEN}" \
 --data '{ "email_verified": true }'
```

New file `api-utils.ts` functions have been tested on a draft RGP automation test: A new user is able to continue enrollement after new email has been verified by Auth0 API calls.

https://user-images.githubusercontent.com/35533885/206065623-a122836d-7d87-422f-b070-c2e842b24fa7.mov

