### PR TITLE
[PEPPER-717] Expired token action may have different message text in some cases; Consolidates error handling due to expired credentials in Auth.doLogout

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/abstraction-field/abstraction-field.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/abstraction-field/abstraction-field.component.ts
@@ -44,7 +44,8 @@ export class AbstractionFieldComponent implements OnInit {
   modalReadOnly: boolean;
   _other: string;
 
-  constructor(private dsmService: DSMService, private router: Router, private compService: ComponentService, private role: RoleService) {
+  constructor(private dsmService: DSMService, private router: Router, private compService: ComponentService,
+              private role: RoleService, private auth: Auth) {
   }
 
   ngOnInit(): void {
@@ -308,7 +309,7 @@ export class AbstractionFieldComponent implements OnInit {
           },
           error: err => {
             if (err._body === Auth.AUTHENTICATION_ERROR) {
-              this.router.navigate([ Statics.HOME_URL ]);
+              this.auth.doLogout();
             }
           }
         });
@@ -343,7 +344,7 @@ export class AbstractionFieldComponent implements OnInit {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.router.navigate([ Statics.HOME_URL ]);
+          this.auth.doLogout();
         }
       }
     });

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/abstraction-settings/abstraction-settings.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/abstraction-settings/abstraction-settings.component.ts
@@ -95,7 +95,7 @@ export class AbstractionSettingsComponent implements OnInit {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.auth.sessionLogout();
+          this.auth.doLogout();
           this.loading = false;
         }
         this.errorMessage = 'Error - Loading medical record abstraction form controls\n ' + err;
