### PR TITLE
PEPPER-298 Automatically trigger build and lint on PR commits for all studies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -484,9 +484,8 @@ jobs:
             if [[ ${CIRCLE_PULL_REQUEST} ]]; then
               echo "CIRCLE_PULL_REQUEST: $CIRCLE_PULL_REQUEST"
               echo "CIRCLE_BRANCH: $CIRCLE_BRANCH"
+              echo "Skip archive build"
               circleci-agent step halt
-            else
-              echo "else"
             fi
       - run:
           name: Create build archive tar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -529,7 +529,7 @@ jobs:
       - store_artifacts:
           path: /tmp/junit
 
-  api-unit-test:
+  toolkit-sdk-unit-test:
     working_directory: *ng_workspace_path
     executor:
       name: build-executor
@@ -765,7 +765,7 @@ workflows:
       jobs:
         - app-ui-unit-test:
             study_key: << pipeline.parameters.study_key >>
-        - api-unit-test
+        - toolkit-sdk-unit-test
 
   playwright-e2e-test-workflow:
     # Triggered by CI API (for example, run_ci.sh)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -481,15 +481,13 @@ jobs:
       - run:
           name: Don't archive build artifacts if branch is a pull request
           command: |
-            if [[ !${CIRCLE_PULL_REQUEST} ]]; then
+            if [[ ${CIRCLE_PULL_REQUEST} ]]; then
               echo "CIRCLE_PULL_REQUEST: $CIRCLE_PULL_REQUEST"
-              regexp="[[:digit:]]\+$"
-              PR_NUMBER=$(echo $CIRCLE_PULL_REQUEST | grep -o $regexp)
-              echo "PR_NUMBER: $PR_NUMBER"
               echo "CIRCLE_BRANCH: $CIRCLE_BRANCH"
               circleci-agent step halt
+            else
+              echo "else"
             fi
-            echo "continue"
       - run:
           name: Create build archive tar
           command: |
@@ -762,14 +760,14 @@ workflows:
           matrix:
             alias: build-app
             parameters:
-              study_key: [ basil, osteo, angio, brain, mbc, testboston, mpc, atcp, rarex, rgp, esc, prion, cgc, circadia, pancan, singular, brugada, lms, fon ]
+              study_key: [ basil, osteo, angio, brain, mbc, testboston, mpc, atcp, rarex, rgp, esc, prion, cgc, pancan, singular, brugada, lms, fon ]
       - app-ui-unit-test:
           <<: *filter-pr-branch
           name: << matrix.study_key >>-unit-test
           matrix:
             alias: ui-unit-test
             parameters:
-              study_key: [ basil, osteo, angio, brain, mbc, testboston, mpc, atcp, rarex, rgp, esc, prion, cgc, circadia, pancan, singular, brugada, lms, fon ]
+              study_key: [ basil, osteo, angio, brain, mbc, testboston, mpc, atcp, rarex, rgp, esc, prion, cgc, pancan, singular, brugada, lms, fon ]
       - toolkit-sdk-unit-test:
           <<: *filter-pr-branch
       - playwright-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -529,11 +529,11 @@ jobs:
       - setup-shared-env:
           study_key: << parameters.study_key >>
       - run:
-          name: "Lint code for $ANGULAR_PROJECT_NAME"
+          name: Lint code
           command: |
             ng lint $ANGULAR_PROJECT_NAME
       - run:
-          name: "Run ng unit tests for $ANGULAR_PROJECT_NAME"
+          name: Run ui unit tests
           command: |
             mkdir -p /tmp/junit
             ng test $ANGULAR_PROJECT_NAME --watch=false --browsers ChromeHeadlessNoSandbox --reporters junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,21 +65,38 @@ commands:
           paths:
             - ./node_modules
 
-  app-build-and-store:
-    description: Run build and store archive of it
+  build:
+    # Requires "setup-shared-env" command run first
+    description: Build specified study app
     parameters:
       study_key:
         type: string
+        default: UNKNOWN
     steps:
