### PR TITLE
[PEPPER-731] Auth0 invalid signature returns a 400 response.

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/auth.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/auth.service.ts
@@ -179,8 +179,7 @@ export class Auth implements OnDestroy {
 
   private checkForAuth0Error(error: any): boolean {
     return (error instanceof HttpErrorResponse &&  error && error.hasOwnProperty('status')
-      && error.hasOwnProperty('ok') && error.url &&
-      (error.status === 401 || error.status === 400 || error.status === 0)
+      && error.hasOwnProperty('ok') && error.url
       && !error.ok && error.url.includes('ui/auth0'));
   }
   private handleError(error: any): Observable<any> {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/auth.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/auth.service.ts
@@ -180,7 +180,7 @@ export class Auth implements OnDestroy {
   private checkForAuth0Error(error: any): boolean {
     return (error instanceof HttpErrorResponse &&  error && error.hasOwnProperty('status')
       && error.hasOwnProperty('ok') && error.url &&
-      (error.status === 401 || error.status === 0)
+      (error.status === 401 || error.status === 400 || error.status === 0)
       && !error.ok && error.url.includes('ui/auth0'));
   }
   private handleError(error: any): Observable<any> {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/auth.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/auth.service.ts
@@ -186,21 +186,18 @@ export class Auth implements OnDestroy {
     // In a real world app, we might use a remote logging infrastructure
     // We'd also dig deeper into the error to get a better message
     let errMsg: string | null = null;
+
+    errMsg = (error.message) ? error.message :
+      error.status ? `${error.status} - ${error.statusText}` : 'Server error';
+    this.authError.next(errMsg);
+    console.error(errMsg); // log to console instead
+
     if(this.checkForAuth0Error(error)) {
       this.doLogout();
       this.lock.show();
       return;
     }
-    if(error.status === 500) {
-      errMsg = 'Incorrect user name or password.';
-    } else {
-      errMsg = (error.message) ? error.message :
-        error.status ? `${error.status} - ${error.statusText}` : 'Server error';
-    }
 
-    this.authError.next(errMsg);
-
-    console.error(errMsg); // log to console instead
     return throwError(() => new Error(errMsg));
   }
 


### PR DESCRIPTION
[PEPPER-731](https://broadworkbench.atlassian.net/browse/PEPPER-731) was discovered while testing in dev. Zim recieved responses from Auth0 with invalid signature errors.  As a result, the web client received errors with 400 status codes.

This PR updates the logic that checks Auth0 Errors to include the 400 error code as a candidate to examine.

[PEPPER-731]: https://broadworkbench.atlassian.net/browse/PEPPER-731?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