@@ -130,7 +130,7 @@ export class AbstractionSettingsComponent implements OnInit {
             },
             error: err => {
               if (err._body === Auth.AUTHENTICATION_ERROR) {
-                this.auth.sessionLogout();
+                this.auth.doLogout();
                 this.loading = false;
               }
               this.errorMessage = 'Error - Loading medical record abstraction form controls\n ' + err;

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/auth0/auth.guard.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/auth0/auth.guard.ts
@@ -4,6 +4,7 @@ import { Auth } from '../services/auth.service';
 import { SessionService } from '../services/session.service';
 import { DSMService } from '../services/dsm.service';
 import { Statics } from '../utils/statics';
+import {ComponentService} from '../services/component.service';
 
 @Injectable()
 export class AuthGuard implements CanActivate {
@@ -12,7 +13,9 @@ export class AuthGuard implements CanActivate {
   }
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
-    if (localStorage.getItem(Auth.AUTH0_TOKEN_NAME) && localStorage.getItem(SessionService.DSM_TOKEN_NAME)) {
+    const selectedRealm = sessionStorage.getItem(ComponentService.MENU_SELECTED_REALM);
+    if (localStorage.getItem(Auth.AUTH0_TOKEN_NAME) && localStorage.getItem(SessionService.DSM_TOKEN_NAME)
+      && state.url.includes(selectedRealm)) {
       // logged in so return true
       return true;
     }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard/dashboard.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/dashboard/dashboard.component.ts
@@ -124,7 +124,7 @@ export class DashboardComponent implements OnInit {
                     },
                     error: err => {
                       if (err._body === Auth.AUTHENTICATION_ERROR) {
-                        this.auth.sessionLogout();
+                        this.auth.doLogout();
                       }
                       this.loadingDDPData = false;
                       this.errorMessage = 'Error - Loading ddp information\nPlease contact your DSM developer';
@@ -157,7 +157,7 @@ export class DashboardComponent implements OnInit {
                     },
                     error: err => {
                       if (err._body === Auth.AUTHENTICATION_ERROR) {
-                        this.auth.sessionLogout();
+                        this.auth.doLogout();
                       }
                       this.errorMessage = 'Error - Loading ddp information\nPlease contact your DSM developer';
                       this.loadingDDPData = false;
@@ -246,7 +246,7 @@ export class DashboardComponent implements OnInit {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.auth.sessionLogout();
+          this.auth.doLogout();
         }
         this.loadingDDPData = false;
         this.errorMessage = 'Error - Loading ddp information ' + err;
@@ -281,7 +281,7 @@ export class DashboardComponent implements OnInit {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.auth.sessionLogout();
+          this.auth.doLogout();
         }
         this.loadingDDPData = false;
         this.errorMessage = 'Error - Loading ddp information ' + err;
@@ -475,7 +475,7 @@ export class DashboardComponent implements OnInit {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.auth.sessionLogout();
+          this.auth.doLogout();
         }
         // eslint-disable-next-line no-throw-literal
         throw 'Error - Loading display settings' + err;
@@ -496,7 +496,7 @@ export class DashboardComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.loadingDDPData = false;
           this.errorMessage = 'Error - Downloading Participant List, Please contact your DSM developer';

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/discard-sample-page/discard-sample-page.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/discard-sample-page/discard-sample-page.component.ts
@@ -96,7 +96,7 @@ export class DiscardSamplePageComponent implements OnInit, OnDestroy {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.errorMessage = 'Error - Loading list of samples of exited participants\nPlease contact your DSM developer';
         }
@@ -120,7 +120,7 @@ export class DiscardSamplePageComponent implements OnInit, OnDestroy {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.auth.sessionLogout();
+          this.auth.doLogout();
         }
         this.errorMessage = 'Error - Uploading file\nPlease contact your DSM developer';
         this.waiting = false;
@@ -140,7 +140,7 @@ export class DiscardSamplePageComponent implements OnInit, OnDestroy {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.errorMessage = 'Error - Loading list of samples of exited participants\nPlease contact your DSM developer';
         }
@@ -174,7 +174,7 @@ export class DiscardSamplePageComponent implements OnInit, OnDestroy {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.modalRef.hide();
           this.additionalMessage = null;
@@ -224,7 +224,7 @@ export class DiscardSamplePageComponent implements OnInit, OnDestroy {
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
           console.info('received error back');
-          this.auth.sessionLogout();
+          this.auth.doLogout();
         }
         this.errorMessage = 'Error - Loading list of samples of exited participants\nPlease contact your DSM developer';
       }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/discard-sample/discard-sample.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/discard-sample/discard-sample.component.ts
@@ -94,7 +94,7 @@ export class DiscardSampleComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.loading = false;
           this.errorMessage = 'Error - Loading list of samples of exited participants\nPlease contact your DSM developer';
@@ -125,7 +125,7 @@ export class DiscardSampleComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.loading = false;
           this.errorMessage = 'Error - Loading list of samples of exited participants\nPlease contact your DSM developer';

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/drug-list/drug-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/drug-list/drug-list.component.ts
@@ -68,7 +68,7 @@ export class DrugListComponent implements OnInit {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.auth.sessionLogout();
+          this.auth.doLogout();
         }
         this.loading = false;
         this.errorMessage = 'Error - Loading Drug List\nPlease contact your DSM developer';
@@ -133,7 +133,7 @@ export class DrugListComponent implements OnInit {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.auth.sessionLogout();
+          this.auth.doLogout();
         }
       }
     });
@@ -178,7 +178,7 @@ export class DrugListComponent implements OnInit {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.auth.sessionLogout();
+          this.auth.doLogout();
         }
         this.loading = false;
         this.additionalMessage = 'Error - Saving Drug\nPlease contact your DSM developer';

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/field-settings/field-settings.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/field-settings/field-settings.component.ts
@@ -154,7 +154,7 @@ export class FieldSettingsComponent implements OnInit {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.auth.sessionLogout();
+          this.auth.doLogout();
         }
         this.loading = false;
         const returnedMessage = JSON.parse(err._body);
@@ -199,7 +199,7 @@ export class FieldSettingsComponent implements OnInit {
           },
           error: err => {
             if (err._body === Auth.AUTHENTICATION_ERROR) {
-              this.auth.sessionLogout();
+              this.auth.doLogout();
               this.loading = false;
             }
             this.additionalMessage = JSON.parse(err._body).body;

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/label-settings/label-settings.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/label-settings/label-settings.component.ts
@@ -39,7 +39,7 @@ export class LabelSettingsComponent implements OnInit {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.auth.sessionLogout();
+          this.auth.doLogout();
         }
         this.loading = false;
         this.errorMessage = 'Error - Loading Label Settings\nPlease contact your DSM developer';
@@ -101,7 +101,7 @@ export class LabelSettingsComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.loading = false;
           this.additionalMessage = 'Error - Saving label settings\nPlease contact your DSM developer';

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/mailing-list/mailing-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/mailing-list/mailing-list.component.ts
@@ -93,7 +93,7 @@ export class MailingListComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.errorMessage = 'Error - Loading contacts  ' + err;
           this.loadingContacts = false;

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/medical-record/medical-record.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/medical-record/medical-record.component.ts
@@ -176,7 +176,7 @@ export class MedicalRecordComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.router.navigate([ Statics.HOME_URL ]);
+            this.auth.doLogout();
           }
           this.additionalMessage = 'Error - Saving changes \n' + err;
         }
@@ -207,7 +207,7 @@ export class MedicalRecordComponent implements OnInit {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.auth.sessionLogout();
+          this.auth.doLogout();
         }
         this.errorMessage = 'Error - Loading mr log\nPlease contact your DSM developer';
       }
