### PR TITLE
PEPPER-308 Run Playwright tests when PR merge into develop branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -465,6 +465,9 @@ jobs:
     executor:
       name: build-executor
     steps:
+      # REMOVE THIS BEFORE MERGE
+      - run:
+          command: circleci-agent step halt
       - checkout-code
       - when:
           condition: << parameters.check_changes >>
@@ -544,16 +547,8 @@ jobs:
       store_build:
         type: boolean
         default: true
-      check_changes:
-        type: boolean
-        default: false
     steps:
       - checkout-code
-      - when:
-          condition: << parameters.check_changes >>
-          steps:
-            - halt-when-study-unchanged:
-                study_key: << parameters.study_key >>
       - build:
           study_key: << parameters.study_key >>
       - when:
@@ -795,6 +790,7 @@ workflows:
         - equal: [ "UNKNOWN", << pipeline.parameters.api_call >> ]
         - equal: [ "UNKNOWN", << pipeline.parameters.study_key >> ]
         - equal: [ "UNKNOWN", << pipeline.parameters.deploy_env >> ]
+        - << pipeline.parameters.do-builds >> # REMOVE THIS BEFORE MERGE
     jobs:
       - app-build:
           <<: *filter-pr-branch
@@ -889,9 +885,9 @@ workflows:
         - not: << pipeline.parameters.scheduled-playwright >>
     jobs:
       - api-unit-test:
-          <<: *filter-develop-branch
+          <<: *filter-pr-branch
       - ui-unit-test:
-          <<: *filter-develop-branch
+          <<: *filter-pr-branch
           name: << matrix.study_key >>-ui-unit-test
           matrix:
             alias: ui-unit-test
@@ -899,7 +895,7 @@ workflows:
               <<: *studies
           check_changes: true
       - app-deploy:
-          <<: *filter-develop-branch
+          <<: *filter-pr-branch
           name: << matrix.study_key >>-deploy
           matrix:
             alias: app-deploy
@@ -911,10 +907,10 @@ workflows:
             - api-unit-test
       - playwright-build:
           # run Playwright build and test after app-deploy
-          <<: *filter-develop-branch
+          <<: *filter-pr-branch
           env: dev # env is Dev because it's PR merge into develop branch
       - playwright-test:
-          <<: *filter-develop-branch
+          <<: *filter-pr-branch
           env: dev
           test_suite: UNKNOWN
           parallelism_num: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -907,9 +907,8 @@ workflows:
               <<: *studies
           check_changes: true
           requires:
-            requires:
-              - << matrix.study_key >>-ui-unit-test
-              - api-unit-test
+            - << matrix.study_key >>-ui-unit-test
+            - api-unit-test
       - playwright-build:
           # run Playwright build and test after app-deploy
           <<: *filter-develop-branch
@@ -924,7 +923,6 @@ workflows:
             - app-deploy # start after all deploys have been completed
 
   build-and-deploy-workflow:
-    # Deploy to Dev env
     when:
       and:
         - << pipeline.parameters.do-builds >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -465,9 +465,6 @@ jobs:
     executor:
       name: build-executor
     steps:
-      # REMOVE THIS BEFORE MERGE
-      - run:
-          command: circleci-agent step halt
       - checkout-code
       - when:
           condition: << parameters.check_changes >>
@@ -790,7 +787,6 @@ workflows:
         - equal: [ "UNKNOWN", << pipeline.parameters.api_call >> ]
         - equal: [ "UNKNOWN", << pipeline.parameters.study_key >> ]
         - equal: [ "UNKNOWN", << pipeline.parameters.deploy_env >> ]
-        - << pipeline.parameters.do-builds >> # REMOVE THIS BEFORE MERGE
     jobs:
       - app-build:
           <<: *filter-pr-branch
@@ -885,9 +881,9 @@ workflows:
         - not: << pipeline.parameters.scheduled-playwright >>
     jobs:
       - api-unit-test:
-          <<: *filter-pr-branch
+          <<: *filter-develop-branch
       - ui-unit-test:
-          <<: *filter-pr-branch
+          <<: *filter-develop-branch
           name: << matrix.study_key >>-ui-unit-test
           matrix:
             alias: ui-unit-test
@@ -895,7 +891,7 @@ workflows:
               <<: *studies
           check_changes: true
       - app-deploy:
