### PR TITLE
DSM-PEPPER-909-hide-followup-survey-inputs-v2

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/survey/survey.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/survey/survey.component.html
@@ -35,7 +35,7 @@
 
     <br/>
 
-    <div *ngIf="survey != null" class="Width--100">
+    <div *ngIf="survey != null && !hideSurveyInputs" class="Width--100">
       <div>
         <table class="Width--100">
           <tr>
@@ -62,7 +62,7 @@
               [disabled]="disableButton()">Create Survey</button>
     </div>
 
-    <div class="Float--left Width--80">
+    <div class="Float--left Width--80" *ngIf="!hideSurveyInputs">
       <b>
         <br/>
         <br/>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/survey/survey.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/survey/survey.component.ts
@@ -24,6 +24,8 @@ export class SurveyComponent implements OnInit {
   @ViewChild(FieldFilepickerComponent)
   public filepicker: FieldFilepickerComponent;
 
+  public hideSurveyInputs = false;
+
   errorMessage: string;
   additionalMessage: string;
   loading = false;
@@ -131,7 +133,11 @@ export class SurveyComponent implements OnInit {
   }
 
   getListOfSurveyStatus(): void {
+    this.hideSurveyInputs = false;
     if (this.realm !== '' && (this.survey != null && this.survey.name !== '')) {
+      if(this.survey.name === 'SOMATIC_RESULTS') {
+        this.hideSurveyInputs = true;
+      }
       this.errorMessage = null;
       this.additionalMessage = null;
       this.loading = true;


### PR DESCRIPTION
[PEPPER-909](https://broadworkbench.atlassian.net/jira/software/projects/pepper/boards/164?assignee=621677042d057500723f90e4&selectedIssue=PEPPER-909)

After the **SOMATIC_RESULTS** is selected:
<img width="1127" alt="Screenshot 2023-06-21 at 15 28 26" src="https://github.com/broadinstitute/ddp-angular/assets/77500504/0b2a748d-9d47-4843-9bbb-bf553d981aaa">


[PEPPER-909]: https://broadworkbench.atlassian.net/browse/PEPPER-909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