@@ -227,7 +227,7 @@ export class MedicalRecordComponent implements OnInit {
           },
           error: err => {
             if (err._body === Auth.AUTHENTICATION_ERROR) {
-              this.router.navigate([Statics.HOME_URL]);
+              this.auth.doLogout();
             }
             this.additionalMessage = 'Error - Saving log data\nPlease contact your DSM developer';
           }
@@ -271,7 +271,7 @@ export class MedicalRecordComponent implements OnInit {
           },
           error: err => {
             if (err._body === Auth.AUTHENTICATION_ERROR) {
-              this.router.navigate([Statics.HOME_URL]);
+              this.auth.doLogout();
             }
             this.message = 'Failed to download pdf.';
             this.downloading = false;
@@ -361,7 +361,7 @@ export class MedicalRecordComponent implements OnInit {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.router.navigate([ Statics.HOME_URL ]);
+          this.auth.doLogout();
         }
         this.additionalMessage = 'Error - Saving changes \n' + err;
       }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/ndiupload/ndiupload.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/ndiupload/ndiupload.component.ts
@@ -49,7 +49,7 @@ export class NDIUploadComponent implements OnInit {
         //        console.log(`received***: ${JSON.stringify(err, null, 2)}`);
         this.loading = false;
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.auth.sessionLogout();
+          this.auth.doLogout();
         }
         this.errorMessage = 'Error - Uploading txt\n' + err._body;
       }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/onc-history-detail/onc-history-detail.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/onc-history-detail/onc-history-detail.component.ts
@@ -51,7 +51,7 @@ export class OncHistoryDetailComponent implements OnInit {
   patchFinished = true;
 
   constructor(private dsmService: DSMService, private compService: ComponentService, private role: RoleService,
-               private router: Router, private util: Utils) {
+               private router: Router, private util: Utils, private auth: Auth) {
   }
 
   ngOnInit(): void {
@@ -174,7 +174,7 @@ export class OncHistoryDetailComponent implements OnInit {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.router.navigate([ Statics.HOME_URL ]);
+          this.auth.doLogout();
         }
       }
     });
@@ -258,7 +258,7 @@ export class OncHistoryDetailComponent implements OnInit {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.router.navigate([ Statics.HOME_URL ]);
+          this.auth.doLogout();
         }
       }
     });

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-event/participant-event.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-event/participant-event.component.ts
@@ -93,7 +93,7 @@ export class ParticipantEventComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.loading = false;
           this.errorMessage = 'Error - Loading list of event types\nPlease contact your DSM developer';
