### PR TITLE
DSM-fix-IDE-warning-about-experimental-decorators

### DIFF
--- a/ddp-workspace/tsconfig.json
+++ b/ddp-workspace/tsconfig.json
@@ -145,6 +145,12 @@
       "path": "./projects/ddp-dsm-ui/tsconfig.spec.json"
     },
     {
+      "path": "./projects/study-builder-ui/tsconfig.app.json"
+    },
+    {
+      "path": "./projects/study-builder-ui/tsconfig.spec.json"
+    },
+    {
       "path": "./projects/ddp-fon/tsconfig.app.json"
     },
     {

--- a/ddp-workspace/tsconfig.json
+++ b/ddp-workspace/tsconfig.json
@@ -139,10 +139,10 @@
       "path": "./projects/ddp-lms/tsconfig.spec.json"
     },
     {
-      "path": "./projects/study-builder-ui/tsconfig.app.json"
+      "path": "./projects/ddp-dsm-ui/tsconfig.app.json"
     },
     {
-      "path": "./projects/study-builder-ui/tsconfig.spec.json"
+      "path": "./projects/ddp-dsm-ui/tsconfig.spec.json"
     },
     {
       "path": "./projects/ddp-fon/tsconfig.app.json"


### PR DESCRIPTION
Added ddp-dsm-ui path to the main tsconfig.json, which should solve all TS-related bugs for the DSM project, including not detecting the decorators feature (picture):

![Screenshot 2023-01-31 at 18 17 25](https://user-images.githubusercontent.com/77500504/215785187-ad5a53c0-8982-4706-80fd-ca0bde4c419f.png)
