### PR TITLE
DSM-PEPPER-448-clear-manual-filters

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -1239,6 +1239,7 @@ export class ParticipantListComponent implements OnInit {
         }
       }
     });
+    this.currentFilter = [];
   }
 
   private resetPagination(): void {


### PR DESCRIPTION
[PEPPER-448](https://broadworkbench.atlassian.net/browse/PEPPER-448)

**Seems like this bug has always been there.**

`currentFilter` is the field, where all filters are stored after pressing the "Search" button and as it is not cleared when clearing manual filters, it gets attached to the `saveCurrentFilter` request. the `currentFilter` field is set to null only in the `checkRight` method, which is called only once at the initial load.

**SOLUTION:**
the `currentFilter` will be set to an empty array when calling the `clearManualFilters` method.

P.S. Please let me know if this approach can introduce any bug in order to fix it ASAP (Up until now, I didn't find any).

Please see the video:

https://user-images.githubusercontent.com/77500504/208843464-e240105c-897f-4f7e-b4be-9fc689090eda.mov



[PEPPER-448]: https://broadworkbench.atlassian.net/browse/PEPPER-448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