@@ -125,7 +125,7 @@ export class ParticipantEventComponent implements OnInit {
         error: err => {
           // console.log(err);
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.router.navigate([Statics.HOME_URL]);
+            this.auth.doLogout();
           }
           this.errorMessage = 'Failed to skip email for given participant';
           this.loading = false;
@@ -155,7 +155,7 @@ export class ParticipantEventComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.loading = false;
           this.errorMessage = 'Error - Loading list of skipped participant events\nPlease contact your DSM developer';

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-exit/participant-exit.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-exit/participant-exit.component.ts
@@ -98,7 +98,7 @@ export class ParticipantExitComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.router.navigate([Statics.HOME_URL]);
+            this.auth.doLogout();
           }
           this.errorMessage = 'Error - Failed to exit participant';
           this.loading = false;
@@ -121,7 +121,7 @@ export class ParticipantExitComponent implements OnInit {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.auth.sessionLogout();
+          this.auth.doLogout();
         }
         this.loading = false;
         this.errorMessage = 'Error - Loading list of samples of exited participants\nPlease contact your DSM developer';
@@ -148,7 +148,7 @@ export class ParticipantExitComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.loading = false;
           this.errorMessage = 'Error - Loading list of exited participants\nPlease contact your DSM developer';

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -204,7 +204,7 @@ export class ParticipantListComponent implements OnInit {
             },
             error: err => {
               if (err._body === Auth.AUTHENTICATION_ERROR) {
-                this.auth.sessionLogout();
+                this.auth.doLogout();
               }
               this.loadingParticipants = null;
               this.errorMessage = 'Error - Loading Participant List, Please contact your DSM developer';
@@ -733,7 +733,7 @@ export class ParticipantListComponent implements OnInit {
       // this.renewSelectedColumns(); commented out because if we have defaultColumns for all the studies we won't need it anymore
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.auth.sessionLogout();
+          this.auth.doLogout();
         }
         // eslint-disable-next-line no-throw-literal
         throw 'Error - Loading display settings' + err;
@@ -940,7 +940,7 @@ export class ParticipantListComponent implements OnInit {
           },
           error: err => {
             if (err._body === Auth.AUTHENTICATION_ERROR) {
-              this.auth.sessionLogout();
+              this.auth.doLogout();
             }
             this.loadingParticipants = null;
             this.errorMessage = 'Error - Loading Participant List, Please contact your DSM developer';
@@ -1094,7 +1094,7 @@ export class ParticipantListComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.loadingParticipants = null;
           this.errorMessage = 'Error - Loading Participant List, Please contact your DSM developer';
@@ -1955,7 +1955,7 @@ export class ParticipantListComponent implements OnInit {
           },
           error: err => {
             if (err._body === Auth.AUTHENTICATION_ERROR) {
-              this.router.navigate([Statics.HOME_URL]);
+              this.auth.doLogout();
             }
             this.additionalMessage = 'Error - Assigning Participants, Please contact your DSM developer';
           }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
@@ -585,7 +585,7 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.router.navigate([Statics.HOME_URL]);
+            this.auth.doLogout();
           }
           this.additionalMessage = 'Error - Saving changed field \n' + err;
         }
@@ -623,7 +623,7 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
         }
       });
@@ -670,7 +670,7 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.router.navigate([Statics.HOME_URL]);
+            this.auth.doLogout();
           }
         }
       });
@@ -791,7 +791,7 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.router.navigate([Statics.HOME_URL]);
+          this.auth.doLogout();
         }
         this.additionalMessage = 'Error - Saving paper C/R changes \n' + err;
       }
@@ -855,7 +855,7 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.router.navigate([Statics.HOME_URL]);
+          this.auth.doLogout();
         }
         this.disableTissueRequestButton = false;
         this.downloading = false;
@@ -990,7 +990,7 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
         }
       });
