### PR TITLE
[DSM]-PEPPER-194 Removing other data if not used

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
@@ -1464,20 +1464,20 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
         const keyForDiagnosis = key.slice(10,-SPECIFY.length);
 
         if(ptData['DIAGNOSIS'] !== keyForDiagnosis) {
-          delete ptData[key]
+          delete ptData[key];
         }
       } else if(key.includes('OTHER')) {
         const keyForOtherField = key.slice(0, -OTHER_SPECIFY.length);
 
         if(ptData[keyForOtherField] !== 'OTHER') {
-          delete ptData[key]
+          delete ptData[key];
         }
 
       } else {
-        const keyForCheckboxSpecify = key.slice(0, -SPECIFY.length)
+        const keyForCheckboxSpecify = key.slice(0, -SPECIFY.length);
 
         if(!ptData[keyForCheckboxSpecify]) {
-          delete ptData[key]
+          delete ptData[key];
         }
       }
     });

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
@@ -1455,7 +1455,33 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
     }
   }
 
+  private cleanupParticipantData({data: ptData}: ParticipantData): void {
+    const SPECIFY = '_SPECIFY';
+    const OTHER_SPECIFY = '_OTHER_SPECIFY';
 
+    Object.keys(ptData).filter((key: string) => key.includes(SPECIFY)).forEach((key: string) => {
+      if(key.includes('DIAGNOSIS')) {
+        const keyForDiagnosis = key.slice(10,-SPECIFY.length);
+
+        if(ptData['DIAGNOSIS'] !== keyForDiagnosis) {
+          delete ptData[key]
+        }
+      } else if(key.includes('OTHER')) {
+        const keyForOtherField = key.slice(0, -OTHER_SPECIFY.length);
+
+        if(ptData[keyForOtherField] !== 'OTHER') {
+          delete ptData[key]
+        }
+
+      } else {
+        const keyForCheckboxSpecify = key.slice(0, -SPECIFY.length)
+
+        if(!ptData[keyForCheckboxSpecify]) {
+          delete ptData[key]
+        }
+      }
+    });
+  }
 
   formPatch(value: any, fieldSetting: FieldSettings, groupSetting: FieldSettings, dataId?: string): void {
     if (fieldSetting == null || fieldSetting.fieldType == null) {
@@ -1480,6 +1506,8 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
       }
       if (participantData != null && participantData.data != null) {
         participantData.data[fieldSetting.columnName] = value;
+
+        this.cleanupParticipantData(participantData);
 
         const nameValue: { name: string; value: any }[] = [];
         nameValue.push({name: 'd.data', value: JSON.stringify(participantData.data)});


### PR DESCRIPTION
[PEPPER-194](https://broadworkbench.atlassian.net/browse/PEPPER-194)

**Problem:** 
> In the dynamic forms e.g. Cardiac Malformation  → Fundamental Cardiac Diagnosis, if a radio button option has a conditionally displayed text option that has input entered - but then that radio button becomes inactive (because a different one in the same question was selected) - the input of the inactive radio button is still preserved.

**Solution:**
Each time a changed value is emitted from the form-data component, the function `cleanupParticipantData()` will clean up the participantData object from unused data.

**_Please see the video:_**

https://user-images.githubusercontent.com/77500504/207288977-62fcf43e-bb9f-48eb-8cfb-906468555b73.mov


