### PR TITLE
PEPPER-298 Automatically run app build and lint on every pr commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -742,7 +742,8 @@ workflows:
       - playwright-build:
           <<: *filter-pr-branch
           requires:
-            - app-build
+            - app-ui-unit-test
+            - api-unit-test
 
   api-build-and-store-workflow:
     # Build study specified in api call

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -723,7 +723,7 @@ workflows:
           store_build: false
           name: << matrix.study_key >>-build
           matrix:
-            alias: app-build-and-store
+            alias: app-build
             parameters:
               study_key: [ basil, osteo, angio, brain, mbc, mpc, atcp, rgp, esc, prion, pancan, singular, brugada, lms ]
       - ui-unit-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -743,8 +743,8 @@ workflows:
       - playwright-build:
           <<: *filter-pr-branch
 
-  api-build-and-store-workflow:
-    # Build study specified in api call
+  build-single-app-workflow:
+    # Build study specified in api call by run_ci.sh
     when:
       and:
         - equal: ["build-and-store", << pipeline.parameters.api_call >>]
@@ -760,8 +760,8 @@ workflows:
             - ui-unit-test
             - api-unit-test
 
-  api-deploy-workflow:
-    # Deploy a study build to environment specified in api call
+  deploy-single-app-workflow:
+    # Deploy a study build to environment specified in api call by run_ci.sh
     when:
       and:
         - equal: ["deploy", << pipeline.parameters.api_call >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -374,6 +374,7 @@ commands:
       - run:
           name: Run ng ui unit tests
           command: |
+            echo "ng test $ANGULAR_PROJECT_NAME"
             mkdir -p /tmp/junit
             ng test $ANGULAR_PROJECT_NAME --watch=false --browsers ChromeHeadlessNoSandbox --reporters junit
           environment:
@@ -490,39 +491,37 @@ jobs:
     parameters:
       study_key:
         type: string
+      store_build:
+        type: boolean
+        default: true
     steps:
       - build:
           study_key: << parameters.study_key >>
-      - run:
-          name: Short circuit - Don't store build artifacts if branch is a pull request
-          command: |
-            if [[ ${CIRCLE_PULL_REQUEST} ]]; then
-              echo "CIRCLE_PULL_REQUEST: $CIRCLE_PULL_REQUEST"
-              echo "CIRCLE_BRANCH: $CIRCLE_BRANCH"
-              echo "Skip store build"
-              circleci-agent step halt
-            fi
-      - run:
-          name: Create build archive for << parameters.study_key >> with git SHA << pipeline.git.revision >>
-          command: |
-            set -u
-            DATE=`date +%F`
-            TAR_NAME="${ANGULAR_PROJECT_NAME}_${DATE}_${SHORT_GIT_SHA}.tar.gz"
-            TAR_PATH="/tmp/${TAR_NAME}"
-            # Save some ENV vars for in job downstream
-            echo "export TAR_NAME=$TAR_NAME" >> $BASH_ENV
-            echo "export TAR_PATH=$TAR_PATH" >> $BASH_ENV
-            cd ${OUTPUT_DIR}
-            tar -czvf ${TAR_PATH} .
-            echo "Tar file created at ${TAR_PATH}"
-            ls -l $TAR_PATH
-      - run:
-          name: Store build archive for << parameters.study_key >> with git SHA << pipeline.git.revision >>
-          command: |
-            set -u
-            readvault.sh secret/pepper/prod/v1/conf .data.gcp.serviceKey | gcloud auth activate-service-account --key-file=-
-            gsutil cp  ${TAR_PATH} "gs://${BUILDS_BUCKET}/${ANGULAR_PROJECT_NAME}/${TAR_NAME}"
-      
+      - when:
+          # Store build artifacts if store_build = true
+          condition: << parameters.store_build >>
+          steps:
+            - run:
+                name: Create build archive for << parameters.study_key >> with git SHA << pipeline.git.revision >>
+                command: |
+                  set -u
+                  DATE=`date +%F`
+                  TAR_NAME="${ANGULAR_PROJECT_NAME}_${DATE}_${SHORT_GIT_SHA}.tar.gz"
+                  TAR_PATH="/tmp/${TAR_NAME}"
+                  # Save some ENV vars for in job downstream
+                  echo "export TAR_NAME=$TAR_NAME" >> $BASH_ENV
+                  echo "export TAR_PATH=$TAR_PATH" >> $BASH_ENV
+                  cd ${OUTPUT_DIR}
+                  tar -czvf ${TAR_PATH} .
+                  echo "Tar file created at ${TAR_PATH}"
+                  ls -l $TAR_PATH
+            - run:
+                name: Store build archive for << parameters.study_key >> with git SHA << pipeline.git.revision >>
+                command: |
+                  set -u
+                  readvault.sh secret/pepper/prod/v1/conf .data.gcp.serviceKey | gcloud auth activate-service-account --key-file=-
+                  gsutil cp  ${TAR_PATH} "gs://${BUILDS_BUCKET}/${ANGULAR_PROJECT_NAME}/${TAR_NAME}"
+            
 
   deploy-stored-build-job:
     description: Deploy archived build to GAE
@@ -717,10 +716,12 @@ workflows:
   version: 2
 
   build-test-pr:
-    # Automatically launched on every PR commit
+    # Automatically run on every PR commit
     jobs:
       - app-build:
           <<: *filter-pr-branch
+          # Don't store PR build artifacts
+          store_build: false
           name: << matrix.study_key >>-build
           matrix:
             alias: app-build-and-store

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -751,6 +751,9 @@ workflows:
       - api-unit-test
       - app-build:
           study_key: << pipeline.parameters.study_key >>
+          requires:
+            - ui-unit-test
+            - api-unit-test
 
   api-deploy-workflow:
     # Deploy a study build to environment specified in api call

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -733,10 +733,16 @@ workflows:
             alias: app-ui-unit-test
             parameters:
               study_key: [ basil, osteo, angio, brain, mbc, mpc, atcp, rgp, esc, prion, pancan, singular, brugada, lms ]
+          requires:
+            - app-build
       - api-unit-test:
           <<: *filter-pr-branch
+          requires:
+            - app-build
       - playwright-build:
           <<: *filter-pr-branch
+          requires:
+            - app-build
 
   api-build-and-store-workflow:
     # Build study specified in api call

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,18 +6,24 @@ orbs:
 references:
   repo_path: &repo_path
       /home/circleci/repo
+
   ng_workspace_path: &ng_workspace_path
       /home/circleci/repo/ddp-workspace
+
   playwright_path: &playwright_path
       /home/circleci/repo/playwright-e2e
+
   npm_cache_key: &npm_cache_key
     v1-dependency-npm2-{{ checksum "package.json" }}-{{ checksum "package-lock.json" }}
+
   npm_cache_restore_key: &npm_cache_restore_key
     keys:
       - *npm_cache_key
+
   # Note: important that values of guids and keys have matching order!"
   study_keys: &study_keys
     "basil dsm-ui osteo brain angio mbc testboston mpc prion atcp rarex rgp esc cgc circadia pancan singular brugada lms fon"
+
   study_guids: &study_guids
     "basil NA CMI-OSTEO cmi-brain ANGIO cmi-mbc testboston cmi-mpc PRION atcp rarex RGP cmi-esc cgc circadia cmi-pancan singular brugada cmi-lms fon"
 
@@ -41,6 +47,7 @@ executors:
       - image: broadinstitute/study-website-build:12-08-2020A
     working_directory: *ng_workspace_path
     resource_class: medium+
+
   playwright-test-executor:
     resource_class: medium+
     docker:
@@ -108,7 +115,7 @@ commands:
             echo "export ENVIRONMENT=$DEPLOY_ENV" >> $BASH_ENV
             echo "export BUILD_PARAMS=$BUILD_PARAMS" >> $BASH_ENV
             source $BASH_ENV
-
+          #
 
   deploy-exploded-build:
     description: Deploy files to GAE
@@ -184,6 +191,7 @@ commands:
               gcloud app versions delete --quiet --service "$SERVICE" "$VERSION_TO_DELETE" --project "broad-ddp-${ENVIRONMENT}"
             done;
             exit 0;
+          #
 
   setup-shared-env:
     description: "Setup shared ENV vars used by multiple scripts"
@@ -231,7 +239,7 @@ commands:
             echo "export SHORT_GIT_SHA=`echo '<< pipeline.git.revision >>' | cut -c 1-7`" >> $BASH_ENV
             echo 'export BUILDS_BUCKET=ddp-build-artifacts' >> $BASH_ENV
             source $BASH_ENV
-
+          #
 
   build:
     description: "Build DDP study app"
@@ -265,7 +273,7 @@ commands:
             set -u
             export NODE_OPTIONS="--max-old-space-size=4096"
             ng build $ANGULAR_PROJECT_NAME $BUILD_PARAMS --configuration production --aot --base-href=/ --output-path=$OUTPUT_DIR --verbose=true --progress=true
-
+          #
 
   conditionally-launch-build-and-deploy:
     description: Launch build and deploy if project has changed
@@ -305,6 +313,7 @@ commands:
                 echo "Skipping $STUDY_KEY"
               fi
             done;
+          #
 
   conditionally-launch-build-and-store:
     description: Launch build and save job if build missing
@@ -339,25 +348,7 @@ commands:
               else
                 echo "Build for <<parameters.study_key>> found at URL: ${TAR_FILE_URL}. No new build will be initiated"
             fi
-
-  halt-playwright-test-check:
-    description: "Stop running Playwright e2e tests if halt conditions are met"
-    parameters:
-      env:
-        default: dev
-        type: enum
-        enum: [ dev, test, staging, prod, UNKNOWN ]
-    steps:
-      - when:
-          condition:
-            or:
-              - equal: [ UNKNOWN, << parameters.env >> ]
-              - equal: [ prod, << parameters.env >> ]
-              - equal: [ staging, << parameters.env >> ]
-          steps:
-            - run:
-                name: Halt job ENV=<< parameters.env >>
-                command: circleci-agent step halt
+          #
 
   run-ui-unit-test:
     description: Lint code and run ui unit tests for specified app
@@ -395,7 +386,7 @@ commands:
             ng lint ddp-sdk
             ng lint toolkit
       - run:
-          name: Run sdk and toolkit api unit tests
+          name: Run sdk and toolkit ng api unit tests
           command: |
             mkdir -p /tmp/junit
             ng test ddp-sdk --watch=false --browsers ChromeHeadlessNoSandbox --reporters junit
@@ -521,7 +512,7 @@ jobs:
                   set -u
                   readvault.sh secret/pepper/prod/v1/conf .data.gcp.serviceKey | gcloud auth activate-service-account --key-file=-
                   gsutil cp  ${TAR_PATH} "gs://${BUILDS_BUCKET}/${ANGULAR_PROJECT_NAME}/${TAR_NAME}"
-            
+                #
 
   deploy-stored-build-job:
     description: Deploy archived build to GAE
@@ -561,7 +552,6 @@ jobs:
       - deploy-exploded-build:
           study_key: << parameters.study_key >>
 
-
   playwright-build:
     executor: build-executor
     working_directory: *repo_path
@@ -600,7 +590,7 @@ jobs:
             - playwright-e2e
 
   playwright-test:
-    # Run Playwright tests only for targeted env: Dev, Test or Staging.
+    # Run Playwright tests only for targeted env: Dev or Test.
     executor: playwright-test-executor
     working_directory: *repo_path
     parameters:
@@ -618,8 +608,17 @@ jobs:
         default: << pipeline.parameters.study_key >>
     parallelism: << parameters.parallelism_num >>
     steps:
-      - halt-playwright-test-check:
-          env: << parameters.env >>
+      - when:
+          # Stop running Playwright e2e tests if env is UNKNOWN, Prod or Staging
+          condition:
+            or:
+              - equal: [ UNKNOWN, << parameters.env >> ]
+              - equal: [ prod, << parameters.env >> ]
+              - equal: [ staging, << parameters.env >> ]
+          steps:
+            - run:
+                name: Halt running Playwright tests ENV=<< parameters.env >>
+                command: circleci-agent step halt
       - attach_workspace:
           at: .
       - run:
@@ -739,7 +738,6 @@ workflows:
       - playwright-build:
           <<: *filter-pr-branch
 
-
   api-build-and-store-workflow:
     # Build study specified in api call
     when:
@@ -748,11 +746,11 @@ workflows:
         - not:
             equal: ["UNKNOWN", << pipeline.parameters.study_key >>]
     jobs:
-      - app-build:
-          study_key: << pipeline.parameters.study_key >>
       - ui-unit-test:
           study_key: << pipeline.parameters.study_key >>
       - api-unit-test
+      - app-build:
+          study_key: << pipeline.parameters.study_key >>
 
   api-deploy-workflow:
     # Deploy a study build to environment specified in api call
@@ -831,14 +829,14 @@ workflows:
   build-app-workflow:
     when: << pipeline.parameters.do-builds >>
     jobs:
-      - app-build:
-          <<: *build-and-store-filters
-          study_key: << pipeline.parameters.study_key >>
       - ui-unit-test:
           <<: *build-and-store-filters
           study_key: << pipeline.parameters.study_key >>
       - api-unit-test:
           <<: *build-and-store-filters
+      - app-build:
+          <<: *build-and-store-filters
+          study_key: << pipeline.parameters.study_key >>
 
   deploy-all-apps-workflow:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -842,6 +842,9 @@ workflows:
       - app-build:
           <<: *build-and-store-filters
           study_key: << pipeline.parameters.study_key >>
+          requires:
+            - ui-unit-test
+            - api-unit-test
 
   deploy-all-apps-workflow:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -715,7 +715,12 @@ workflows:
   version: 2
 
   build-test-pr:
-    # Automatically run on every PR commit
+    # Automatically run on every PR commit.
+    # CircleCI API calls will not launch this workflow.
+    when:
+      and:
+        - equal: [ "UNKNOWN", << pipeline.parameters.api_call >> ]
+        - equal: [ "UNKNOWN", << pipeline.parameters.study_key >> ]
     jobs:
       - app-build:
           <<: *filter-pr-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,10 +24,15 @@ references:
   # Job runs for develop branch only
   filter-develop-branch: &filter-develop-branch
     filters:
+      branches:
+        only: develop
+
+  filter-pr-branch: &filter-pr-branch
+    filters:
       tags:
         ignore: /.*/
       branches:
-        only: develop
+        ignore: develop
 
 # Container for all the builds
 executors:
@@ -81,11 +86,11 @@ commands:
             case $DEPLOY_TARGET_ENV in
               dev*)
                 DEPLOY_ENV=dev
