### PR TITLE
DSM-scanner-RGPFinalScanPage-changed-order

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/scanner/services/scanner.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/scanner/services/scanner.service.ts
@@ -80,16 +80,16 @@ export class ScannerService {
           validators: [Validators.required]
         },
         {
-          controllerName: 'ddpLabel',
-          placeholder: 'DSM Label',
-          maxLength: undefined,
-          validators: [Validators.required]
-        },
-        {
           controllerName: 'RNA',
           placeholder: 'RNA',
           maxLength: undefined,
           validators: [this.shouldIncludeRNA(), Validators.required]
+        },
+        {
+          controllerName: 'ddpLabel',
+          placeholder: 'DSM Label',
+          maxLength: undefined,
+          validators: [Validators.required]
         }
       ]
     },


### PR DESCRIPTION
Changed the order of input fields on the RGP Final Scan page:

<img width="748" alt="Screenshot 2023-02-17 at 09 53 29" src="https://user-images.githubusercontent.com/77500504/219560825-3638f208-5a32-4b58-ba6e-5a6d7c862e97.png">
