### PR TITLE
[Playwright] New RGP registration E2E test

### DIFF
--- a/playwright-e2e/tests/rgp/email-verification-required.spec.ts
+++ b/playwright-e2e/tests/rgp/email-verification-required.spec.ts
@@ -1,0 +1,41 @@
+import { expect } from '@playwright/test';
+import * as auth from 'authentication/auth-rgp';
+import { test } from 'fixtures/rgp-fixture';
+import HowItWorksPage from 'pages/rgp/how-it-works-page';
+import TellUsYourStoryPage, { WHO } from 'pages/rgp/enrollment/tell-us-your-story-page';
+import HomePage from 'pages/rgp/home-page';
+
+const { RGP_USER_EMAIL, RGP_USER_PASSWORD, RGP_BASE_URL } = process.env;
+
+test.describe('Registration requires email Verification', () => {
+  test('Login is blocked without verification @functional @enrollment @rgp', async ({ page }) => {
+    const homePage = new HomePage(page);
+    await homePage.clickGetStarted();
+
+    const howItWorks = new HowItWorksPage(page);
+    await howItWorks.startApplication();
+
+    const tellUsYourStoryPage = new TellUsYourStoryPage(page);
+    await tellUsYourStoryPage.waitForReady();
+
+    await tellUsYourStoryPage.who().check(WHO.UnderstandEnglishOrSpanish);
+    await tellUsYourStoryPage.who().check(WHO.LivesInUS);
+    await tellUsYourStoryPage.who().check(WHO.HasRareGeneticallyUndiagnosedCondition);
+    await tellUsYourStoryPage.who().check(WHO.IsUnderCare);
+    await tellUsYourStoryPage.submit();
+
+    const userEmail = await auth.createAccountWithEmailAlias(page, {
+      email: RGP_USER_EMAIL,
+      password: RGP_USER_PASSWORD,
+      waitForNavigation: false,
+      waitForAuth: false
+    });
+    await expect(page.locator('text="Account Verification"')).toBeVisible();
+
+    await auth.login(page, { email: userEmail });
+
+    await expect(page.locator('.PageHeader-title')).toHaveText('Email verification required');
+    await expect(page.locator('p.Paragraph')).toHaveText('Please verify your email using the link that was sent to your email address.');
+    expect(page.url()).toEqual(`${RGP_BASE_URL}/email-verification-required`);
+  });
+});


### PR DESCRIPTION
[PEPPER-336](https://broadworkbench.atlassian.net/browse/PEPPER-336)

**Registration**

RGP uses a 2 part registration where initially the participant inputs their email and password and then goes into their inbox to get a link to login as a form of verification

Test to make sure that if email verification is not done, skipping to login is blocked i.e. study participant is navigated to [Rare Genomes Project](https://rgp.dev.datadonationplatform.org/email-verification-required)

[PEPPER-336]: https://broadworkbench.atlassian.net/browse/PEPPER-336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<img width="1130" alt="Screenshot 2023-04-25 at 2 27 18 PM" src="https://user-images.githubusercontent.com/35533885/234368530-c409088c-b5de-4680-8a08-5879878b4cfc.png">