-                BUILD_PARAMS=--sourceMap
+                BUILD_PARAMS=--source-map
               ;;
               test)
                 DEPLOY_ENV=test
-                BUILD_PARAMS=--sourceMap
+                BUILD_PARAMS=--source-map
               ;;
               staging)
                 DEPLOY_ENV=staging
@@ -95,7 +100,7 @@ commands:
               ;;
               *)
                 DEPLOY_ENV=dev
-                BUILD_PARAMS=--sourceMap
+                BUILD_PARAMS=--source-map
                 echo "Defaulting $DEPLOY_TARGET_ENV to dev environment"
               ;;
             esac
@@ -104,40 +109,6 @@ commands:
             echo "export BUILD_PARAMS=$BUILD_PARAMS" >> $BASH_ENV
             source $BASH_ENV
 
-  deploy-stored-build:
-    description: Deploy archived build to GAE
-    parameters:
-      study_key:
-        type: string
-    steps:
-      - checkout:
-          path: *repo_path
-      - setup-shared-env:
-          study_key: << parameters.study_key >>
-      - set-deployment-environment
-      - run:
-          name: Retrieve and expand build archive for << parameters.study_key >> with git SHA << pipeline.git.revision >>
-          command: |
-            set -u
-            # we are getting our builds from the one bucket
-            readvault.sh secret/pepper/prod/v1/conf .data.gcp.serviceKey | gcloud auth activate-service-account --key-file=-
-            TAR_FILE_URL_PATTERN="gs://${BUILDS_BUCKET}/${ANGULAR_PROJECT_NAME}/${ANGULAR_PROJECT_NAME}_*_${SHORT_GIT_SHA}.tar.gz"
-            echo "Looking for archive matching ${TAR_FILE_URL_PATTERN}"
-            TAR_FILE_URL=`gsutil ls $TAR_FILE_URL_PATTERN  | sort -r | head -1`
-
-            if [ -z $TAR_FILE_URL ]
-            then
-              echo "Could not find archive using pattern ${TAR_FILE_URL_PATTERN}"
-              exit 1
-            fi
-            TAR_FILE_PATH="/tmp/$(basename -- $TAR_FILE_URL)"
-            echo "Downloading ${TAR_FILE_URL} to ${TAR_FILE_PATH}"
-            gsutil cp  $TAR_FILE_URL $TAR_FILE_PATH
-            mkdir -p $OUTPUT_DIR && tar -xvf $TAR_FILE_PATH -C $OUTPUT_DIR
-            echo "Contents of extracted archive at $OUTPUT_DIR"
-            ls -l $OUTPUT_DIR
-      - deploy-exploded-build:
-          study_key: << parameters.study_key >>
 
   deploy-exploded-build:
     description: Deploy files to GAE
