### PR TITLE
[Playwright] Fix env export issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -645,6 +645,10 @@ jobs:
           name: Export env variables to BASH_ENV
           command: |
             cp "playwright-e2e/config/.env.<< parameters.env >>" .env
+            
+            cat .env
+            cat playwright-env/envvars
+            
             cat .env | awk '/^[^#]/ {print "export " $0}' >> "$BASH_ENV"
             # export env from file (created in build-playwright-job)
             cat playwright-env/envvars | awk '{print "export " $0}' >> "$BASH_ENV"
@@ -664,10 +668,10 @@ jobs:
           working_directory: *playwright_path
           command: |
             node -v
-            echo $RGP_AUTH0_CLIENT_SECRET
-            echo $RGP_AUTH0_CLIENT_ID
-            echo $RGP_AUTH0_DOMAIN
-            echo $RGP_AUTH0_AUDIENCE
+            echo "$RGP_AUTH0_CLIENT_SECRET"
+            echo "$RGP_AUTH0_CLIENT_ID"
+            echo "$RGP_AUTH0_DOMAIN"
+            echo "$RGP_AUTH0_AUDIENCE"
             echo ""
 
             if [ << parameters.test_suite >> == "UNKNOWN" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -598,6 +598,8 @@ jobs:
           name: Save Vault secrets into temp file to persist across jobs
           command: |
             set -u
+            echo "export ENV=<< parameters.env >>" >> $BASH_ENV
+            source $BASH_ENV
             .circleci/export-playwright-env.sh
       - run:
           working_directory: *playwright_path

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -648,7 +648,7 @@ jobs:
             cat .env | awk '/^[^#]/ {print "export " $0}' >> "$BASH_ENV"
             # export env from file (created in build-playwright-job)
             cat playwright-env/envvars | awk '{print "export " $0}' >> "$BASH_ENV"
-            source "$BASH_ENV"
+            source $BASH_ENV
       - node/install:
           install-yarn: false
           node-version: '18.13.0' # LTS version
@@ -664,7 +664,10 @@ jobs:
           working_directory: *playwright_path
           command: |
             node -v
-            echo "$BASH_ENV"
+            echo $RGP_AUTH0_CLIENT_SECRET
+            echo $RGP_AUTH0_CLIENT_ID
+            echo $RGP_AUTH0_DOMAIN
+            echo $RGP_AUTH0_AUDIENCE
             echo ""
 
             if [ << parameters.test_suite >> == "UNKNOWN" ]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -663,7 +663,9 @@ jobs:
           name: Running Playwright tests
           working_directory: *playwright_path
           command: |
-            echo 'Study: ' << parameters.test_suite >>
+            node -v
+            echo "$BASH_ENV"
+            echo ""
 
             if [ << parameters.test_suite >> == "UNKNOWN" ]; then
               # Grep all E2E tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -647,10 +647,6 @@ jobs:
           name: Export env variables to BASH_ENV
           command: |
             cp "playwright-e2e/config/.env.<< parameters.env >>" .env
-            
-            cat .env
-            cat playwright-env/envvars
-            
             cat .env | awk '/^[^#]/ {print "export " $0}' >> "$BASH_ENV"
             # export env from file (created in build-playwright-job)
             cat playwright-env/envvars | awk '{print "export " $0}' >> "$BASH_ENV"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -665,13 +665,7 @@ jobs:
           name: Running Playwright tests
           working_directory: *playwright_path
           command: |
-            node -v
-            echo "$RGP_AUTH0_CLIENT_SECRET"
-            echo "$RGP_AUTH0_CLIENT_ID"
-            echo "$RGP_AUTH0_DOMAIN"
-            echo "$RGP_AUTH0_AUDIENCE"
-            echo ""
-
+            echo 'Study: ' << parameters.test_suite >>
             if [ << parameters.test_suite >> == "UNKNOWN" ]; then
               # Grep all E2E tests
               npx playwright test --list | grep -o 'tests/.*.spec.ts' > e2e_tests.txt

--- a/.circleci/export-playwright-env.sh
+++ b/.circleci/export-playwright-env.sh
@@ -3,59 +3,59 @@
 mkdir -p playwright-env
 
 export sitePwd=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.sitePassword")
-echo "export SITE_PASSWORD=$sitePwd" >>playwright-env/envvars
+echo "export SITE_PASSWORD=$sitePwd" >> playwright-env/envvars
 
 #DSM
 export dsmUser=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[] | select(.app==\"dsm\") | .userName")
 export dsmUserPassword=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[] | select(.app==\"dsm\") | .password")
-echo "export DSM_USER_EMAIL=$dsmUser" >>playwright-env/envvars
-echo "export DSM_USER_PASSWORD=$dsmUserPassword" >>playwright-env/envvars
+echo "export DSM_USER_EMAIL=$dsmUser" >> playwright-env/envvars
+echo "export DSM_USER_PASSWORD=$dsmUserPassword" >> playwright-env/envvars
 
 # SINGULAR
 export singularUser=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[] | select(.app==\"singular\") | .userName")
 export singularUserPassword=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[] | select(.app==\"singular\") | .password")
-echo "export SINGULAR_USER_EMAIL=$singularUser" >>playwright-env/envvars
-echo "export SINGULAR_USER_PASSWORD=$singularUserPassword" >>playwright-env/envvars
+echo "export SINGULAR_USER_EMAIL=$singularUser" >> playwright-env/envvars
+echo "export SINGULAR_USER_PASSWORD=$singularUserPassword" >> playwright-env/envvars
 
 # RGP
 export rgpUser=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[] | select(.app==\"rgp\") | .userName")
 export rgpUserPassword=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[] | select(.app==\"rgp\") | .password")
-echo "export RGP_USER_PASSWORD=$rgpUserPassword" >>playwright-env/envvars
-echo "export RGP_USER_EMAIL=$rgpUser" >>playwright-env/envvars
+echo "export RGP_USER_PASSWORD=$rgpUserPassword" >> playwright-env/envvars
+echo "export RGP_USER_EMAIL=$rgpUser" >> playwright-env/envvars
 
 # Read Auth0 RGP client credentials
-export rgpDomain=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.auth0 | .[] | select(.app==\"rgp\" and .env==\"<< parameters.env >>\") | .domain")
-export rgpAudience=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.auth0 | .[] | select(.app==\"rgp\" and .env==\"<< parameters.env >>\") | .audience")
-export rgpClientId=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.auth0 | .[] | select(.app==\"rgp\" and .env==\"<< parameters.env >>\") | .clientId")
-export rgpClientSecret=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.auth0 | .[] | select(.app==\"rgp\" and .env==\"<< parameters.env >>\") | .clientSecret")
-echo "export RGP_AUTH0_DOMAIN=$rgpDomain" >>playwright-env/envvars
-echo "export RGP_AUTH0_AUDIENCE=$rgpAudience" >>playwright-env/envvars
-echo "export RGP_AUTH0_CLIENT_ID=$rgpClientId" >>playwright-env/envvars
-echo "export RGP_AUTH0_CLIENT_SECRET=$rgpClientSecret" >>playwright-env/envvars
+export rgpDomain=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.auth0 | .[] | select(.app==\"rgp\" and .env==\"$ENV\") | .domain")
+export rgpAudience=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.auth0 | .[] | select(.app==\"rgp\" and .env==\"$ENV\") | .audience")
+export rgpClientId=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.auth0 | .[] | select(.app==\"rgp\" and .env==\"$ENV\") | .clientId")
+export rgpClientSecret=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.auth0 | .[] | select(.app==\"rgp\" and .env==\"$ENV\") | .clientSecret")
+echo "export RGP_AUTH0_DOMAIN=$rgpDomain" >> playwright-env/envvars
+echo "export RGP_AUTH0_AUDIENCE=$rgpAudience" >> playwright-env/envvars
+echo "export RGP_AUTH0_CLIENT_ID=$rgpClientId" >> playwright-env/envvars
+echo "export RGP_AUTH0_CLIENT_SECRET=$rgpClientSecret" >> playwright-env/envvars
 
 # ANGIO
 export angioUser=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[] | select(.app==\"angio\") | .userName")
 export angioUserPassword=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[] | select(.app==\"angio\") | .password")
-echo "export ANGIO_USER_PASSWORD=$angioUserPassword" >>playwright-env/envvars
-echo "export ANGIO_USER_EMAIL=$angioUser" >>playwright-env/envvars
+echo "export ANGIO_USER_PASSWORD=$angioUserPassword" >> playwright-env/envvars
+echo "export ANGIO_USER_EMAIL=$angioUser" >> playwright-env/envvars
 
 # PANCAN
 export pancanUser=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[] | select(.app==\"pancan\") | .userName")
 export pancanUserPassword=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[] | select(.app==\"pancan\") | .password")
-echo "export PANCAN_USER_PASSWORD=$pancanUserPassword" >>playwright-env/envvars
-echo "export PANCAN_USER_EMAIL=$pancanUser" >>playwright-env/envvars
+echo "export PANCAN_USER_PASSWORD=$pancanUserPassword" >> playwright-env/envvars
+echo "export PANCAN_USER_EMAIL=$pancanUser" >> playwright-env/envvars
 
 # OSTEO
 export osteoUser=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[] | select(.app==\"osteo\") | .userName")
 export osteoUserPassword=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[] | select(.app==\"osteo\") | .password")
-echo "export OSTEO_USER_PASSWORD=$osteoUserPassword" >>playwright-env/envvars
-echo "export OSTEO_USER_EMAIL=$osteoUser" >>playwright-env/envvars
+echo "export OSTEO_USER_PASSWORD=$osteoUserPassword" >> playwright-env/envvars
+echo "export OSTEO_USER_EMAIL=$osteoUser" >> playwright-env/envvars
 
 # BRAIN
 export brainUser=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[] | select(.app==\"brain\") | .userName")
 export brainUserPassword=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.users | .[] | select(.app==\"brain\") | .password")
-echo "export BRAIN_USER_PASSWORD=$brainUserPassword" >>playwright-env/envvars
-echo "export BRAIN_USER_EMAIL=$brainUser" >>playwright-env/envvars
+echo "export BRAIN_USER_PASSWORD=$brainUserPassword" >> playwright-env/envvars
+echo "export BRAIN_USER_EMAIL=$brainUser" >> playwright-env/envvars
 
 # EMAIL TESTING
 export refreshToken=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.email.refreshToken")
@@ -63,8 +63,8 @@ export emailClientId=$(vault read --format=json secret/pepper/test/v1/e2e | jq -
 export emailClientSecret=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.email.clientSecret")
 export emailRedirectUri=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.email.redirectUri")
 export emailWaitTime=$(vault read --format=json secret/pepper/test/v1/e2e | jq -r ".data.email.minWaitTime")
-echo "export EMAIL_REFRESH_TOKEN=$refreshToken" >>playwright-env/envvars
-echo "export EMAIL_CLIENT_ID=$emailClientId" >>playwright-env/envvars
-echo "export EMAIL_CLIENT_SECRET=$emailClientSecret" >>playwright-env/envvars
-echo "export EMAIL_REDIRECT_URL=$emailRedirectUri" >>playwright-env/envvars
-echo "export MIN_EMAIL_WAIT_TIME=$emailWaitTime" >>playwright-env/envvars
+echo "export EMAIL_REFRESH_TOKEN=$refreshToken" >> playwright-env/envvars
+echo "export EMAIL_CLIENT_ID=$emailClientId" >> playwright-env/envvars
+echo "export EMAIL_CLIENT_SECRET=$emailClientSecret" >> playwright-env/envvars
+echo "export EMAIL_REDIRECT_URL=$emailRedirectUri" >> playwright-env/envvars
+echo "export MIN_EMAIL_WAIT_TIME=$emailWaitTime" >> playwright-env/envvars


### PR DESCRIPTION
Node fetch error due to missing RGP Auth0 credential because `export-playwright-env.sh` fails to evaluate `<< parameters.env >>`.

RGP test fails due ot missing Auth0 credentials.

```
adult-enrollment.spec.ts:22:3 Can complete application @functional @enrollment @rgp
[chromium] › tests/rgp/adult-enrollment.spec.ts:22:3 › Adult Self Enrollment › Can complete application @functional @enrollment @rgp 

    TypeError: fetch failed

        at Object.fetch (node:internal/deps/undici/undici:14062:11)
        at processTicksAndRejections (node:internal/process/task_queues:95:5)
        at setAuth0UserEmailVerified (/home/circleci/repo/playwright-e2e/utils/api-utils.ts:134:49)
        at /home/circleci/repo/playwright-e2e/tests/rgp/adult-enrollment.spec.ts:57:5

ERROR: POST /oauth/token:
 TypeError: fetch failed
[90m    at Object.fetch (node:internal/deps/undici/undici:14062:11)[39m
[90m    at processTicksAndRejections (node:internal/process/task_queues:95:5)[39m
    at setAuth0UserEmailVerified [90m(/home/circleci/repo/playwright-e2e/[39mutils/api-utils.ts:134:49[90m)[39m
    at [90m/home/circleci/repo/playwright-e2e/[39mtests/rgp/adult-enrollment.spec.ts:57:5
    at [90m/home/circleci/repo/playwright-e2e/[39mnode_modules/[4m@playwright[24m/test/lib/workerRunner.js:376:9
    at TestInfoImpl._runFn [90m(/home/circleci/repo/playwright-e2e/[39mnode_modules/[4m@playwright[24m/test/lib/testInfo.js:146:7[90m)[39m
    at [90m/home/circleci/repo/playwright-e2e/[39mnode_modules/[4m@playwright[24m/test/lib/workerRunner.js:331:26
    at TimeoutRunner.run [90m(/home/circleci/repo/playwright-e2e/[39mnode_modules/[4mplaywright-core[24m/lib/utils/timeoutRunner.js:45:14[90m)[39m
    at TimeoutManager.runWithTimeout [90m(/home/circleci/repo/playwright-e2e/[39mnode_modules/[4m@playwright[24m/test/lib/timeoutManager.js:62:7[90m)[39m
    at TestInfoImpl._runWithTimeout [90m(/home/circleci/repo/playwright-e2e/[39mnode_modules/[4m@playwright[24m/test/lib/testInfo.js:135:26[90m)[39m
    at WorkerRunner._runTest [90m(/home/circleci/repo/playwright-e2e/[39mnode_modules/[4m@playwright[24m/test/lib/workerRunner.js:312:5[90m)[39m
    at WorkerRunner.runTestGroup [90m(/home/circleci/repo/playwright-e2e/[39mnode_modules/[4m@playwright[24m/test/lib/workerRunner.js:192:11[90m)[39m
    at process.<anonymous> [90m(/home/circleci/repo/playwright-e2e/[39mnode_modules/[4m@playwright[24m/test/lib/worker.js:74:5[90m)[39m {
  cause: Error: getaddrinfo ENOTFOUND oauth
  [90m    at GetAddrInfoReqWrap.onlookup [as oncomplete] (node:dns:107:26)[39m {
    errno: [33m-3008[39m,
    code: [32m'ENOTFOUND'[39m,
    syscall: [32m'getaddrinfo'[39m,
    hostname: [32m'oauth'[39m
  }
```