### PR TITLE
DSM-PEPPER-676-display-error-only-if-includes-error-field

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/scanner/scanner.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/scanner/scanner.component.ts
@@ -19,7 +19,7 @@ import {InputField} from './interfaces/input-field';
 import {Auth} from '../services/auth.service';
 import {Statics} from '../utils/statics';
 import {Scanner} from './interfaces/scanners';
-import {first, map} from 'rxjs/operators';
+import {first} from 'rxjs/operators';
 // changing
 @Component({
   selector: 'app-scanner',

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/scanner/scanner.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/scanner/scanner.component.ts
@@ -19,7 +19,7 @@ import {InputField} from './interfaces/input-field';
 import {Auth} from '../services/auth.service';
 import {Statics} from '../utils/statics';
 import {Scanner} from './interfaces/scanners';
-import {first} from 'rxjs/operators';
+import {first, map} from 'rxjs/operators';
 // changing
 @Component({
   selector: 'app-scanner',
@@ -82,7 +82,7 @@ export class ScannerComponent implements DoCheck, OnDestroy {
       .subscribe({
         next: (data: any[]) => {
           this.cdr.markForCheck();
-          if (data.some(d => d)) {
+          if (data.some(d => d?.hasOwnProperty('error'))) {
             this.removeSuccessfulScans(data);
             this.additionalMessage = 'Error - Failed to save all changes';
           } else {
@@ -169,7 +169,7 @@ export class ScannerComponent implements DoCheck, OnDestroy {
   }
 
   private removeSuccessfulScans(responseData: any[]): void {
-    responseData.forEach((data: any, index: number) => data &&
+    responseData.forEach((data: any, index: number) => data?.hasOwnProperty('error') &&
       this.scannerFields.at(index).setErrors({notFound: data?.error})
     );
     for (let i = this.scannerFields.length - 2; i >= 0; i--) {


### PR DESCRIPTION
[PEPPER-676](https://broadworkbench.atlassian.net/browse/PEPPER-676)

Displays error only if the backend response includes the `error` field

[PEPPER-676]: https://broadworkbench.atlassian.net/browse/PEPPER-676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