@@ -262,34 +233,6 @@ commands:
             source $BASH_ENV
 
 
-  run-linter-check:
-    description: "Run linter check"
-    steps:
-      - run:
-          name: Linter check
-          command: |
-            ng lint ddp-sdk
-            ng lint toolkit
-            ng lint $ANGULAR_PROJECT_NAME
-  run-tests:
-    description: "Run all tests"
-    steps:
-      - run:
-          name: ng test
-          command: |
-            mkdir -p /tmp/junit
-            ng test ddp-sdk --watch=false --browsers ChromeHeadlessNoSandbox --reporters junit
-            ng test toolkit --watch=false --browsers ChromeHeadlessNoSandbox --reporters junit
-            ng test $ANGULAR_PROJECT_NAME --watch=false --browsers ChromeHeadlessNoSandbox --reporters junit
-          environment:
-            JUNIT_REPORT_PATH: /tmp/junit/
-            JUNIT_REPORT_NAME: test-results.xml
-          when: always
-      - store_test_results:
-          path: /tmp/junit
-      - store_artifacts:
-          path: /tmp/junit
-
   build:
     description: "Build DDP study app"
     parameters:
@@ -321,31 +264,8 @@ commands:
           command: |
             set -u
             export NODE_OPTIONS="--max-old-space-size=4096"
