### PR TITLE
[Playwright] Fix flaky Osteo playwright test

### DIFF
--- a/playwright-e2e/pages/brain/brain-base-page.ts
+++ b/playwright-e2e/pages/brain/brain-base-page.ts
@@ -10,9 +10,4 @@ export abstract class BrainBasePage extends PageBase {
     }
     super(page, BRAIN_BASE_URL);
   }
-
-  async finish(): Promise<void> {
-    await this.page.waitForTimeout(1000);
-    await this.page.getByRole('button', { name: 'Finish' }).click();
-  }
 }

--- a/playwright-e2e/pages/page-base.ts
+++ b/playwright-e2e/pages/page-base.ts
@@ -152,10 +152,9 @@ export default abstract class PageBase implements PageInterface {
   }
 
   async finish(): Promise<void> {
-    await Promise.all([
-      waitForNoSpinner(this.page),
-      this.getFinishButton().click()
-    ]);
+    await waitForNoSpinner(this.page);
+    await this.getFinishButton().click();
+    await waitForNoSpinner(this.page);
   }
 
   /** Click "Next" button */

--- a/playwright-e2e/pages/page-base.ts
+++ b/playwright-e2e/pages/page-base.ts
@@ -70,6 +70,10 @@ export default abstract class PageBase implements PageInterface {
     return this.page.locator('.header button[data-ddp-test="signOutButton"]:has-text("Log Out")');
   }
 
+  getFinishButton(): Locator {
+    return this.page.getByRole('button', { name: 'Finish' });
+  }
+
   /**
    * Return "Next" button locator
    */
@@ -145,6 +149,13 @@ export default abstract class PageBase implements PageInterface {
    */
   async agreeToAllowUsToContactPhysicians(): Promise<void> {
     await new Checkbox(this.page, { label: 'I have already read and signed the informed consent document' }).check();
+  }
+
+  async finish(): Promise<void> {
+    await Promise.all([
+      waitForNoSpinner(this.page),
+      this.getFinishButton().click()
+    ]);
   }
 
   /** Click "Next" button */

--- a/playwright-e2e/tests/osteosarcoma/adult-enrollment.spec.ts
+++ b/playwright-e2e/tests/osteosarcoma/adult-enrollment.spec.ts
@@ -1,5 +1,6 @@
 import { expect, Page } from '@playwright/test';
 import { test } from 'fixtures/osteo-fixture';
+import TextArea from 'lib/widget/textarea';
 import ConsentAddendumPage from 'pages/osteo/consent-addendump-page';
 import GetStartedPage from 'pages/osteo/get-started-page';
 import SurveyAboutYou from 'pages/survey-about-you';
@@ -347,14 +348,20 @@ test('Osteo adult self enroll @osteo', async ({ page }) => {
   });
 
   await familyHistoryPage.next();
+
+  await new TextArea(page, { ddpTestID: 'answer:FH_OTHER_FACTORS_CANCER_RISK' }).toLocator().waitFor({
+    state: 'visible',
+    timeout: 60 * 1000
+  });
+
   await familyHistoryPage.finish();
 
-  await page
+  const viewCompletedButton = page
     .getByRole('row', {
       name: 'Survey: Family History of Cancer Thank you for telling us more about your family history of cancer.'
     })
-    .getByRole('button', { name: 'View Completed' })
-    .click();
+    .getByRole('button', { name: 'View Completed' });
+  await viewCompletedButton.click();
   await page.getByRole('link', { name: 'Dashboard' }).click();
 
 


### PR DESCRIPTION
CircleCI failed [run](https://app.circleci.com/pipelines/github/broadinstitute/ddp-angular/24356/workflows/09bb57e8-994a-4408-8a6b-41189831ff60/jobs/53024/tests).

```
adult-enrollment.spec.ts:25:5 Osteo adult self enroll @osteo
[chromium] › tests/osteosarcoma/adult-enrollment.spec.ts:25:5 › Osteo adult self enroll @osteo ───

    Error: Timed out 30000ms waiting for expect(received).toHaveValue(expected)

    Expected string: "Giant Cell Tumor of the Bone (GCT)"
    Received string: "bone"
    Call log:
      - expect.toHaveValue with timeout 30000ms
      - waiting for locator('.activity-text-input-OTHER_CANCER_NAME').locator('mat-form-field').locator('input').first()
 ```

Test failed because it run faster than application UI can complete rendering. Before clicking `Finish` button, we should wait until page has finished rendering. Fix test by adding few code for synch.

<img width="725" alt="Screenshot 2023-05-04 at 1 08 51 PM" src="https://user-images.githubusercontent.com/35533885/236276387-7aaaea09-a3ff-48d1-81be-065ed82165b3.png">
