### PR TITLE
Redirect user to login after Auth0 error (token expiration, etc)

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/auth.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/auth.service.ts
@@ -178,9 +178,10 @@ export class Auth implements OnDestroy {
   }
 
   private checkForAuth0Error(error: any): boolean {
-    return (error instanceof HttpErrorResponse &&  error && error.hasOwnProperty('status') && error.hasOwnProperty('ok') && error.message && error.url &&
+    return (error instanceof HttpErrorResponse &&  error && error.hasOwnProperty('status')
+      && error.hasOwnProperty('ok') && error.message && error.url &&
       (error.status === 401 || error.status === 0)
-      && !error.ok && error.message.includes('ui/auth0: 0 Unknown Error') && error.url.includes('ui/auth0'))
+      && !error.ok && error.message.includes('ui/auth0: 0 Unknown Error') && error.url.includes('ui/auth0'));
   }
   private handleError(error: any): Observable<any> {
     // In a real world app, we might use a remote logging infrastructure


### PR DESCRIPTION
[PEPPER-717](https://broadworkbench.atlassian.net/browse/PEPPER-717) identifies an issue as a side effect of the multiple browser tabs implementation that reveals an error with Auth0 and token expiration.

This PR updates the logic in the Auth service so that when an Auth0 related error is detected, the user is redirected to the login page for login after clearing the current auth token.

[PEPPER-717]: https://broadworkbench.atlassian.net/browse/PEPPER-717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