-            ng build $ANGULAR_PROJECT_NAME $BUILD_PARAMS --prod --aot --base-href=/ --output-path=$OUTPUT_DIR --verbose=true --progress=true
+            ng build $ANGULAR_PROJECT_NAME $BUILD_PARAMS --configuration production --aot --base-href=/ --output-path=$OUTPUT_DIR --verbose=true --progress=true
 
-  store-app-build:
-    description: "Copy build to cloud storage"
-    steps:
-      - run:
-          name: Create build archive
-          command: |
-            set -u
-            DATE=`date +%F`
-            TAR_NAME="${ANGULAR_PROJECT_NAME}_${DATE}_${SHORT_GIT_SHA}.tar.gz"
-            TAR_PATH="/tmp/${TAR_NAME}"
-            # Save some ENV vars for in job downstream
-            echo "export TAR_NAME=$TAR_NAME" >> $BASH_ENV
-            echo "export TAR_PATH=$TAR_PATH" >> $BASH_ENV
-            cd ${OUTPUT_DIR}
-            tar -czvf ${TAR_PATH} .
-            echo "Tar file created at ${TAR_PATH}"
-            ls -l $TAR_PATH
-      - run:
-          name: Store build archive
-          command: |
-            set -u
-            readvault.sh secret/pepper/prod/v1/conf .data.gcp.serviceKey | gcloud auth activate-service-account --key-file=-
-            gsutil cp  ${TAR_PATH} "gs://${BUILDS_BUCKET}/${ANGULAR_PROJECT_NAME}/${TAR_NAME}"
 
   conditionally-launch-build-and-deploy:
     description: Launch build and deploy if project has changed