@@ -1045,7 +1045,7 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.router.navigate([Statics.HOME_URL]);
+            this.auth.doLogout();
           }
         }
       });
@@ -1085,7 +1085,7 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.router.navigate([Statics.HOME_URL]);
+          this.auth.doLogout();
         }
       }
     });
@@ -1127,7 +1127,7 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.router.navigate([Statics.HOME_URL]);
+          this.auth.doLogout();
         }
       }
     });
@@ -1161,7 +1161,7 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.router.navigate([Statics.HOME_URL]);
+          this.auth.doLogout();
         }
       }
     });
@@ -1286,7 +1286,7 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.router.navigate([Statics.HOME_URL]);
+          this.auth.doLogout();
         }
         this.additionalMessage = 'Error - Downloading consent pdf file\nPlease contact your DSM developer';
         this.disableDownload = false;
@@ -1571,7 +1571,7 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
           },
           error: err => {
             if (err._body === Auth.AUTHENTICATION_ERROR) {
-              this.router.navigate([Statics.HOME_URL]);
+              this.auth.doLogout();
             }
           }
         });

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/pdf-download/pdf-download.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/pdf-download/pdf-download.component.ts
@@ -101,7 +101,7 @@ export class PdfDownloadComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.loading = false;
           this.errorMessage = 'Error - Loading list of event types\nPlease contact your DSM developer';
@@ -131,7 +131,7 @@ export class PdfDownloadComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.loading = false;
           this.errorMessage = 'Error - Loading list of event types\nPlease contact your DSM developer';
@@ -153,7 +153,7 @@ export class PdfDownloadComponent implements OnInit {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.router.navigate([Statics.HOME_URL]);
+          this.auth.doLogout();
         }
         this.additionalMessage = 'Error - Downloading consent pdf file\nPlease contact your DSM developer';
         this.loading = false;

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/permalink/permalink.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/permalink/permalink.component.ts
@@ -60,7 +60,7 @@ export class PermalinkComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           // eslint-disable-next-line no-throw-literal
           throw 'Error loading institutions' + err;
@@ -78,14 +78,14 @@ export class PermalinkComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           // eslint-disable-next-line no-throw-literal
           throw 'Error loading medical record data' + err;
         }
       });
     } else {
-      this.router.navigate([ Statics.HOME_URL ]);
+      this.router.navigateByUrl('/');
     }
   }
 }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/scanner/scanner.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/scanner/scanner.component.ts