-      - checkout-code
-      - set-deployment-environment
-      - setup-shared-env:
-          study_key: << parameters.study_key >>
-      - run-linter-check
-      - run-tests
-      - build-app:
-          study_key: << parameters.study_key >>
-      - store-app-build
+      - when:
+          condition:
+            equal: [ atcp, << parameters.study_key >> ]
+          steps:
+            - run:
+                name: build atcp auth0 scripts
+                command: |
+                  set -u
+                  ng build ddp-atcp-auth
+                  npm run convert-atcp-auth-build-to-UMD
+            - run:
+                name: build atcp auth0 styles
+                command: |
+                  set -u
+                  ./node_modules/.bin/sass ./projects/ddp-atcp/src/auth0/auth0-styles/main.scss ./projects/ddp-atcp/src/auth0/compiled/auth0-styles/main.css --style compressed
+      
+
+      - run:
+          name: ng build
+          command: |
+            set -u
+            export NODE_OPTIONS="--max-old-space-size=4096"
+            ng build $ANGULAR_PROJECT_NAME $BUILD_PARAMS --prod --aot --base-href=/ --output-path=$OUTPUT_DIR --verbose=true --progress=true
+      
 
   set-deployment-environment:
     description: "Determine working environment"
@@ -278,107 +295,6 @@ commands:
             source $BASH_ENV
 
 
-  run-linter-check:
-    description: "Run linter check"
-    steps:
-      - run:
-          name: Linter check
-          command: |
-            ng lint ddp-sdk
-            ng lint toolkit
-            ng lint $ANGULAR_PROJECT_NAME
-  run-tests:
-    description: "Run all tests"
-    steps:
-      - run:
-          name: ng test
-          command: |
-            mkdir -p /tmp/junit
-            ng test ddp-sdk --watch=false --browsers ChromeHeadlessNoSandbox --reporters junit
-            ng test toolkit --watch=false --browsers ChromeHeadlessNoSandbox --reporters junit
-            ng test $ANGULAR_PROJECT_NAME --watch=false --browsers ChromeHeadlessNoSandbox --reporters junit
-          environment:
-            JUNIT_REPORT_PATH: /tmp/junit/
-            JUNIT_REPORT_NAME: test-results.xml
-          when: always
-      - store_test_results:
-          path: /tmp/junit
-      - store_artifacts:
-          path: /tmp/junit
-
-  build-atcp-assets:
-    description: build atcp auth0 scripts & styles
-    steps:
-      - run:
-          name: build atcp auth0 scripts
-          command: |
-            set -u
-            ng build ddp-atcp-auth
-            npm run convert-atcp-auth-build-to-UMD
-      - run:
-          name: build atcp auth0 styles
-          command: |
-            set -u
-            ./node_modules/.bin/sass ./projects/ddp-atcp/src/auth0/auth0-styles/main.scss ./projects/ddp-atcp/src/auth0/compiled/auth0-styles/main.css --style compressed
-
-  execute-study-specific-commands:
-    description: run study specific commands if necessary
-    parameters:
-      study_key:
-        type: string
-        default: "UNKNOWN"
-    steps:
-      - when:
-          condition:
-            equal: [ atcp, << parameters.study_key >> ]
-          steps:
-            - build-atcp-assets
-
-  build-app:
-    description: "Build DDP study app"
-    parameters:
-      study_key:
-        type: string
-        default: "UNKNOWN"
-    steps:
-      - when:
-          condition:
-            or:
-              - equal: [ atcp, << parameters.study_key >> ]
-          steps:
-            - execute-study-specific-commands:
-                study_key: << parameters.study_key >>
-      - run:
-          name: ng build
-          command: |
-            set -u
-            export NODE_OPTIONS="--max-old-space-size=4096"
-            ng build $ANGULAR_PROJECT_NAME $BUILD_PARAMS --prod --aot --base-href=/ --output-path=$OUTPUT_DIR --verbose=true --progress=true
-
-  store-app-build:
-    description: "Copy build to cloud storage"
-    steps:
-      - run:
-          name: Create build archive
-          command: |
-            set -u
-            DATE=`date +%F`
-            TAR_NAME="${ANGULAR_PROJECT_NAME}_${DATE}_${SHORT_GIT_SHA}.tar.gz"
-            TAR_PATH="/tmp/${TAR_NAME}"
-            # Save some ENV vars for in job downstream
-            echo "export TAR_NAME=$TAR_NAME" >> $BASH_ENV
-            echo "export TAR_PATH=$TAR_PATH" >> $BASH_ENV
-            cd ${OUTPUT_DIR}
-            tar -czvf ${TAR_PATH} .
-            echo "Tar file created at ${TAR_PATH}"
-            ls -l $TAR_PATH
-      - run:
-          name: Store build archive
-          command: |
-            set -u
-            readvault.sh secret/pepper/prod/v1/conf .data.gcp.serviceKey | gcloud auth activate-service-account --key-file=-
-            gsutil cp  ${TAR_PATH} "gs://${BUILDS_BUCKET}/${ANGULAR_PROJECT_NAME}/${TAR_NAME}"
-
   conditionally-launch-build-and-deploy:
     description: Launch build and deploy if project has changed
     parameters:
@@ -471,7 +387,7 @@ commands:
                 command: circleci-agent step halt
 
 jobs:
-  build-and-deploy-job:
+  app-deploy-job:
     working_directory: *ng_workspace_path
     parameters:
       study_key:
@@ -483,7 +399,7 @@ jobs:
       - set-deployment-environment
       - setup-shared-env:
           study_key: << parameters.study_key >>
-      - build-app:
+      - build:
           study_key: << parameters.study_key >>
       - deploy-exploded-build:
           study_key: << parameters.study_key >>
@@ -546,12 +462,37 @@ jobs:
           study_key: fon
 
   app-build-and-store-job:
+    description: Build and store build artifacts to Google cloud storage
     working_directory: *ng_workspace_path
     executor:
       name: build-executor
     steps:
-      - app-build-and-store:
+      - checkout-code
+      - set-deployment-environment
+      - setup-shared-env:
           study_key: << pipeline.parameters.study_key >>
+      - build:
+          study_key: << pipeline.parameters.study_key >>
+      - run:
+          name: Create build archive
+          command: |
+            set -u
+            DATE=`date +%F`
+            TAR_NAME="${ANGULAR_PROJECT_NAME}_${DATE}_${SHORT_GIT_SHA}.tar.gz"
+            TAR_PATH="/tmp/${TAR_NAME}"
+            # Save some ENV vars for in job downstream
+            echo "export TAR_NAME=$TAR_NAME" >> $BASH_ENV
+            echo "export TAR_PATH=$TAR_PATH" >> $BASH_ENV
+            cd ${OUTPUT_DIR}
+            tar -czvf ${TAR_PATH} .
+            echo "Tar file created at ${TAR_PATH}"
+            ls -l $TAR_PATH
+      - run:
+          name: Store build archive
+          command: |
+            set -u
+            readvault.sh secret/pepper/prod/v1/conf .data.gcp.serviceKey | gcloud auth activate-service-account --key-file=-
+            gsutil cp  ${TAR_PATH} "gs://${BUILDS_BUCKET}/${ANGULAR_PROJECT_NAME}/${TAR_NAME}"
 
   deploy-stored-build-job:
     working_directory: *ng_workspace_path
@@ -564,16 +505,60 @@ jobs:
       - deploy-stored-build:
           study_key: << parameters.study_key >>
 
-  app-run-tests-job:
+  app-ui-unit-test:
+    working_directory: *ng_workspace_path
+    executor:
+      name: build-executor
+    parameters:
+      study_key:
+        type: string
+    steps:
+      - checkout-code
+      - setup-shared-env:
+          study_key: << parameters.study_key >>
+      - run:
+          name: Lint code for specified project
+          command: |
+            ng lint $ANGULAR_PROJECT_NAME
+      - run:
+          name: Run ng unit tests for specified project
+          command: |
+            mkdir -p /tmp/junit
+            ng test $ANGULAR_PROJECT_NAME --watch=false --browsers ChromeHeadlessNoSandbox --reporters junit
+          environment:
+            JUNIT_REPORT_PATH: /tmp/junit/
+            JUNIT_REPORT_NAME: test-results.xml
+          when: always
+      - store_test_results:
+          path: /tmp/junit
+      - store_artifacts:
+          path: /tmp/junit
+
+  api-unit-test:
     working_directory: *ng_workspace_path
     executor:
       name: build-executor
     steps:
       - checkout-code
-      - setup-shared-env:
-          study_key: << pipeline.parameters.study_key >>
-      - run-linter-check
-      - run-tests
+      - run:
+          name: Lint code
+          command: |
+            ng lint ddp-sdk
+            ng lint toolkit
+      - run:
+          name: Run ng unit tests for ddp-sdk and toolkit projects
+          command: |
+            mkdir -p /tmp/junit
+            ng test ddp-sdk --watch=false --browsers ChromeHeadlessNoSandbox --reporters junit
+            ng test toolkit --watch=false --browsers ChromeHeadlessNoSandbox --reporters junit
+          environment:
+            JUNIT_REPORT_PATH: /tmp/junit/
+            JUNIT_REPORT_NAME: test-results.xml
+          when: always
+      - store_test_results:
+          path: /tmp/junit
+      - store_artifacts:
+          path: /tmp/junit
 
   build-playwright-test-job:
     executor: build-executor
@@ -783,7 +768,8 @@ workflows:
           - not:
               equal: ["UNKNOWN", << pipeline.parameters.study_key >>]
       jobs:
-        - app-run-tests-job
+        - app-ui-unit-test
+        - api-unit-test
 
   playwright-e2e-test-workflow:
     # Triggered by CI API (for example, run_ci.sh)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -759,14 +759,14 @@ workflows:
           matrix:
             alias: build-app
             parameters:
-              study_key: [ basil, osteo, angio, brain, mbc, testboston, mpc, atcp, rarex, rgp, esc, prion, cgc, pancan, singular, brugada, lms, fon ]
+              study_key: [ basil, osteo, angio, brain, mbc, testboston, mpc, atcp, rgp, esc, prion, cgc, pancan, singular, brugada, lms ]
       - app-ui-unit-test:
           <<: *filter-pr-branch
           name: << matrix.study_key >>-unit-test
           matrix:
             alias: ui-unit-test
             parameters:
-              study_key: [ basil, osteo, angio, brain, mbc, testboston, mpc, atcp, rarex, rgp, esc, prion, cgc, pancan, singular, brugada, lms, fon ]
+              study_key: [ basil, osteo, angio, brain, mbc, testboston, mpc, atcp, rgp, esc, prion, cgc, pancan, singular, brugada, lms ]
       - toolkit-sdk-unit-test:
           <<: *filter-pr-branch
       - playwright-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -529,11 +529,11 @@ jobs:
       - setup-shared-env:
           study_key: << parameters.study_key >>
       - run:
-          name: Lint code for specified project
+          name: Lint code for $ANGULAR_PROJECT_NAME
           command: |
             ng lint $ANGULAR_PROJECT_NAME
       - run:
-          name: Run ng unit tests for specified project
+          name: Run ng unit tests for $ANGULAR_PROJECT_NAME
           command: |
             mkdir -p /tmp/junit
             ng test $ANGULAR_PROJECT_NAME --watch=false --browsers ChromeHeadlessNoSandbox --reporters junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,9 @@ commands:
         type: string
         default: UNKNOWN
     steps:
+      - checkout-code
+      - setup-shared-env:
+          study_key: << parameters.study_key >>
       - when:
           condition:
             equal: [ atcp, << parameters.study_key >> ]
@@ -88,8 +91,6 @@ commands:
                 command: |
                   set -u
                   ./node_modules/.bin/sass ./projects/ddp-atcp/src/auth0/auth0-styles/main.scss ./projects/ddp-atcp/src/auth0/compiled/auth0-styles/main.css --style compressed
-      
-
       - run:
           name: ng build
           command: |
@@ -395,12 +396,9 @@ jobs:
     executor:
       name: build-executor
     steps:
-      - checkout-code
-      - set-deployment-environment
-      - setup-shared-env:
-          study_key: << parameters.study_key >>
       - build:
           study_key: << parameters.study_key >>
+      - set-deployment-environment
       - deploy-exploded-build:
           study_key: << parameters.study_key >>
 
@@ -467,14 +465,11 @@ jobs:
     executor:
       name: build-executor
     steps:
-      - checkout-code
-      - set-deployment-environment
-      - setup-shared-env:
-          study_key: << pipeline.parameters.study_key >>
       - build:
           study_key: << pipeline.parameters.study_key >>
+      - set-deployment-environment
       - run:
-          name: Create build archive
+          name: Create build archive tar
           command: |
             set -u
             DATE=`date +%F`
@@ -768,7 +763,8 @@ workflows:
           - not:
               equal: ["UNKNOWN", << pipeline.parameters.study_key >>]
       jobs:
-        - app-ui-unit-test
+        - app-ui-unit-test:
+            study_key: << pipeline.parameters.study_key >>
         - api-unit-test
 
   playwright-e2e-test-workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,14 @@ references:
       branches:
         only: develop
 
+  # On PR branches only
+  filter-pr-branch: &filter-pr-branch
+    filters:
+      tags:
+        ignore: /.*/
+      branches:
+        ignore: develop
+
 # Container for all the builds
 executors:
   build-executor:
@@ -464,9 +472,18 @@ jobs:
     working_directory: *ng_workspace_path
     executor:
       name: build-executor
+    parameters:
+      study_key:
+        type: string
     steps:
       - build:
-          study_key: << pipeline.parameters.study_key >>
+          study_key: << parameters.study_key >>
+      - run:
+          name: Don't archive build artifacts if branch is not develop
+          command: |
+            if [ "$CIRCLE_BRANCH" != "develop" ]; then
+              circleci-agent step halt
+            fi
       - set-deployment-environment
       - run:
           name: Create build archive tar
@@ -555,7 +572,7 @@ jobs:
       - store_artifacts:
           path: /tmp/junit
 
-  build-playwright-test-job:
+  playwright-build:
     executor: build-executor
     working_directory: *repo_path
     parameters:
@@ -636,7 +653,7 @@ jobs:
             - playwright-env # dir which contains env-variables file
             - playwright-e2e
 
-  run-playwright-test-job:
+  playwright-test:
     # Run Playwright tests only for targeted env: Dev, Test or Staging.
     executor: playwright-test-executor
     working_directory: *repo_path
@@ -731,6 +748,28 @@ parameters:
 workflows:
   version: 2
 
+  build-pr:
+    # Launched on PR commits
+    jobs:
+      - app-build-and-store-job:
+          <<: *filter-pr-branch
+          name: build-<< matrix.study_key >>
+          matrix:
+            alias: build-app
+            parameters:
+              study_key: [ basil, osteo, angio, brain, mbc, testboston, mpc, atcp, rarex, rgp, esc, prion, cgc, circadia, pancan, singular, brugada, lms, fon ]
+      - app-ui-unit-test:
+          <<: *filter-pr-branch
+          name: unit-test-<< matrix.study_key >>
+          matrix:
+            alias: ui-unit-test
+            parameters:
+              study_key: [ basil, osteo, angio, brain, mbc, testboston, mpc, atcp, rarex, rgp, esc, prion, cgc, circadia, pancan, singular, brugada, lms, fon ]
+      - toolkit-sdk-unit-test:
+          <<: *filter-pr-branch
+      - playwright-build:
+          <<: *filter-pr-branch
+
   api-build-and-store-workflow:
     # Build study specified in api call
     when:
@@ -739,7 +778,8 @@ workflows:
         - not:
             equal: ["UNKNOWN", << pipeline.parameters.study_key >>]
     jobs:
-      - app-build-and-store-job
+      - app-build-and-store-job:
+          study_key: << pipeline.parameters.study_key >>
 
   api-deploy-workflow:
     # Deploy a study build to environment specified in api call
@@ -767,21 +807,21 @@ workflows:
             study_key: << pipeline.parameters.study_key >>
         - toolkit-sdk-unit-test
 
-  playwright-e2e-test-workflow:
+  playwright-test-workflow:
     # Triggered by CI API (for example, run_ci.sh)
-    # Run Playwright tests against Dev and Test but not for Staging and Production
+    # Run Playwright E2E tests against Dev and Test but not for Staging and Production
     when:
       and:
         - equal: [ "run-e2e-tests", << pipeline.parameters.api_call >> ]
     jobs:
-      - build-playwright-test-job:
+      - playwright-build:
           env: << pipeline.parameters.deploy_env >>
-      - run-playwright-test-job:
+      - playwright-test:
           env: << pipeline.parameters.deploy_env >>
           test_suite: << pipeline.parameters.study_key >>
           parallelism_num: << pipeline.parameters.e2e-test-parallelism >>
           requires:
-            - build-playwright-test-job
+            - playwright-build
 
   build-and-deploy-all-apps-workflow:
     unless: << pipeline.parameters.do-builds >>
@@ -823,6 +863,7 @@ workflows:
     jobs:
       - app-build-and-store-job:
           <<: *build-and-store-filters
+          study_key: << pipeline.parameters.study_key >>
 
   deploy-all-apps-workflow:
     jobs:
@@ -900,13 +941,13 @@ workflows:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         - equal: [ nightly-playwright-test, << pipeline.schedule.name >> ]
     jobs:
-      - build-playwright-test-job:
+      - playwright-build:
           <<: *filter-develop-branch
           env: << pipeline.parameters.deploy_env >>
-      - run-playwright-test-job:
+      - playwright-test:
           <<: *filter-develop-branch
           env: << pipeline.parameters.deploy_env >>
           parallelism_num: 2
           test_suite: UNKNOWN
           requires:
-            - build-playwright-test-job
+            - playwright-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -529,11 +529,11 @@ jobs:
       - setup-shared-env:
           study_key: << parameters.study_key >>
       - run:
-          name: Lint code for $ANGULAR_PROJECT_NAME
+          name: "Lint code for $ANGULAR_PROJECT_NAME"
           command: |
             ng lint $ANGULAR_PROJECT_NAME
       - run:
-          name: Run ng unit tests for $ANGULAR_PROJECT_NAME
+          name: "Run ng unit tests for $ANGULAR_PROJECT_NAME"
           command: |
             mkdir -p /tmp/junit
             ng test $ANGULAR_PROJECT_NAME --watch=false --browsers ChromeHeadlessNoSandbox --reporters junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -759,14 +759,14 @@ workflows:
           matrix:
             alias: build-app
             parameters:
-              study_key: [ basil, osteo, angio, brain, mbc, testboston, mpc, atcp, rgp, esc, prion, cgc, pancan, singular, brugada, lms ]
+              study_key: [ basil, osteo, angio, brain, mbc, mpc, atcp, rgp, esc, prion, pancan, singular, brugada, lms ]
       - app-ui-unit-test:
           <<: *filter-pr-branch
           name: << matrix.study_key >>-unit-test
           matrix:
             alias: ui-unit-test
             parameters:
-              study_key: [ basil, osteo, angio, brain, mbc, testboston, mpc, atcp, rgp, esc, prion, cgc, pancan, singular, brugada, lms ]
+              study_key: [ basil, osteo, angio, brain, mbc, mpc, atcp, rgp, esc, prion, pancan, singular, brugada, lms ]
       - toolkit-sdk-unit-test:
           <<: *filter-pr-branch
       - playwright-build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -479,12 +479,17 @@ jobs:
       - build:
           study_key: << parameters.study_key >>
       - run:
-          name: Don't archive build artifacts if branch is not develop
+          name: Don't archive build artifacts if branch is a pull request
           command: |
-            if [ "$CIRCLE_BRANCH" != "develop" ]; then
-              echo "CIRCLE_BRANCH=$CIRCLE_BRANCH"
+            if [[ !${CIRCLE_PULL_REQUEST} ]]; then
+              echo "CIRCLE_PULL_REQUEST: $CIRCLE_PULL_REQUEST"
+              regexp="[[:digit:]]\+$"
+              PR_NUMBER=$(echo $CIRCLE_PULL_REQUEST | grep -o $regexp)
+              echo "PR_NUMBER: $PR_NUMBER"
+              echo "CIRCLE_BRANCH: $CIRCLE_BRANCH"
               circleci-agent step halt
             fi
+            echo "continue"
       - run:
           name: Create build archive tar
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -482,6 +482,7 @@ jobs:
           name: Don't archive build artifacts if branch is not develop
           command: |
             if [ "$CIRCLE_BRANCH" != "develop" ]; then
+              echo "CIRCLE_BRANCH=$CIRCLE_BRANCH"
               circleci-agent step halt
             fi
       - run:
@@ -752,14 +753,14 @@ workflows:
     jobs:
       - app-build-and-store-job:
           <<: *filter-pr-branch
-          name: build-<< matrix.study_key >>
+          name: << matrix.study_key >>-build
           matrix:
             alias: build-app
             parameters:
               study_key: [ basil, osteo, angio, brain, mbc, testboston, mpc, atcp, rarex, rgp, esc, prion, cgc, circadia, pancan, singular, brugada, lms, fon ]
       - app-ui-unit-test:
           <<: *filter-pr-branch
-          name: unit-test-<< matrix.study_key >>
+          name: << matrix.study_key >>-unit-test
           matrix:
             alias: ui-unit-test
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -388,7 +388,7 @@ commands:
                 command: circleci-agent step halt
 
 jobs:
-  app-deploy-job:
+  app-deploy:
     working_directory: *ng_workspace_path
     parameters:
       study_key:
@@ -798,7 +798,7 @@ workflows:
         - << pipeline.parameters.do-builds >>
         - equal: ["UNKNOWN", << pipeline.parameters.deploy_env >>]
     jobs:
-      - app-deploy-job:
+      - app-deploy:
           study_key: << pipeline.parameters.study_key >>
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,7 @@ commands:
         default: UNKNOWN
     steps:
       - checkout-code
+      - set-deployment-environment
       - setup-shared-env:
           study_key: << parameters.study_key >>
       - when:
@@ -406,7 +407,6 @@ jobs:
     steps:
       - build:
           study_key: << parameters.study_key >>
-      - set-deployment-environment
       - deploy-exploded-build:
           study_key: << parameters.study_key >>
 
@@ -484,7 +484,6 @@ jobs:
             if [ "$CIRCLE_BRANCH" != "develop" ]; then
               circleci-agent step halt
             fi
-      - set-deployment-environment
       - run:
           name: Create build archive tar
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -798,7 +798,7 @@ workflows:
         - << pipeline.parameters.do-builds >>
         - equal: ["UNKNOWN", << pipeline.parameters.deploy_env >>]
     jobs:
-      - build-and-deploy-job:
+      - app-deploy-job:
           study_key: << pipeline.parameters.study_key >>
           filters:
             branches:

--- a/build-utils/findmodifiedprojects.sh
+++ b/build-utils/findmodifiedprojects.sh
@@ -3,8 +3,8 @@
 # Can run anywhere within the repo
 # If a file from a common area, like the root diretory was modified, we call that _SHARED_
 set +x
-#ignore these file name patterns when figuring out what modules changed 
-declare -a exclude_patterns=( '^.*\.md' '^.*.pdf' )
+#ignore these file name patterns when figuring out what modules changed
+declare -a exclude_patterns=( '^.*\.md' '^.*.pdf', '^.*\.spec\.ts' )
 
 EXCLUDE_CMD='grep -v -E'
 


### PR DESCRIPTION
### Clean up code clutter in CircleCI config.yml. Set new naming convention for CI job names. Automatically run build/lint/unit tests for all studies and playwright-e2e subproject.

Executed CircleCI [workflows](https://app.circleci.com/pipelines/github/broadinstitute/ddp-angular?branch=pepper-298-ci-config-refactor-2) for this pull request.


*******
CircleCI project setting for Github notification is now enabled .

> <img width="1037" alt="Screenshot 2023-02-09 at 8 25 57 PM" src="https://user-images.githubusercontent.com/35533885/217976937-1a630d61-a330-4006-9142-8179dcac7193.png">

> <img width="884" alt="Screenshot 2023-02-09 at 8 24 28 PM" src="https://user-images.githubusercontent.com/35533885/217976725-f0064526-cce3-45da-8727-c6ecf716b313.png">

*******
On every new PR commits, `build-pr` workflow runs automatically.

> <img width="1334" alt="Screenshot 2023-02-09 at 8 49 22 PM" src="https://user-images.githubusercontent.com/35533885/217980071-5246a0da-2011-46b4-bdb3-f46b1304ef23.png">