@@ -439,6 +359,55 @@ commands:
                 name: Halt job ENV=<< parameters.env >>
                 command: circleci-agent step halt
 
+  run-ui-unit-test:
+    description: Lint code and run ui unit tests for specified app
+    parameters:
+      study_key:
+        type: string
+    steps:
+      - setup-shared-env:
+          study_key: << parameters.study_key >>
+      - run:
+          name: Lint app code
+          command: |
+            ng lint $ANGULAR_PROJECT_NAME
+      - run:
+          name: Run ng ui unit tests
+          command: |
+            mkdir -p /tmp/junit
+            ng test $ANGULAR_PROJECT_NAME --watch=false --browsers ChromeHeadlessNoSandbox --reporters junit
+          environment:
+            JUNIT_REPORT_PATH: /tmp/junit/
+            JUNIT_REPORT_NAME: test-results.xml
+          when: always
+      - store_test_results:
+          path: /tmp/junit
+      - store_artifacts:
+          path: /tmp/junit
+
+  run-api-unit-test:
+    description: Lint code and run api unit tests for sdk and toolkit
+    steps:
+      - run:
+          name: Lint sdk and toolkit code
+          command: |
+            ng lint ddp-sdk
+            ng lint toolkit
+      - run:
+          name: Run sdk and toolkit api unit tests
+          command: |
+            mkdir -p /tmp/junit
+            ng test ddp-sdk --watch=false --browsers ChromeHeadlessNoSandbox --reporters junit
+            ng test toolkit --watch=false --browsers ChromeHeadlessNoSandbox --reporters junit
+          environment:
+            JUNIT_REPORT_PATH: /tmp/junit/
+            JUNIT_REPORT_NAME: test-results.xml
+          when: always
+      - store_test_results:
+          path: /tmp/junit
+      - store_artifacts:
+          path: /tmp/junit
+
 jobs:
   app-deploy:
     working_directory: *ng_workspace_path