-          <<: *filter-pr-branch
+          <<: *filter-develop-branch
           name: << matrix.study_key >>-deploy
           matrix:
             alias: app-deploy
@@ -907,10 +903,10 @@ workflows:
             - api-unit-test
       - playwright-build:
           # run Playwright build and test after app-deploy
-          <<: *filter-pr-branch
+          <<: *filter-develop-branch
           env: dev # env is Dev because it's PR merge into develop branch
       - playwright-test:
-          <<: *filter-pr-branch
+          <<: *filter-develop-branch
           env: dev
           test_suite: UNKNOWN
           parallelism_num: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,7 +257,6 @@ commands:
         type: string
         default: "UNKNOWN"
     steps:
-      - checkout-code
       - set-deployment-environment
       - setup-shared-env:
           study_key: << parameters.study_key >>
@@ -429,6 +428,30 @@ commands:
                 name: "Halt running Playwright test job. Not supported for ENV=<< parameters.env >>"
                 command: circleci-agent step halt
 
+  halt-when-study-unchanged:
+    description: Stop job if specified study has not changed
+    parameters:
+      study_key:
+        type: string
+    steps:
+      - run:
+          name: Check << parameters.study_key >> and stop job if study has not changed
+          command: |
+            set -u
+            CHANGED_STUDIES=$(../build-utils/findmodifiedprojects.sh << pipeline.git.base_revision >> << pipeline.git.revision >>)
+            echo "The following projects were found to have changed: $CHANGED_STUDIES"
+            
+            NG_PROJECT_NAME="ddp-<< parameters.study_key >>"
+            CHANGED_DEPENDENCIES=$(echo $CHANGED_STUDIES | grep -E -e $NG_PROJECT_NAME -e _SHARED_ -e ddp-sdk -e toolkit)
+            echo "CHANGED_DEPENDENCIES: $CHANGED_DEPENDENCIES"
+            
+            if [[ -z $CHANGED_DEPENDENCIES ]]; then
+              echo "Study << parameters.study_key >> has not changed"
+              circleci-agent step halt
+            else
+              echo "Study has changed"
+            fi
+        #
 
 jobs:
   app-deploy:
@@ -436,14 +459,20 @@ jobs:
     parameters:
       study_key:
         type: string
+      check_changes:
+        type: boolean
+        default: false
     executor:
       name: build-executor
     steps:
+      - checkout-code
+      - when:
+          condition: << parameters.check_changes >>
+          steps:
+            - halt-when-study-unchanged:
+                study_key: << parameters.study_key >>
       - build:
           study_key: << parameters.study_key >>
-      - run-ui-unit-test:
-          study_key: << parameters.study_key >>
-      - run-api-unit-test
       - deploy-exploded-build:
           study_key: << parameters.study_key >>
 
@@ -515,7 +544,16 @@ jobs:
       store_build:
         type: boolean
         default: true
+      check_changes:
+        type: boolean
+        default: false
     steps:
+      - checkout-code
+      - when:
+          condition: << parameters.check_changes >>
+          steps:
+            - halt-when-study-unchanged:
+                study_key: << parameters.study_key >>
       - build:
           study_key: << parameters.study_key >>
       - when:
@@ -708,8 +746,16 @@ jobs:
     parameters:
       study_key:
         type: string
+      check_changes:
+        type: boolean
+        default: false
     steps:
       - checkout-code
+      - when:
+          condition: << parameters.check_changes >>
+          steps:
+            - halt-when-study-unchanged:
+                study_key: << parameters.study_key >>
       - run-ui-unit-test:
           study_key: << parameters.study_key >>
 
@@ -836,15 +882,52 @@ workflows:
             - playwright-build
 
   build-and-deploy-all-apps-workflow:
+    # Check all studies, launch GAE deploy if a study has changed.
     when:
       and:
         - not: << pipeline.parameters.do-builds >>
         - not: << pipeline.parameters.scheduled-playwright >>
     jobs:
-      - conditionally-launch-build-and-deploy-all-job:
+      #- conditionally-launch-build-and-deploy-all-job:
+      #    <<: *filter-develop-branch
+
+      - api-unit-test:
           <<: *filter-develop-branch
