### PR TITLE
PEPPER-314: changing composite question search with a child picklist …

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -453,6 +453,33 @@ export class ParticipantListComponent implements OnInit {
                         }
                       });
                     }
+                  } else if (question.questionType === 'COMPOSITE') {
+                    options = new Array<NameValue>();
+                    type = Filter.OPTION_TYPE;
+                    if (question.childQuestions != null) {
+                      question.childQuestions.forEach((childQuestion: QuestionDefinition) => {
+                        if (childQuestion.options != null) {
+                          childQuestion.options.forEach((option: Option) => {
+                            options.push(new NameValue(option.optionStableId, option.optionText));
+                            if (option?.nestedOptions != null) {
+                              option.nestedOptions.forEach((nOption: Option) => {
+                                options.push(new NameValue(nOption.optionStableId, nOption.optionText));
+                              });
+                            }
+                          });
+                        }
+                        if (childQuestion.groups != null) {
+                          childQuestion.groups.forEach((group: Group) => {
+                            options.push(new NameValue(group.groupStableId, group.groupText));
+                            if (group.options != null) {
+                              group.options.forEach((gOption: Option) => {
+                                options.push(new NameValue(gOption.optionStableId, gOption.optionText));
+                              });
+                            }
+                          });
+                        }
+                      });
+                    }
                   } else if (question.questionType === 'NUMERIC') {
                     type = Filter.NUMBER_TYPE;
                   }


### PR DESCRIPTION
…to filter component as `OPTIONS` instead of `COMPOSITE` type

<img width="1567" alt="Screen Shot 2023-01-12 at 3 16 23 PM" src="https://user-images.githubusercontent.com/20780088/212171527-6312cf8b-8341-4923-8b4a-e1f12e10f185.png">

Pancan Prequal question PRIMARY_CANCER_LIST_SELF and _CHILD will have now a picklist and not a text field @ manual search