@@ -450,8 +419,9 @@ jobs:
     steps:
       - build:
           study_key: << parameters.study_key >>
-      - run-linter-check
-      - run-tests
+      - run-ui-unit-test:
+          study_key: << parameters.study_key >>
+      - run-api-unit-test
       - deploy-exploded-build:
           study_key: << parameters.study_key >>
 
@@ -513,6 +483,7 @@ jobs:
           study_key: fon
 
   app-build:
+    description: Run build and store build artifacts to Google cloud storage
     working_directory: *ng_workspace_path
     executor:
       name: build-executor
@@ -522,8 +493,6 @@ jobs:
     steps:
       - build:
           study_key: << parameters.study_key >>
-      - run-linter-check
-      - run-tests
       - run:
           name: Short circuit - Don't store build artifacts if branch is a pull request
           command: |
@@ -533,9 +502,30 @@ jobs:
               echo "Skip store build"
               circleci-agent step halt
             fi
-      - store-app-build
+      - run:
+          name: Create build archive for << parameters.study_key >> with git SHA << pipeline.git.revision >>
+          command: |
+            set -u
+            DATE=`date +%F`
+            TAR_NAME="${ANGULAR_PROJECT_NAME}_${DATE}_${SHORT_GIT_SHA}.tar.gz"
+            TAR_PATH="/tmp/${TAR_NAME}"
+            # Save some ENV vars for in job downstream
+            echo "export TAR_NAME=$TAR_NAME" >> $BASH_ENV
+            echo "export TAR_PATH=$TAR_PATH" >> $BASH_ENV
+            cd ${OUTPUT_DIR}
+            tar -czvf ${TAR_PATH} .
+            echo "Tar file created at ${TAR_PATH}"
+            ls -l $TAR_PATH
+      - run:
+          name: Store build archive for << parameters.study_key >> with git SHA << pipeline.git.revision >>
+          command: |
+            set -u
+            readvault.sh secret/pepper/prod/v1/conf .data.gcp.serviceKey | gcloud auth activate-service-account --key-file=-
+            gsutil cp  ${TAR_PATH} "gs://${BUILDS_BUCKET}/${ANGULAR_PROJECT_NAME}/${TAR_NAME}"
+      
 
   deploy-stored-build-job:
+    description: Deploy archived build to GAE
     working_directory: *ng_workspace_path
     parameters:
       study_key:
@@ -543,19 +533,35 @@ jobs:
     executor:
       name: build-executor
     steps:
-      - deploy-stored-build:
+      - checkout:
+          path: *repo_path
+      - setup-shared-env:
+          study_key: << parameters.study_key >>
+      - set-deployment-environment
+      - run:
+          name: Retrieve and expand build archive for << parameters.study_key >> with git SHA << pipeline.git.revision >>
+          command: |
+            set -u
+            # we are getting our builds from the one bucket
+            readvault.sh secret/pepper/prod/v1/conf .data.gcp.serviceKey | gcloud auth activate-service-account --key-file=-
+            TAR_FILE_URL_PATTERN="gs://${BUILDS_BUCKET}/${ANGULAR_PROJECT_NAME}/${ANGULAR_PROJECT_NAME}_*_${SHORT_GIT_SHA}.tar.gz"
+            echo "Looking for archive matching ${TAR_FILE_URL_PATTERN}"
+            TAR_FILE_URL=`gsutil ls $TAR_FILE_URL_PATTERN  | sort -r | head -1`
+
+            if [ -z $TAR_FILE_URL ]
+            then
+              echo "Could not find archive using pattern ${TAR_FILE_URL_PATTERN}"
+              exit 1
+            fi
+            TAR_FILE_PATH="/tmp/$(basename -- $TAR_FILE_URL)"
+            echo "Downloading ${TAR_FILE_URL} to ${TAR_FILE_PATH}"
+            gsutil cp  $TAR_FILE_URL $TAR_FILE_PATH
+            mkdir -p $OUTPUT_DIR && tar -xvf $TAR_FILE_PATH -C $OUTPUT_DIR
+            echo "Contents of extracted archive at $OUTPUT_DIR"
+            ls -l $OUTPUT_DIR
+      - deploy-exploded-build:
           study_key: << parameters.study_key >>
 