+      - ui-unit-test:
+          <<: *filter-develop-branch
+          name: << matrix.study_key >>-ui-unit-test
+          matrix:
+            alias: ui-unit-test
+            parameters:
+              <<: *studies
+          check_changes: true
+      - app-deploy:
+          <<: *filter-develop-branch
+          name: << matrix.study_key >>-deploy
+          matrix:
+            alias: app-deploy
+            parameters:
+              <<: *studies
+          check_changes: true
+          requires:
+            requires:
+              - << matrix.study_key >>-ui-unit-test
+              - api-unit-test
+      - playwright-build:
+          # run Playwright build and test after app-deploy
+          <<: *filter-develop-branch
+          env: dev # env is Dev because it's PR merge into develop branch
+      - playwright-test:
+          <<: *filter-develop-branch
+          env: dev
+          test_suite: UNKNOWN
+          parallelism_num: 2
+          requires:
+            - playwright-build
+            - app-deploy # start after all deploys have been completed
 
   build-and-deploy-workflow:
+    # Deploy to Dev env
     when:
       and:
         - << pipeline.parameters.do-builds >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -459,7 +459,7 @@ jobs:
     parameters:
       study_key:
         type: string
-      check_changes:
+      check_changed:
         type: boolean
         default: false
     executor:
@@ -467,7 +467,7 @@ jobs:
     steps:
       - checkout-code
       - when:
-          condition: << parameters.check_changes >>
+          condition: << parameters.check_changed >>
           steps:
             - halt-when-study-unchanged:
                 study_key: << parameters.study_key >>
@@ -738,13 +738,13 @@ jobs:
     parameters:
       study_key:
         type: string
-      check_changes:
+      check_changed:
         type: boolean
         default: false
     steps:
       - checkout-code
       - when:
-          condition: << parameters.check_changes >>
+          condition: << parameters.check_changed >>
           steps:
             - halt-when-study-unchanged:
                 study_key: << parameters.study_key >>
@@ -874,7 +874,7 @@ workflows:
             - playwright-build
 
   build-and-deploy-all-apps-workflow:
-    # Check all studies, launch GAE deploy if a study has changed.
+    # check all studies, launch GAE deploy if a study has changed.
     when:
       and:
         - not: << pipeline.parameters.do-builds >>
@@ -889,7 +889,7 @@ workflows:
             alias: ui-unit-test
             parameters:
               <<: *studies
-          check_changes: true
+          check_changed: true
       - app-deploy:
           <<: *filter-develop-branch
           name: << matrix.study_key >>-deploy
@@ -897,7 +897,7 @@ workflows:
             alias: app-deploy
             parameters:
               <<: *studies
-          check_changes: true
+          check_changed: true
           requires:
             - << matrix.study_key >>-ui-unit-test
             - api-unit-test
@@ -912,7 +912,7 @@ workflows:
           parallelism_num: 2
           requires:
             - playwright-build
-            - app-deploy # start after all deploys have been completed
+            - app-deploy
 
   build-and-deploy-workflow:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -888,9 +888,6 @@ workflows:
         - not: << pipeline.parameters.do-builds >>
         - not: << pipeline.parameters.scheduled-playwright >>
     jobs:
-      #- conditionally-launch-build-and-deploy-all-job:
-      #    <<: *filter-develop-branch
-
       - api-unit-test:
           <<: *filter-develop-branch
       - ui-unit-test:


### PR DESCRIPTION
Reworked `build-and-deploy-all-apps-workflow` workflow because:

- Playwright tests should start ONLY AFTER all deploys have finished
- `build-and-deploy-all-apps-workflow` workflow is launched by PR merge into develop branch
- `build-and-deploy-all-apps-workflow` workflow triggers individual `app-deploy` workflows via CI api calls.

** Before changes, `app-deploy` workflows and `build-and-deploy-all-apps-workflow` workflow are separately launched, similar to this screenshot,

<img width="1237" alt="Screenshot 2023-02-27 at 7 19 40 PM" src="https://user-images.githubusercontent.com/35533885/221719526-0854cba8-6bc6-47b0-ab7a-31d1f54523dd.png">


** After changes, workflow triggered by PR merge will look similar to this screenshot. Note, ui and sdk & toolkit unit tests are pre-requisite for any deploy.

<img width="1109" alt="Screenshot 2023-02-27 at 7 44 06 PM" src="https://user-images.githubusercontent.com/35533885/221722787-8e44a933-b6d4-437d-b82d-a0cdf4471ef0.png">
