### PR TITLE
PEPPER-44-Proxy-columns-not-visible

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -564,6 +564,23 @@ export class ParticipantListComponent implements OnInit {
         } else {
           this.dataSources.delete('a');
         }
+
+        if (jsonData.hasProxyData != null) {
+          this.dataSources.set('proxy', 'Proxy');
+          const possibleColumns: Array<Filter> = [];
+          possibleColumns.push(new Filter(new ParticipantColumn('First Name', 'firstName', 'proxy', null, true), Filter.TEXT_TYPE));
+          possibleColumns.push(new Filter(new ParticipantColumn('Last Name', 'lastName', 'proxy', null, true), Filter.TEXT_TYPE));
+          possibleColumns.push(new Filter(new ParticipantColumn('Email', 'email', 'proxy', null, true), Filter.TEXT_TYPE));
+
+          this.sourceColumns['proxy'] = possibleColumns;
+          this.selectedColumns['proxy'] = [];
+          possibleColumns.forEach(filter => {
+            const tmp = filter.participantColumn.object != null ? filter.participantColumn.object : filter.participantColumn.tableAlias;
+            this.allFieldNames.add(tmp + '.' + filter.participantColumn.name);
+          });
+          this.orderColumns();
+        }
+
         if (jsonData.filters != null) {
           jsonData.filters.forEach((val) => {
             const view: ViewFilter = ViewFilter.parseFilter(val, this.sourceColumns);
@@ -676,21 +693,7 @@ export class ParticipantListComponent implements OnInit {
         if (jsonData.hasComputedObject) {
           this.addAutomatedScoringColumns();
         }
-        if (jsonData.hasProxyData != null) {
-          this.dataSources.set('proxy', 'Proxy');
-          const possibleColumns: Array<Filter> = [];
-          possibleColumns.push(new Filter(new ParticipantColumn('First Name', 'firstName', 'proxy', null, true), Filter.TEXT_TYPE));
-          possibleColumns.push(new Filter(new ParticipantColumn('Last Name', 'lastName', 'proxy', null, true), Filter.TEXT_TYPE));
-          possibleColumns.push(new Filter(new ParticipantColumn('Email', 'email', 'proxy', null, true), Filter.TEXT_TYPE));
 
-          this.sourceColumns['proxy'] = possibleColumns;
-          this.selectedColumns['proxy'] = [];
-          possibleColumns.forEach(filter => {
-            const tmp = filter.participantColumn.object != null ? filter.participantColumn.object : filter.participantColumn.tableAlias;
-            this.allFieldNames.add(tmp + '.' + filter.participantColumn.name);
-          });
-          this.orderColumns();
-        }
         if (jsonData.hideESFields != null) {
           const hideESFields: Value[] = [];
           jsonData.hideESFields.forEach((val) => {


### PR DESCRIPTION
[PEPPER-44](https://broadworkbench.atlassian.net/browse/PEPPER-44)

**The cause:**
It was not attaching proxy columns due to a very simple reason: we attempt to get access to the proxy columns while they don't exist, which means that they don't exist by the time we create `savedFilters`, particularly when we call the `pareseFilter()` method and push filters into `savedFilters` array, which later is used to filter data. The proxy columns are actually created after `pareseFilter()`

Before I hoisted the proxy columns creation code block to the top of the `pareseFilter()`:

https://user-images.githubusercontent.com/77500504/215432747-0f1b08b6-0495-4d3d-ad7f-b19f5aabd2e1.mov

After (Fixed):

https://user-images.githubusercontent.com/77500504/215432807-3ecc3055-170b-4b3f-9638-0ba251532a19.mov



[PEPPER-44]: https://broadworkbench.atlassian.net/browse/PEPPER-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