### PR TITLE
[PEPPER-730] Reset roles when setting token.

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/role.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/role.service.ts
@@ -47,11 +47,44 @@ export class RoleService {
     this.setRoles( token );
   }
 
+  private resetRolesToDefault(): void {
+    this._isShipping = false;
+    this._isMRRequesting = false;
+    this._isMRView = false;
+    this._isMailingList = false;
+    this._isUpload = false;
+    this._isExitParticipant = false;
+    this._isDeactivation = false;
+    this._isViewingEEL = false;
+    this._isReceiving = false;
+    this._isExpressKit = false;
+    this._isTriggeringSurveyCreation = false;
+    this._isSkipParticipant = false;
+    this._isDiscardingSamples = false;
+    this._isSampleListView = false;
+    this._isDownloadPDF = false;
+    this._isDownloadNDI = false;
+    this._noTissueRequest = false;
+    this._fieldSettings = false;
+    this._isAbstracter = false;
+    this._isQC = false;
+    this._isAbstractionAdmin = false;
+    this._canEditDrugList = false;
+    this._isParticipantListView = false;
+    this._isParticipantEdit = false;
+    this._isKitUploadInvalidAddress = false;
+    this._isDownloadParticipantFile = false;
+    this._hasKitSequencingOrder = false;
+    this._viewOnlyDssData = false;
+    this._viewStatisticsDashboard = false;
+  }
+
   public setRoles( token: string ): void {
     if (token != null) {
       const accessRoles: string = this.getClaimByKeyName( token, 'USER_ACCESS_ROLE' );
       if (accessRoles != null) {
         // console.log( accessRoles );
+        this.resetRolesToDefault();
         const roles: string[] = JSON.parse( accessRoles );
         for (const entry of roles) {
           // only special kit_shipping_xxx rights should get added here, not the overall only kit_shipping_view

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/role.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/role.service.ts
@@ -2,6 +2,7 @@ import {Inject, Injectable} from '@angular/core';
 import {ConfigurationService} from 'ddp-sdk';
 import {UserSetting} from '../user-setting/user-setting.model';
 import {SessionService} from './session.service';
+import {Utils} from "../utils/utils";
 
 @Injectable({providedIn: 'root'})
 export class RoleService {
@@ -80,11 +81,11 @@ export class RoleService {
   }
 
   public setRoles( token: string ): void {
+    this.resetRolesToDefault();
     if (token != null) {
       const accessRoles: string = this.getClaimByKeyName( token, 'USER_ACCESS_ROLE' );
       if (accessRoles != null) {
         // console.log( accessRoles );
-        this.resetRolesToDefault();
         const roles: string[] = JSON.parse( accessRoles );
         for (const entry of roles) {
           // only special kit_shipping_xxx rights should get added here, not the overall only kit_shipping_view
@@ -179,6 +180,8 @@ export class RoleService {
       const userSettings: any = this.getClaimByKeyName( token, 'USER_SETTINGS' );
       if (userSettings != null && userSettings !== 'null') {
         this._userSetting = UserSetting.parse( JSON.parse( userSettings ) );
+      } else {
+        this._userSetting = UserSetting.parse({});
       }
       this._userId = this.getClaimByKeyName( token, 'USER_ID' );
       this._user = this.getClaimByKeyName( token, 'USER_NAME' );

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/role.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/role.service.ts
@@ -2,7 +2,6 @@ import {Inject, Injectable} from '@angular/core';
 import {ConfigurationService} from 'ddp-sdk';
 import {UserSetting} from '../user-setting/user-setting.model';
 import {SessionService} from './session.service';
-import {Utils} from "../utils/utils";
 
 @Injectable({providedIn: 'root'})
 export class RoleService {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/user-setting/user-setting.model.spec.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/user-setting/user-setting.model.spec.ts
@@ -1,7 +1,7 @@
-import {UserSetting} from "./user-setting.model";
-import {Utils} from "../utils/utils";
+import {UserSetting} from './user-setting.model';
+import {Utils} from '../utils/utils';
 
-function validateDefaultValues(settings:UserSetting):void {
+function validateDefaultValues(settings: UserSetting): void {
   expect(settings).toBeTruthy();
   expect(settings.getRowsPerPage()).toBe(10);
   expect(settings.getRowSet0()).toBe(10);
@@ -10,17 +10,19 @@ function validateDefaultValues(settings:UserSetting):void {
   expect(settings.getDateFormat()).toBe(Utils.DATE_STRING_IN_CVS);
 }
 
-describe('UserSetting', ()=>{
+describe('UserSetting', ()=> {
   it('should create an instance', () => {
     const defaultConstructorUserSetting =
       new UserSetting(0,
-      0,0,0,null,null, null, null);
+        0,0,0,null,null, null, null);
     validateDefaultValues(defaultConstructorUserSetting);
-  }),
-  it('should create an instance from empty json', () => {
-    const userSetting = UserSetting.parse(JSON.parse('{}'));
-    validateDefaultValues(userSetting);
-  }),
+  });
+
+    it('should create an instance from empty json', () => {
+      const userSetting = UserSetting.parse(JSON.parse('{}'));
+      validateDefaultValues(userSetting);
+    });
+
     it('should create an instance from rowsOnPage json, with other values as defaults', () => {
       const userSetting = UserSetting.parse(JSON.parse('{"rowsOnPage":13}'));
       expect(userSetting).toBeTruthy();
@@ -29,7 +31,8 @@ describe('UserSetting', ()=>{
       expect(userSetting.getRowSet1()).toBe(25);
       expect(userSetting.getRowSet2()).toBe(50);
       expect(userSetting.getDateFormat()).toBe(Utils.DATE_STRING_IN_CVS);
-    }),
+    });
+
     it('should create an instance from json with a date format string, others as defaults', () => {
       const userSetting = UserSetting.parse(JSON.parse('{"_dateFormat":"some text"}'));
       expect(userSetting).toBeTruthy();
@@ -37,6 +40,6 @@ describe('UserSetting', ()=>{
       expect(userSetting.getRowSet0()).toBe(10);
       expect(userSetting.getRowSet1()).toBe(25);
       expect(userSetting.getRowSet2()).toBe(50);
-      expect(userSetting.getDateFormat()).toBe("some text");
-    })
-})
+      expect(userSetting.getDateFormat()).toBe('some text');
+    });
+});

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/user-setting/user-setting.model.spec.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/user-setting/user-setting.model.spec.ts
@@ -1,0 +1,42 @@
+import {UserSetting} from "./user-setting.model";
+import {Utils} from "../utils/utils";
+
+function validateDefaultValues(settings:UserSetting):void {
+  expect(settings).toBeTruthy();
+  expect(settings.getRowsPerPage()).toBe(10);
+  expect(settings.getRowSet0()).toBe(10);
+  expect(settings.getRowSet1()).toBe(25);
+  expect(settings.getRowSet2()).toBe(50);
+  expect(settings.getDateFormat()).toBe(Utils.DATE_STRING_IN_CVS);
+}
+
+describe('UserSetting', ()=>{
+  it('should create an instance', () => {
+    const defaultConstructorUserSetting =
+      new UserSetting(0,
+      0,0,0,null,null, null, null);
+    validateDefaultValues(defaultConstructorUserSetting);
+  }),
+  it('should create an instance from empty json', () => {
+    const userSetting = UserSetting.parse(JSON.parse('{}'));
+    validateDefaultValues(userSetting);
+  }),
+    it('should create an instance from rowsOnPage json, with other values as defaults', () => {
+      const userSetting = UserSetting.parse(JSON.parse('{"rowsOnPage":13}'));
+      expect(userSetting).toBeTruthy();
+      expect(userSetting.getRowsPerPage()).toBe(13);
+      expect(userSetting.getRowSet0()).toBe(10);
+      expect(userSetting.getRowSet1()).toBe(25);
+      expect(userSetting.getRowSet2()).toBe(50);
+      expect(userSetting.getDateFormat()).toBe(Utils.DATE_STRING_IN_CVS);
+    }),
+    it('should create an instance from json with a date format string, others as defaults', () => {
+      const userSetting = UserSetting.parse(JSON.parse('{"_dateFormat":"some text"}'));
+      expect(userSetting).toBeTruthy();
+      expect(userSetting.getRowsPerPage()).toBe(10);
+      expect(userSetting.getRowSet0()).toBe(10);
+      expect(userSetting.getRowSet1()).toBe(25);
+      expect(userSetting.getRowSet2()).toBe(50);
+      expect(userSetting.getDateFormat()).toBe("some text");
+    })
+})

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/user-setting/user-setting.model.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/user-setting/user-setting.model.ts
@@ -1,4 +1,5 @@
 import { Utils } from '../utils/utils';
+import * as _ from 'underscore';
 
 export class UserSetting {
   constructor(public rowsOnPage: number, public rowSet0: number, public rowSet1: number, public rowSet2: number,
@@ -8,19 +9,19 @@ export class UserSetting {
     this.setToDefaultValues();
 
     // if value is not 0 fill with actual value from user settings table
-    if (rowsOnPage !== 0) {
+    if (rowsOnPage !== 0 && _.isNumber(rowsOnPage)) {
       this.rowsOnPage = rowsOnPage;
     }
-    if (rowSet0 !== 0) {
+    if (rowSet0 !== 0 && _.isNumber(rowSet0)) {
       this.rowSet0 = rowSet0;
     }
-    if (rowSet1 !== 0) {
+    if (rowSet1 !== 0 && _.isNumber(rowSet1)) {
       this.rowSet1 = rowSet1;
     }
-    if (rowSet2 !== 0) {
+    if (rowSet2 !== 0 && _.isNumber(rowSet2)) {
       this.rowSet2 = rowSet2;
     }
-    if (this.dateFormat != null) {
+    if (!_.isNull(dateFormat) && !_.isUndefined(dateFormat)) {
       this.dateFormat = dateFormat;
     }
     this.defaultParticipantFilter = defaultParticipantFilter;


### PR DESCRIPTION
[PEPPER-730](https://broadworkbench.atlassian.net/browse/PEPPER-730) was discovered during release testing.

Before this change, when switching users, roles were not reset.  This could lead the UI to showing features from the previously logged in user.

This PR:
1) Adds logic to reset these values whenever the RoleService.setRoles method is called.
2) Includes handling clearing UserSetting if one isn't provided.
3) Adds code and coverage to ensure valid UserSetting objects are built even if one isn't returned from the backend.

[PEPPER-730]: https://broadworkbench.atlassian.net/browse/PEPPER-730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