@@ -17,7 +17,6 @@ import {
 import {Subject, takeUntil} from 'rxjs';
 import {InputField} from './interfaces/input-field';
 import {Auth} from '../services/auth.service';
-import {Statics} from '../utils/statics';
 import {Scanner} from './interfaces/scanners';
 import {first} from 'rxjs/operators';
 // changing
@@ -47,7 +46,8 @@ export class ScannerComponent implements DoCheck, OnDestroy {
     private readonly fb: FormBuilder,
     private readonly activatedRoute: ActivatedRoute,
     private readonly cdr: ChangeDetectorRef,
-    private readonly router: Router
+    private readonly router: Router,
+    private auth: Auth
   ) {
     activatedRoute.queryParams
       .pipe(takeUntil(this.subscriptionSubject$))
@@ -96,7 +96,7 @@ export class ScannerComponent implements DoCheck, OnDestroy {
         error: async (error: any) => {
           this.cdr.markForCheck();
           if (error.body === Auth.AUTHENTICATION_ERROR) {
-            await this.router.navigate([Statics.HOME_URL]);
+            this.auth.doLogout();
           }
           this.additionalMessage = 'Error - Failed to save data';
         }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/sequencing-order/sequencing-order.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/sequencing-order/sequencing-order.component.ts
@@ -62,7 +62,7 @@ export class SequencingOrderComponent {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.auth.sessionLogout();
+          this.auth.doLogout();
         }
       }
     } );

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/auth.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/auth.service.ts
@@ -140,9 +140,7 @@ export class Auth implements OnDestroy {
     this.selectedRealm = null;
 }
   public sessionLogout(): void {
-    // Do NOT remove token from localStorage at this point.
-    this.sessionService.logout();
-    this.selectedRealm = null;
+    this.doLogout();
   }
 
   public doLogin(authPayload: any): void {
@@ -179,9 +177,9 @@ export class Auth implements OnDestroy {
 
   private checkForAuth0Error(error: any): boolean {
     return (error instanceof HttpErrorResponse &&  error && error.hasOwnProperty('status')
-      && error.hasOwnProperty('ok') && error.message && error.url &&
+      && error.hasOwnProperty('ok') && error.url &&
       (error.status === 401 || error.status === 0)
-      && !error.ok && error.message.includes('ui/auth0: 0 Unknown Error') && error.url.includes('ui/auth0'));
+      && !error.ok && error.url.includes('ui/auth0'));
   }
   private handleError(error: any): Observable<any> {
     // In a real world app, we might use a remote logging infrastructure

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/auth.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/auth.service.ts
@@ -90,8 +90,8 @@ export class Auth implements OnDestroy {
 
   constructor(private router: Router, private activatedRoute: ActivatedRoute, private http: HttpClient,
               private sessionService: SessionService, private role: RoleService,
-              private compService: ComponentService, private dsmService: DSMService, private localStorageService: LocalStorageService
-               ) {
+              private compService: ComponentService, private dsmService: DSMService,
+              private localStorageService: LocalStorageService) {
     // Add callback for lock `authenticated` event
     this.lock.on('authenticated', (authResult: any) => {
       localStorage.setItem(Auth.AUTH0_TOKEN_NAME, authResult.idToken);
@@ -112,7 +112,6 @@ export class Auth implements OnDestroy {
       event => {
         if (event.key === SessionService.DSM_TOKEN_NAME && event.newValue === null) {
           this.doLogout();
-          this.router.navigateByUrl('/');
         }
       }
     );
@@ -138,6 +137,7 @@ export class Auth implements OnDestroy {
     this.localStorageService.clear();
     this.sessionService.logout();
     this.selectedRealm = null;
+    this.router.navigateByUrl('/');
 }
   public sessionLogout(): void {
     // Do NOT remove token from localStorage at this point.

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/auth.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/auth.service.ts
@@ -140,7 +140,9 @@ export class Auth implements OnDestroy {
     this.selectedRealm = null;
 }
   public sessionLogout(): void {
-    this.doLogout();
+    // Do NOT remove token from localStorage at this point.
+    this.sessionService.logout();
+    this.selectedRealm = null;
   }
 
   public doLogin(authPayload: any): void {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dsm.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dsm.service.ts
@@ -1165,8 +1165,9 @@ export class DSMService {
 
   private checkCookieBeforeCall(): boolean {
     if (this.sessionService.getDSMToken() == null) {
+      this.localStorageService.clear();
       this.sessionService.logout();
-      this.router.navigate([ Statics.HOME_URL ]);
+      this.router.navigateByUrl('/');
       return false;
     } else {
       const jwtHelper = new JwtHelperService();

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/shipping-report/shipping-report.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/shipping-report/shipping-report.component.ts
@@ -53,7 +53,7 @@ export class ShippingReportComponent implements OnInit {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.auth.sessionLogout();
+          this.auth.doLogout();
         }
         this.loadingReport = false;
         this.errorMessage = 'Error - Loading Sample Report\nPlease contact your DSM developer';
@@ -93,7 +93,7 @@ export class ShippingReportComponent implements OnInit {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.auth.sessionLogout();
+          this.auth.doLogout();
         }
         this.loadingReport = false;
         this.errorMessage = 'Error - Loading Sample Report\nPlease contact your DSM developer';

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/shipping-search/shipping-search.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/shipping-search/shipping-search.component.ts
@@ -67,7 +67,7 @@ export class ShippingSearchComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.errorMessage = 'Error - Loading ddp information\nPlease contact your DSM developer';
           this.searching = false;
@@ -112,7 +112,7 @@ export class ShippingSearchComponent implements OnInit {
           },
           error: err => {
             if (err._body === Auth.AUTHENTICATION_ERROR) {
-              this.auth.sessionLogout();
+              this.auth.doLogout();
             }
             this.errorMessage = 'Error - Loading ddp information\nPlease contact your DSM developer';
             this.searching = false;

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/shipping/shipping.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/shipping/shipping.component.ts
@@ -232,7 +232,7 @@ export class ShippingComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.loading = false;
           this.additionalMessage = 'Error - Loading kit types\n' + err;
@@ -299,7 +299,7 @@ export class ShippingComponent implements OnInit {
           },
           error: err => {
             if (err._body === Auth.AUTHENTICATION_ERROR) {
-              this.auth.sessionLogout();
+              this.auth.doLogout();
             }
             this.loading = false;
             this.errorMessage = 'Error - Loading kit request data\n' + err;
@@ -563,7 +563,7 @@ export class ShippingComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.loading = false;
           this.errorMessage = 'Error - Buying express label\n' + err;
@@ -589,7 +589,7 @@ export class ShippingComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.loading = false;
           this.errorMessage = 'Error - Deactivating kit request\n' + err;
@@ -619,7 +619,7 @@ export class ShippingComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.loading = false;
           this.errorMessage = 'Error - Deactivating kit request\n' + err;
@@ -661,7 +661,7 @@ export class ShippingComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.loading = false;
           this.errorMessage = 'Error - Activating kit request.\nPlease contact your DSM developer';
@@ -727,7 +727,7 @@ export class ShippingComponent implements OnInit {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.auth.sessionLogout();
+          this.auth.doLogout();
         }
         this.loading = false;
         this.errorMessage = 'Error - Deactivating kit request\n' + err;
@@ -778,7 +778,7 @@ export class ShippingComponent implements OnInit {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.auth.sessionLogout();
+          this.auth.doLogout();
         }
         this.loading = false;
         this.errorMessage = 'Error - Loading ddp information ' + err;

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/stool-upload/stool-upload.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/stool-upload/stool-upload.component.ts
@@ -104,7 +104,7 @@ export class StoolUploadComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.loading = false;
           this.errorMessage = 'Error - Loading kit types\n' + err;
@@ -130,7 +130,7 @@ export class StoolUploadComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.errorMessage = err.error;
         },

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/survey/survey.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/survey/survey.component.ts
@@ -121,7 +121,7 @@ export class SurveyComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.loading = false;
           this.errorMessage = 'Error - Loading list of surveys\nPlease contact your DSM developer';
@@ -156,7 +156,7 @@ export class SurveyComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.loading = false;
           this.errorMessage = 'Error - Loading list of survey status\nPlease contact your DSM developer';
@@ -276,7 +276,7 @@ export class SurveyComponent implements OnInit {
         error: err => {
           this.loading = false;
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.errorMessage = 'Error - Uploading txt\n' + err;
         }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/tissue-list/tissue-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/tissue-list/tissue-list.component.ts
@@ -487,7 +487,7 @@ export class TissueListComponent implements OnInit {
           },
           error: err => {
             if (err._body === Auth.AUTHENTICATION_ERROR) {
-              this.auth.sessionLogout();
+              this.auth.doLogout();
             }
             this.errorMessage = 'Error - Loading Tissues for tissue view, Please contact your DSM developer\n ' + err;
           },
@@ -1053,7 +1053,7 @@ export class TissueListComponent implements OnInit {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.router.navigate([ Statics.HOME_URL ]);
+          this.auth.doLogout();
         }
       },
     });
@@ -1622,7 +1622,7 @@ export class TissueListComponent implements OnInit {
           },
           error: err => {
             if (err._body === Auth.AUTHENTICATION_ERROR) {
-              this.router.navigate([Statics.HOME_URL]);
+              this.auth.doLogout();
             }
             this.additionalMessage = 'Error - Assigning Tissues, Please contact your DSM developer';
           }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/tissue/tissue.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/tissue/tissue.component.ts
@@ -43,7 +43,8 @@ export class TissueComponent {
   selectedSmIds = 0;
   smIdDuplicate = {};
 
-  constructor(private role: RoleService, private dsmService: DSMService, private compService: ComponentService, private router: Router) {
+  constructor(private role: RoleService, private dsmService: DSMService, private compService: ComponentService,
+              private router: Router, private auth: Auth) {
     this.smIdDuplicate[ this.uss ] = new Set();
     this.smIdDuplicate[ this.he ] = new Set();
     this.smIdDuplicate[ this.scrolls ] = new Set();
@@ -190,7 +191,7 @@ export class TissueComponent {
             this.smIdDuplicate[ this.currentSMIDField ].add(this.createDuplicateIndex( index ) );
           }
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.router.navigate([ Statics.HOME_URL ]);
+            this.auth.doLogout();
           }
         },
       });
@@ -222,7 +223,7 @@ export class TissueComponent {
           },
           error: err => {
             if (err._body === Auth.AUTHENTICATION_ERROR) {
-              this.router.navigate([Statics.HOME_URL]);
+              this.auth.doLogout();
             }
           },
         });

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/upload/upload.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/upload/upload.component.ts
@@ -122,7 +122,7 @@ export class UploadComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.loading = false;
           this.errorMessage = 'Error - Loading kit types\n' + err;
@@ -156,7 +156,7 @@ export class UploadComponent implements OnInit {
   private checkErrorMessage(err: HttpErrorResponse): void {
     switch (err.status) {
       case 401:
-        this.auth.sessionLogout();
+        this.auth.doLogout();
         break;
       case 403:
         this.allowedToSeeInformation = false;
@@ -181,7 +181,7 @@ export class UploadComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.loading = false;
           this.errorMessage = 'Error - Loading shipping carriers\n' + err;
@@ -256,7 +256,7 @@ export class UploadComponent implements OnInit {
         },
         error: (err: HttpErrorResponse) => {
           this.loading = false;
-          err.status === 401 && this.auth.sessionLogout();
+          err.status === 401 && this.auth.doLogout();
           this.errorMessage = err.error;
         }
       });
@@ -312,7 +312,7 @@ export class UploadComponent implements OnInit {
         error: err => {
           this.loading = false;
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.auth.sessionLogout();
+            this.auth.doLogout();
           }
           this.errorMessage = 'Error - Uploading txt\n' + err;
         }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/user-setting/user-setting.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/user-setting/user-setting.component.ts
@@ -100,7 +100,7 @@ export class UserSettingComponent implements OnInit {
       },
       error: err => {
         if (err._body === Auth.AUTHENTICATION_ERROR) {
-          this.router.navigate([Statics.HOME_URL]);
+          this.auth.doLogout();
         }
         this.additionalMessage = 'Error - Saving user settings\n' + err;
         this.saving = false;
@@ -139,7 +139,7 @@ export class UserSettingComponent implements OnInit {
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
-            this.router.navigate([Statics.HOME_URL]);
+            this.auth.doLogout();
           }
           this.additionalMessage = 'Error - Saving user settings\n' + err;
           this.saving = false;


### PR DESCRIPTION
[PEPPER-717](https://broadworkbench.atlassian.net/browse/PEPPER-717)
While testing the first fix for this ticket, a developer was not able to successfully log into the application.  Upon inspection, the error text was different in this case.  This PR removes the inspection of the error.message value since it can change and we have enough information outside of this text to determine we need to send the user to the login page.

Further testing revealed that logout handling was insufficient for cases where the token had expired.  Logic is consolidated in Auth.doLogout where possible (except in a case where cyclical dependencies prevented it).



[PEPPER-717]: https://broadworkbench.atlassian.net/browse/PEPPER-717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