### PR TITLE
PEPPER-535 removed GA from studies that are actively recruiting

### DIFF
--- a/ddp-workspace/projects/ddp-angio/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-angio/src/app/app.module.ts
@@ -159,9 +159,6 @@ export function translateFactory(translate: TranslateService, injector: Injector
 })
 export class AppModule {
     constructor(private analytics: AnalyticsEventsService) {
-        this.analytics.analyticEvents.subscribe((event: AnalyticsEvent) => {
-            ga('send', event);
-            ga('platform.send', event);
-        });
+
     }
 }

--- a/ddp-workspace/projects/ddp-angio/src/index.html
+++ b/ddp-workspace/projects/ddp-angio/src/index.html
@@ -28,16 +28,6 @@
   <script src="assets/config/pepperConfig.js"></script>
   <app-root></app-root>
   <script>
-    (function (i, s, o, g, r, a, m) {
-      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-        (i[r].q = i[r].q || []).push(arguments)
-      }, i[r].l = 1 * new Date(); a = s.createElement(o),
-        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-    ga('create', DDP_ENV.projectGAToken, 'auto');
-    ga('create', DDP_ENV.platformGAToken, 'auto', 'platform');
-  </script>
-  <script>
     window.twttr = (function (d, s, id) {
       var js, fjs = d.getElementsByTagName(s)[0],
         t = window.twttr || {};

--- a/ddp-workspace/projects/ddp-atcp/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-atcp/src/app/app.module.ts
@@ -255,9 +255,6 @@ export function translateFactory(
 })
 export class AppModule {
   constructor(private analytics: AnalyticsEventsService) {
-    this.analytics.analyticEvents.subscribe((event: AnalyticsEvent) => {
-      ga('send', event);
-      ga('platform.send', event);
-    });
+
   }
 }

--- a/ddp-workspace/projects/ddp-atcp/src/index.html
+++ b/ddp-workspace/projects/ddp-atcp/src/index.html
@@ -15,15 +15,6 @@
   <link rel="stylesheet" media="screen" href="https://fonts.googleapis.com/css?family=McLaren">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="assets/config/pepperConfig.js"></script>
-  <script>
-    window.ga = window.ga || function () {
-      (ga.q = ga.q || []).push(arguments)
-    };
-    ga.l = +new Date;
-    ga('create', DDP_ENV.projectGAToken, 'auto');
-    ga('create', DDP_ENV.platformGAToken, 'auto', 'platform');
-  </script>
-  <script async src='https://www.google-analytics.com/analytics.js'></script>
 </head>
 
 <body onload="loadTcell()">

--- a/ddp-workspace/projects/ddp-brain/src/index.html
+++ b/ddp-workspace/projects/ddp-brain/src/index.html
@@ -26,16 +26,6 @@
 <body onload="loadTcell()">
   <script src="assets/config/pepperConfig.js"></script>
   <app-root></app-root>
-  <script>
-    (function (i, s, o, g, r, a, m) {
-      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-        (i[r].q = i[r].q || []).push(arguments)
-      }, i[r].l = 1 * new Date(); a = s.createElement(o),
-        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-    ga('create', DDP_ENV.projectGAToken, 'auto');
-    ga('create', DDP_ENV.platformGAToken, 'auto', 'platform');
-  </script>
 </body>
 
 </html>

--- a/ddp-workspace/projects/ddp-brugada/src/index.html
+++ b/ddp-workspace/projects/ddp-brugada/src/index.html
@@ -16,18 +16,6 @@
     <link href="https://fonts.googleapis.com/css2?family=PT+Sans:wght@400;700&display=swap" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
 
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-95RZ7RFCYH"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-
-      gtag('js', new Date());
-
-      gtag('config', 'G-95RZ7RFCYH');
-    </script>
     <script src="assets/config/pepperConfig.js"></script>
   </head>
 

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-list/participant-list.component.ts
@@ -936,7 +936,6 @@ export class ParticipantListComponent implements OnInit {
               this.selectedColumns[ key ] = [];
             });
             this.refillWithDefaultColumns();
-            this.sendAnalyticsMetric();
           },
           error: err => {
             if (err._body === Auth.AUTHENTICATION_ERROR) {
@@ -1090,7 +1089,6 @@ export class ParticipantListComponent implements OnInit {
             this.loadedTimeStamp = Utils.getDateFormatted(date, Utils.DATE_STRING_IN_EVENT_CVS);
           }
           this.loadingParticipants = null;
-          this.sendAnalyticsMetric();
         },
         error: err => {
           if (err._body === Auth.AUTHENTICATION_ERROR) {
@@ -2477,11 +2475,6 @@ export class ParticipantListComponent implements OnInit {
       this.allFieldNames.add(tmp + '.' + filter.participantColumn.name);
      });
      this.orderColumns();
-  }
-
-  private sendAnalyticsMetric(): void {
-    const passed = new Date().getTime() - this.start;
-    this.dsmService.sendAnalyticsMetric(this.getRealm(), passed).subscribe({});
   }
 
 

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dsm.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dsm.service.ts
@@ -51,16 +51,6 @@ export class DSMService {
     );
   }
 
-  sendAnalyticsMetric( realm: string, passed: number ): Observable<any> {
-    const url = this.baseUrl + DSMService.UI + 'googleAnalytics';
-    const map: { name: string; value: any }[] = [];
-    map.push( {name: DSMService.REALM, value: realm} );
-    map.push( {name: 'timer', value: passed} );
-    return this.http.patch(url, null, this.buildQueryHeader(map)).pipe(
-      catchError(this.handleError.bind(this))
-    );
-  }
-
   public transferScan(scanTracking: boolean, json: string): Observable<any> {
     let url = this.baseUrl + DSMService.UI;
     if (scanTracking) {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/index.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/index.html
@@ -1,15 +1,6 @@
 <!doctype html>
 <html>
 <head>
-  <script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-    ga('create', "UA-210316631-1", 'auto');
-    ga('send', 'pageview');
-  </script>
   <!-- End Google Analytics -->
   <meta charset="utf-8">
   <title>DDP Study Manager</title>
@@ -27,16 +18,6 @@
   <script src="https://cdn.auth0.com/js/lock/11.2.2/lock.min.js"></script>
 
   <script src="/assets/js/jsBarcode-337.js"></script>
-
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-210316631-1"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', DDP_ENV.gaTrackingId);
-  </script>
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="/assets/images/favicon.ico">

--- a/ddp-workspace/projects/ddp-esc/src/index.html
+++ b/ddp-workspace/projects/ddp-esc/src/index.html
@@ -28,16 +28,6 @@
   <script src="assets/config/pepperConfig.js"></script>
   <app-root></app-root>
   <script>
-    (function (i, s, o, g, r, a, m) {
-      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-        (i[r].q = i[r].q || []).push(arguments)
-      }, i[r].l = 1 * new Date(); a = s.createElement(o),
-        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-    ga('create', DDP_ENV.projectGAToken, 'auto');
-    ga('create', DDP_ENV.platformGAToken, 'auto', 'platform');
-  </script>
-  <script>
     window.twttr = (function (d, s, id) {
       var js, fjs = d.getElementsByTagName(s)[0],
         t = window.twttr || {};

--- a/ddp-workspace/projects/ddp-lms/src/index.html
+++ b/ddp-workspace/projects/ddp-lms/src/index.html
@@ -5,11 +5,11 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
-    
+
     <base href="/" />
 
     <title>Leiomyosarcoma Project</title>
-    
+
     <link rel="icon" type="image/x-icon" id="app-favicon" href="favicon.ico" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -20,34 +20,12 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
 
     <script src="assets/config/pepperConfig.js"></script>
-    
-    <script>
-      window.ga =
-      window.ga ||
-      function () {
-        (ga.q = ga.q || []).push(arguments);
-        };
-      ga.l = +new Date();
-      ga('create', DDP_ENV.projectGAToken, 'auto');
-      ga('create', DDP_ENV.platformGAToken, 'auto', 'platform');
-    </script>
-
-<script async src="https://www.google-analytics.com/analytics.js"></script>
-
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-KB65C93K2D"></script>
-
- <script> 
-    window.dataLayer = window.dataLayer || []; 
-    function gtag(){dataLayer.push(arguments);} 
-    gtag('js', new Date()); gtag('config', 'G-KB65C93K2D'); 
- </script>
-
   </head>
 
   <body onload="loadTcell()">
     <app-root></app-root>
   </body>
-  
+
   <script type="text/javascript">
     function loadTcell() {
       var tcellScript = document.createElement('script');

--- a/ddp-workspace/projects/ddp-mbc/src/index.html
+++ b/ddp-workspace/projects/ddp-mbc/src/index.html
@@ -28,16 +28,6 @@
   <script src="assets/config/pepperConfig.js"></script>
   <app-root></app-root>
   <script>
-    (function (i, s, o, g, r, a, m) {
-      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-        (i[r].q = i[r].q || []).push(arguments)
-      }, i[r].l = 1 * new Date(); a = s.createElement(o),
-        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-    ga('create', DDP_ENV.projectGAToken, 'auto');
-    ga('create', DDP_ENV.platformGAToken, 'auto', 'platform');
-  </script>
-  <script>
     window.twttr = (function (d, s, id) {
       var js, fjs = d.getElementsByTagName(s)[0],
         t = window.twttr || {};

--- a/ddp-workspace/projects/ddp-mpc/src/index.html
+++ b/ddp-workspace/projects/ddp-mpc/src/index.html
@@ -28,16 +28,6 @@
   <script src="assets/config/pepperConfig.js"></script>
   <app-root></app-root>
   <script>
-    (function (i, s, o, g, r, a, m) {
-      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-        (i[r].q = i[r].q || []).push(arguments)
-      }, i[r].l = 1 * new Date(); a = s.createElement(o),
-        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-    ga('create', DDP_ENV.projectGAToken, 'auto');
-    ga('create', DDP_ENV.platformGAToken, 'auto', 'platform');
-  </script>
-  <script>
     window.twttr = (function (d, s, id) {
       var js, fjs = d.getElementsByTagName(s)[0],
         t = window.twttr || {};

--- a/ddp-workspace/projects/ddp-osteo/src/index.html
+++ b/ddp-workspace/projects/ddp-osteo/src/index.html
@@ -12,22 +12,6 @@
     rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script src="assets/config/pepperConfig.js"></script>
-  <script>
-    window.ga = window.ga || function () {
-      (ga.q = ga.q || []).push(arguments)
-    };
-    ga.l = +new Date;
-    ga('create', DDP_ENV.projectGAToken, 'auto');
-    ga('create', DDP_ENV.platformGAToken, 'auto', 'platform');
-  </script>
-  <script async src='https://www.google-analytics.com/analytics.js'></script>
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-64885513-8"></script>
-  <script>
-   window.dataLayer = window.dataLayer || [];
-   function gtag(){dataLayer.push(arguments);}
-   gtag('js', new Date()); 
-   gtag('config', 'UA-64885513-8');
-  </script>
 </head>
 
 <body onload="loadTcell()">

--- a/ddp-workspace/projects/ddp-pancan/src/index.html
+++ b/ddp-workspace/projects/ddp-pancan/src/index.html
@@ -15,16 +15,6 @@
 
 <body onload="loadTcell()">
     <app-root></app-root>
-    <script>
-        (function (i, s, o, g, r, a, m) {
-            i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-                (i[r].q = i[r].q || []).push(arguments)
-            }, i[r].l = 1 * new Date(); a = s.createElement(o),
-                m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-        })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-        ga('create', DDP_ENV.projectGAToken, 'auto');
-        ga('create', DDP_ENV.platformGAToken, 'auto', 'platform');
-    </script>
 </body>
 
 <script type="text/javascript">

--- a/ddp-workspace/projects/ddp-prion/src/index.html
+++ b/ddp-workspace/projects/ddp-prion/src/index.html
@@ -40,14 +40,6 @@
 <body onload="loadTcell()">
   <script src="assets/config/pepperConfig.js"></script>
   <app-root></app-root>
-  <script>
-    (function (i, s, o, g, r, a, m) {
-      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-        (i[r].q = i[r].q || []).push(arguments)
-      }, i[r].l = 1 * new Date(); a = s.createElement(o),
-        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-  </script>
 </body>
 
 </html>

--- a/ddp-workspace/projects/ddp-rgp/src/index.html
+++ b/ddp-workspace/projects/ddp-rgp/src/index.html
@@ -29,16 +29,6 @@
 <body onload="loadTcell()">
   <script src="assets/config/pepperConfig.js"></script>
   <app-root></app-root>
-  <script>
-    (function (i, s, o, g, r, a, m) {
-      i['GoogleAnalyticsObject'] = r; i[r] = i[r] || function () {
-        (i[r].q = i[r].q || []).push(arguments)
-      }, i[r].l = 1 * new Date(); a = s.createElement(o),
-        m = s.getElementsByTagName(o)[0]; a.async = 1; a.src = g; m.parentNode.insertBefore(a, m)
-    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-    ga('create', DDP_ENV.projectGAToken, 'auto');
-    ga('create', DDP_ENV.platformGAToken, 'auto', 'platform');
-  </script>
 </body>
 
 </html>

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/analyticsEvents.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/analyticsEvents.service.ts
@@ -11,11 +11,13 @@ export class AnalyticsEventsService {
 
     private events = new Subject<GoogleAnalyticsEvent>();
 
+    /* we no longer use GA so this method is a no-op */
     public emitCustomEvent(
         eventCategory: string,
         eventAction: string,
         eventLabel: string | null = null,
         eventValue: string | null = null): void {
+        /*
         const event: AnalyticsEvent = {
             hitType: 'event',
             // set page directly in order to exclude sensitive query params
@@ -29,15 +31,21 @@ export class AnalyticsEventsService {
         };
         this.events.next(event);
         this.events.next(this.buildGTagEvent(eventCategory, eventAction));
+        */
     }
 
+    /* we no longer use GA so this method is a no-op */
     public emitCustomGtagEvent(eventName: string, clickText?: string, clickUrl?: string): void {
+        /*
         const newEvent = this.buildGTagEvent(eventName, clickText, clickUrl);
         this.events.next(newEvent);
         return;
+         */
     }
 
+    /* we no longer use GA so this method is a no-op */
     public emitNavigationEvent(): void {
+        /*
         const event: AnalyticsEvent = {
             hitType: 'pageview',
             // set page directly in order to exclude sensitive query params
@@ -48,6 +56,7 @@ export class AnalyticsEventsService {
         this.events.next(event);
         // this is a gtag "recommended event" https://developers.google.com/tag-platform/gtagjs/reference/events#page_view
         this.events.next(this.buildGTagEvent('page_view'));
+         */
     }
 
     public get analyticEvents(): Observable<AnalyticsEvent> {

--- a/ddp-workspace/projects/ddp-singular/src/app/app.module.ts
+++ b/ddp-workspace/projects/ddp-singular/src/app/app.module.ts
@@ -101,8 +101,5 @@ declare const gtag: (...args: any[]) => void;
 })
 export class AppModule {
     constructor(private analytics: AnalyticsEventsService) {
-        // https://developers.google.com/tag-platform/gtagjs/reference#event
-        this.analytics.gTagEventsExcludingPageViews
-            .subscribe(event => gtag('event', event.event_name, event.parameters));
     }
 }

--- a/ddp-workspace/projects/toolkit/src/lib/services/analyticsManagement.service.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/services/analyticsManagement.service.ts
@@ -12,11 +12,13 @@ export class AnalyticsManagementService {
   }
 
   public trackAnalytics(): void {
-    this.startGATracking();
+    // we are no longer tracking with GA
+    // this.startGATracking();
   }
 
   public doNotTrackAnalytics(): void {
-    this.doNotTrackGA();
+    // we are no longer tracking with GA
+    // this.doNotTrackGA();
   }
 
   private doNotTrackGA(): void {

--- a/ddp-workspace/projects/toolkit/src/lib/services/cookiesManagement.service.ts
+++ b/ddp-workspace/projects/toolkit/src/lib/services/cookiesManagement.service.ts
@@ -71,6 +71,8 @@ export class CookiesManagementService {
   private setDefaultConsent(): void {
     this.consent = { decision: false, status: 'default_reject', cookies: {} };
     this.cookiesTypes.forEach(x => this.consent.cookies[x] = null);
+    // analytical cookies are default opt-out
+    this.consent.cookies['Analytical'] = false;
     this.updateLocalStorageConsent();
   }
 


### PR DESCRIPTION
For more details about the approach here for PEPPER-535, [please see this doc](https://docs.google.com/document/d/101GrTw3dFgbukNO24pPSBEbLty92_1smGDqAkxXA7ZA).

Each study's index.html loads GA, so these files have had their GA calls removed.  This includes the DSM frontend and each DSS study.  Rather than update many files that make calls to our GA wrapper, I've gone with the approach of commenting out the guts of key methods in the toolkit so that client studies can still call the GA methods, but the methods themselves are no-ops.

Because prion has cookie management that other studies lack, the approach with prion required additional changes so that even if participants opt-in to analytic cookies, the site will still not send data to GA.  Prion's cookie model is now default opt-out instead of opt-in for analytical cookies, and opting in is a no-op that does not result in any metrics going to GA