### PR TITLE
Dsm ignore 401 status for snackbar

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/interceptors/Http-interceptor.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/interceptors/Http-interceptor.service.ts
@@ -19,7 +19,7 @@ export class HttpInterceptorService implements HttpInterceptor {
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     return next.handle(req).pipe(
       catchError((error: any) => {
-        console.log(error, 'ERROR')
+        console.log(error, 'ERROR');
         error instanceof HttpErrorResponse &&
         !this.ignoreStatuses.includes(error?.status) &&
         this.errorsService.openSnackbar(error);

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/interceptors/Http-interceptor.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/interceptors/Http-interceptor.service.ts
@@ -12,12 +12,18 @@ import {ErrorsService} from '../services/errors.service';
 
 @Injectable()
 export class HttpInterceptorService implements HttpInterceptor {
+  private readonly ignoreStatuses: number[] = [401];
+
   constructor(private errorsService: ErrorsService) {}
 
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     return next.handle(req).pipe(
       catchError((error: any) => {
-        error instanceof HttpErrorResponse && this.errorsService.openSnackbar(error);
+        console.log(error, 'ERROR')
+        error instanceof HttpErrorResponse &&
+        !this.ignoreStatuses.includes(error?.status) &&
+        this.errorsService.openSnackbar(error);
+
         return throwError(() => error);
       })
     );

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/interceptors/Http-interceptor.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/interceptors/Http-interceptor.service.ts
@@ -19,7 +19,6 @@ export class HttpInterceptorService implements HttpInterceptor {
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     return next.handle(req).pipe(
       catchError((error: any) => {
-        console.log(error, 'ERROR');
         error instanceof HttpErrorResponse &&
         !this.ignoreStatuses.includes(error?.status) &&
         this.errorsService.openSnackbar(error);


### PR DESCRIPTION
Global error handler snack bar won't open if HttpErrorResponse status is 401