-  app-run-tests-job:
-    working_directory: *ng_workspace_path
-    executor:
-      name: build-executor
-    steps:
-      - checkout-code
-      - setup-shared-env:
-          study_key: << pipeline.parameters.study_key >>
-      - run-linter-check
-      - run-tests
 
   playwright-build:
     executor: build-executor
@@ -663,6 +669,27 @@ jobs:
           path: playwright-e2e/html-test-results
           destination: html-test-results
 
+  api-unit-test:
+    description: Lint code and run api unit tests for sdk and toolkit
+    working_directory: *ng_workspace_path
+    executor:
+      name: build-executor
+    steps:
+      - checkout-code
+      - run-api-unit-test
+
+  ui-unit-test:
+    description: Lint code and run ui unit tests for specified app
+    working_directory: *ng_workspace_path
+    executor:
+      name: build-executor
+    parameters:
+      study_key:
+        type: string
+    steps:
+      - checkout-code
+      - run-ui-unit-test:
+          study_key: << parameters.study_key >>
 
 parameters:
   study_key:
@@ -689,6 +716,29 @@ parameters:
 workflows:
   version: 2
 
+  build-test-pr:
+    # Automatically launched on every PR commit
+    jobs:
+      - app-build:
+          <<: *filter-pr-branch
+          name: << matrix.study_key >>-build
+          matrix:
+            alias: app-build-and-store
+            parameters:
+              study_key: [ basil, osteo, angio, brain, mbc, mpc, atcp, rgp, esc, prion, pancan, singular, brugada, lms ]
+      - ui-unit-test:
+          <<: *filter-pr-branch
+          name: << matrix.study_key >>-ui-unit-test
+          matrix:
+            alias: app-ui-unit-test
+            parameters:
+              study_key: [ basil, osteo, angio, brain, mbc, mpc, atcp, rgp, esc, prion, pancan, singular, brugada, lms ]
+      - api-unit-test:
+          <<: *filter-pr-branch
+      - playwright-build:
+          <<: *filter-pr-branch
+
+
   api-build-and-store-workflow:
     # Build study specified in api call
     when:
@@ -699,6 +749,9 @@ workflows:
     jobs:
       - app-build:
           study_key: << pipeline.parameters.study_key >>
+      - ui-unit-test:
+          study_key: << pipeline.parameters.study_key >>
+      - api-unit-test
 
   api-deploy-workflow:
     # Deploy a study build to environment specified in api call
@@ -722,7 +775,9 @@ workflows:
           - not:
               equal: ["UNKNOWN", << pipeline.parameters.study_key >>]
       jobs:
-        - app-run-tests-job
+        - api-unit-test
+        - ui-unit-test:
+            study_key: << pipeline.parameters.study_key >>
 
   playwright-test-workflow:
     # Triggered by CI API (for example, run_ci.sh)
@@ -744,10 +799,7 @@ workflows:
     unless: << pipeline.parameters.do-builds >>
     jobs:
       - conditionally-launch-build-and-deploy-all-job:
-          filters:
-            branches:
-              only:
-                - develop
+          <<: *filter-develop-branch
 
   build-and-deploy-workflow:
     when:
@@ -781,6 +833,11 @@ workflows:
       - app-build:
           <<: *build-and-store-filters
           study_key: << pipeline.parameters.study_key >>
+      - ui-unit-test:
+          <<: *build-and-store-filters
+          study_key: << pipeline.parameters.study_key >>
+      - api-unit-test:
+          <<: *build-and-store-filters
 
   deploy-all-apps-workflow:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -721,6 +721,7 @@ workflows:
       and:
         - equal: [ "UNKNOWN", << pipeline.parameters.api_call >> ]
         - equal: [ "UNKNOWN", << pipeline.parameters.study_key >> ]
