### PR TITLE
add back missing env in enum in build-playwright-test-job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -599,7 +599,7 @@ jobs:
       env:
         default: dev
         type: enum
-        enum: [ dev, test, UNKNOWN ]
+        enum: [ dev, test, staging, prod, UNKNOWN ]
     steps:
       - halt-playwright-test-check:
           env: << parameters.env >>


### PR DESCRIPTION
When calling this `./run_ci.sh build-and-store dsm-ui dsm_rc_swarm_sprint_5 staging`, CI throws error:

```
Error calling workflow: 'playwright-e2e-test-workflow'
Error calling job: 'build-playwright-test-job'
Type error for argument env: expected type: enum ("dev" "test" "UNKNOWN"), actual value: "staging" (type string)
```