### PR TITLE
PEPPER-571 Rework CircleCI launch-all-app-builds-workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ references:
           - /.*rc.*/
           - /.*hotfix.*/
 
-  filter-rc-hotfix-branch: &filter-release-branch
+  filter-release-branch: &filter-release-branch
     filters:
       tags:
         ignore: /.*/
@@ -176,7 +176,7 @@ commands:
           name: Deploy to GAE
           command: |
             set -u
-            gcloud app deploy --version="${SHORT_GIT_SHA}" --stop-previous-version --project "broad-ddp-${ENVIRONMENT}" "${ANGULAR_PROJECT_DIR_PATH}/app.yaml"
+            gcloud app deploy --version="${SHORT_GIT_SHA}" --stop-previous-version --promote --quiet --project "broad-ddp-${ENVIRONMENT}" "${ANGULAR_PROJECT_DIR_PATH}/app.yaml"
       - run:
           name: Update deployments sheet
           command: |
@@ -184,31 +184,6 @@ commands:
             set +x
             readvault.sh secret/pepper/${ENVIRONMENT}/v1/conf .data.gcp.serviceKey | \
             reportdeploy.sh "$RELEASE_SHEET_ID" '<<parameters.study_key>> Angular client' "$ENVIRONMENT" "$CIRCLE_BUILD_NUM" "$CIRCLE_BUILD_URL"
-      - run:
-          name: Delete previous versions of service
-          command: |
-            set +x
-            # extract the service name from the GAE yaml file
-            CONFIG_FILE="${ANGULAR_PROJECT_DIR_PATH}/app.yaml"
-            SERVICE=$(grep -Eo -m1 "^service:\s*.*" "${CONFIG_FILE}" | awk '{print $2}')
-            echo "The service name is *${SERVICE}*"
-
-            # find what other versions are currently running
-            # skip first line, exclude our version, print 2nd column
-            AWK_COMMMAND="NR > 1 && !/${SHORT_GIT_SHA}/ {print \$2}"
-            VERSIONS_TO_DELETE=$(gcloud app versions list --service "$SERVICE" --project "broad-ddp-${ENVIRONMENT}" | awk "${AWK_COMMMAND}")
-
-            # Sometime deleting versions fails. If there are less than 3 versions then we are not going to worry about it
-            # and set flag so this job step does not fail when exit error value is generated
-            if [[ ! -z $VERSIONS_TO_DELETE ]] && [[ "${#VERSIONS_TO_DELETE[@]}" -lt 3 ]]; then
-              set +e
-            fi
-
-            for VERSION_TO_DELETE in $VERSIONS_TO_DELETE; do
-              echo "Deleting version $VERSION_TO_DELETE of service $SERVICE"
-              gcloud app versions delete --quiet --service "$SERVICE" "$VERSION_TO_DELETE" --project "broad-ddp-${ENVIRONMENT}"
-            done;
-            exit 0;
           #
 
   setup-shared-env:
@@ -462,6 +437,38 @@ commands:
             fi
         #
 
+  halt-build-archive:
+    description: Stop new build and archive if build archive for specified study is found in Google bucket
+    parameters:
+      study_key:
+        type: string
+    steps:
+      - setup-shared-env:
+          study_key: << parameters.study_key >>
+      - run:
+          name: Check build archive for <<parameters.study_key>> with git SHA << pipeline.git.revision >>
+          command: |
+            set -u
+            set +e
+            
+            readvault.sh secret/pepper/prod/v1/conf .data.gcp.serviceKey | gcloud auth activate-service-account --key-file=-
+            TAR_FILE_URL_PATTERN="gs://${BUILDS_BUCKET}/${ANGULAR_PROJECT_NAME}/${ANGULAR_PROJECT_NAME}_*_${SHORT_GIT_SHA}.tar.gz"
+            echo "Checking for ${TAR_FILE_URL_PATTERN}"
+            
+            # For some reason following line generating exit code 1 every time in CircleCI. Use set +e so script can continue
+            TAR_FILE_URL=`gsutil ls $TAR_FILE_URL_PATTERN  | head -1`
+
+            # if not found, continue running build and store
+            if [ -z $TAR_FILE_URL ]
+              then
+                echo "Build archive for <<parameters.study_key>> is not found at URL: ${TAR_FILE_URL}"
+              else
+                echo "Build archive for <<parameters.study_key>> is found at URL: ${TAR_FILE_URL}. No new build artifacts will be archived."
+                circleci-agent step halt
+            fi
+          #
+
+
 jobs:
   app-deploy:
     working_directory: *ng_workspace_path
@@ -556,12 +563,20 @@ jobs:
       check_changed:
         type: boolean
         default: false
+      check_archive:
+        type: boolean
+        default: false
     steps:
       - checkout-code
       - when:
           condition: << parameters.check_changed >>
           steps:
             - halt-when-study-unchanged:
+                study_key: << parameters.study_key >>
+      - when:
+          condition: << parameters.check_archive >>
+          steps:
+            - halt-build-archive:
                 study_key: << parameters.study_key >>
       - build:
           study_key: << parameters.study_key >>
@@ -968,6 +983,8 @@ workflows:
             alias: app-build
             parameters:
               <<: *studies
+          check_archive: true
+          store_build: true
           requires:
             - << matrix.study_key >>-ui-unit-test
             - api-unit-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -972,14 +972,14 @@ workflows:
           <<: *filter-release-branch
       - ui-unit-test:
           <<: *filter-release-branch
-          name: << matrix.study_key >>-ui-unit-test
+          name: << matrix.study_key >>-ui-unit-test-release
           matrix:
             alias: app-ui-unit-test
             parameters:
               <<: *studies
       - app-build:
           <<: *filter-release-branch
-          name: << matrix.study_key >>-build
+          name: << matrix.study_key >>-build-release
           matrix:
             alias: app-build
             parameters:
@@ -987,7 +987,7 @@ workflows:
           check_archive: true
           store_build: true
           requires:
-            - << matrix.study_key >>-ui-unit-test
+            - << matrix.study_key >>-ui-unit-test-release
             - api-unit-test
 
   build-app-workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -986,9 +986,9 @@ workflows:
               <<: *studies
           check_archive: true
           store_build: true
-          #requires:
-          #  - << matrix.study_key >>-ui-unit-test
-          #  - api-unit-test
+          requires:
+            - << matrix.study_key >>-ui-unit-test
+            - api-unit-test
 
   build-app-workflow:
     when: << pipeline.parameters.do-builds >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -969,16 +969,16 @@ workflows:
         - equal: [ UNKNOWN, << pipeline.parameters.api_call >> ]
     jobs:
       - api-unit-test:
-          <<: *filter-pr-branch
+          <<: *filter-release-branch
       - ui-unit-test:
-          <<: *filter-pr-branch
+          <<: *filter-release-branch
           name: << matrix.study_key >>-ui-unit-test
           matrix:
             alias: app-ui-unit-test
             parameters:
               <<: *studies
       - app-build:
-          <<: *filter-pr-branch
+          <<: *filter-release-branch
           name: << matrix.study_key >>-build
           matrix:
             alias: app-build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -978,7 +978,7 @@ workflows:
             parameters:
               <<: *studies
       - app-build:
-          <<: *filter-release-branch
+          <<: *filter-pr-branch
           name: << matrix.study_key >>-build
           matrix:
             alias: app-build
@@ -986,9 +986,9 @@ workflows:
               <<: *studies
           check_archive: true
           store_build: true
-          requires:
-            - << matrix.study_key >>-ui-unit-test
-            - api-unit-test
+          #requires:
+          #  - << matrix.study_key >>-ui-unit-test
+          #  - api-unit-test
 
   build-app-workflow:
     when: << pipeline.parameters.do-builds >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,15 @@ references:
   study_guids: &study_guids
     "basil NA CMI-OSTEO cmi-brain ANGIO cmi-mbc testboston cmi-mpc PRION atcp rarex RGP cmi-esc cgc circadia cmi-pancan singular brugada cmi-lms fon"
 
+  filter-release-branch: &filter-release-branch
+    filters:
+      tags:
+        ignore: /.*/
+      branches:
+        only:
+          - /^rc.*/
+          - /^hotfix.*/
+
   # Job runs for develop branch only
   filter-develop-branch: &filter-develop-branch
     filters:
@@ -49,14 +58,6 @@ references:
           - /.*rc.*/
           - /.*hotfix.*/
 
-  filter-release-branch: &filter-release-branch
-    filters:
-      tags:
-        ignore: /.*/
-      branches:
-        only:
-          - /^rc.*/
-          - /^hotfix.*/
 
 # Container for all the builds
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ commands:
           name: Deploy to GAE
           command: |
             set -u
-            gcloud app deploy --version="${SHORT_GIT_SHA}" --stop-previous-version --promote --quiet --project "broad-ddp-${ENVIRONMENT}" "${ANGULAR_PROJECT_DIR_PATH}/app.yaml"
+            gcloud app deploy --version="${SHORT_GIT_SHA}" --stop-previous-version --promote --project "broad-ddp-${ENVIRONMENT}" "${ANGULAR_PROJECT_DIR_PATH}/app.yaml"
       - run:
           name: Update deployments sheet
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,15 @@ references:
           - production
           - develop
           - master
+          - /.*rc.*/
+          - /.*hotfix.*/
+
+  filter-rc-hotfix-branch: &filter-release-branch
+    filters:
+      tags:
+        ignore: /.*/
+      branches:
+        only:
           - /^rc.*/
           - /^hotfix.*/
 
@@ -938,25 +947,41 @@ workflows:
   launch-all-app-builds-workflow:
     # using do-builds param to select which of the two workflows using the build-on-tag-filters
     # should run; should be this one that just launches the builds or the one actually doing the builds
-    unless: << pipeline.parameters.do-builds >>
+    when:
+      and:
+        - not: << pipeline.parameters.do-builds >>
+        - equal: [ UNKNOWN, << pipeline.parameters.api_call >> ]
     jobs:
-      - conditionally-launch-build-and-store-all-job: &build-and-store-filters
-          filters:
-            branches:
-              only:
-                - /^rc.*/
-                - /^hotfix.*/
+      - api-unit-test:
+          <<: *filter-release-branch
+      - ui-unit-test:
+          <<: *filter-release-branch
+          name: << matrix.study_key >>-ui-unit-test
+          matrix:
+            alias: app-ui-unit-test
+            parameters:
+              <<: *studies
+      - app-build:
+          <<: *filter-release-branch
+          name: << matrix.study_key >>-build
+          matrix:
+            alias: app-build
+            parameters:
+              <<: *studies
+          requires:
+            - << matrix.study_key >>-ui-unit-test
+            - api-unit-test
 
   build-app-workflow:
     when: << pipeline.parameters.do-builds >>
     jobs:
       - ui-unit-test:
-          <<: *build-and-store-filters
+          <<: *filter-release-branch
           study_key: << pipeline.parameters.study_key >>
       - api-unit-test:
-          <<: *build-and-store-filters
+          <<: *filter-release-branch
       - app-build:
-          <<: *build-and-store-filters
+          <<: *filter-release-branch
           study_key: << pipeline.parameters.study_key >>
           requires:
             - ui-unit-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -969,9 +969,9 @@ workflows:
         - equal: [ UNKNOWN, << pipeline.parameters.api_call >> ]
     jobs:
       - api-unit-test:
-          <<: *filter-release-branch
+          <<: *filter-pr-branch
       - ui-unit-test:
-          <<: *filter-release-branch
+          <<: *filter-pr-branch
           name: << matrix.study_key >>-ui-unit-test
           matrix:
             alias: app-ui-unit-test


### PR DESCRIPTION
Second attempt on PEPPER-571 because the old [merge](https://github.com/broadinstitute/ddp-angular/pull/2016) was reverted.

This PR is the first part of PEPPER-571 rework: Modify `launch-all-app-builds-workflow` to combine running of tests and conditionally build and store artifacts on `rc` or `hotfix` branches in one single workflow because:

- `rc` or `hotfix` branches are created for Test env promotion during releases
- `launch-all-app-builds-workflow` is launched automatically by commited `rc` or `hotfix` branches
- Each `build-app-workflow` is launched one at atime by `launch-all-app-builds-workflow` via CI api calls

** Before changes, `build-app-workflow` and all `launch-all-app-builds-workflow` workflows are separately launched, similar to this screenshot

<img width="830" alt="Screenshot 2023-03-01 at 3 04 09 PM" src="https://user-images.githubusercontent.com/35533885/222253793-4965eec4-0379-4bbf-b4bb-22ce3b31dcb9.png">

** After changes, `launch-all-app-builds-workflow` contains all jobs. It will look similar to this screenshot

<img width="578" alt="Screenshot 2023-03-01 at 3 18 20 PM" src="https://user-images.githubusercontent.com/35533885/222256172-5c0db6f0-73bd-4f63-a82b-c98c7474d9c9.png">