+        - equal: [ "UNKNOWN", << pipeline.parameters.deploy_env >> ]
     jobs:
       - app-build:
           <<: *filter-pr-branch
@@ -743,7 +744,7 @@ workflows:
       - playwright-build:
           <<: *filter-pr-branch
 
-  build-single-app-workflow:
+  build-single-app:
     # Build study specified in api call by run_ci.sh
     when:
       and:
@@ -760,7 +761,7 @@ workflows:
             - ui-unit-test
             - api-unit-test
 
-  deploy-single-app-workflow:
+  deploy-single-app:
     # Deploy a study build to environment specified in api call by run_ci.sh
     when:
       and:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -772,7 +772,9 @@ workflows:
         and:
           - equal: ["run-tests", << pipeline.parameters.api_call >>]
           - not:
-              equal: ["UNKNOWN", << pipeline.parameters.study_key >>]
+              - or:
+                - equal: ["UNKNOWN", << pipeline.parameters.study_key >>]
+                - equal: ["unknown", << pipeline.parameters.study_key >>]
       jobs:
         - api-unit-test
         - ui-unit-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -776,7 +776,7 @@ workflows:
           study_key: << pipeline.parameters.study_key >>
 
   api-run-tests-workflow:
-    # Run tests for study specified in api call (also tests for sdk and toolkit)
+    # Run ui tests for study specified in api call by run_ci.sh and tests for sdk and toolkit
       when:
         and:
           - equal: ["run-tests", << pipeline.parameters.api_call >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -733,17 +733,10 @@ workflows:
             alias: app-ui-unit-test
             parameters:
               study_key: [ basil, osteo, angio, brain, mbc, mpc, atcp, rgp, esc, prion, pancan, singular, brugada, lms ]
-          requires:
-            - app-build
       - api-unit-test:
           <<: *filter-pr-branch
-          requires:
-            - app-build
       - playwright-build:
           <<: *filter-pr-branch
-          requires:
-            - app-ui-unit-test
-            - api-unit-test
 
   api-build-and-store-workflow:
     # Build study specified in api call

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -772,7 +772,7 @@ workflows:
         and:
           - equal: ["run-tests", << pipeline.parameters.api_call >>]
           - not:
-              - or:
+              or:
                 - equal: ["UNKNOWN", << pipeline.parameters.study_key >>]
                 - equal: ["unknown", << pipeline.parameters.study_key >>]
       jobs:

--- a/build-utils/findmodifiedprojects.sh
+++ b/build-utils/findmodifiedprojects.sh
@@ -3,8 +3,8 @@
 # Can run anywhere within the repo
 # If a file from a common area, like the root diretory was modified, we call that _SHARED_
 set +x
-#ignore these file name patterns when figuring out what modules changed 
-declare -a exclude_patterns=( '^.*\.md' '^.*.pdf' )
+#ignore these file name patterns when figuring out what modules changed
+declare -a exclude_patterns=( '^.*\.md' '^.*.pdf', '^.*\.spec\.ts' )
 
 EXCLUDE_CMD='grep -v -E'
 


### PR DESCRIPTION
History of CircleCI workflows triggered by commits: [link](https://app.circleci.com/pipelines/github/broadinstitute/ddp-angular?branch=pepper-298-trigger-ci-build-for-pr-commit)

- Refactor to make file easier to read and reduce code clutter.

- Created new CircleCI `build-test-pr` workflow that launch automatically on every PR commit
   1: Build, lint and run units tests for all studies
   2: Build and lint nested `playwright-e2e` project

   **Notes**: All studies are: [ basil, osteo, angio, brain, mbc, mpc, atcp, rgp, esc, prion, pancan, singular, brugada, lms ]


- Tested `.run_ci.sh` with `build-and-store`, `deploy` and `run-tests` commands:
```
./build-utils/run_ci.sh build-and-store basil pepper-298-trigger-ci-build-for-pr-commit dev
./build-utils/run_ci.sh deploy basil pepper-298-trigger-ci-build-for-pr-commit dev
./build-utils/run_ci.sh run-tests UNKNOWN pepper-298-trigger-ci-build-for-pr-commit
```
<img width="887" alt="Screenshot 2023-02-14 at 5 53 24 PM" src="https://user-images.githubusercontent.com/35533885/218881731-8fa49258-8522-492f-b506-2e8075d96424.png">
