### PR TITLE
[PEPPER-925] Update the access rules so that kids under 7 can have shared learnings.

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
@@ -1785,10 +1785,12 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
           const consentAddendumPediatric = this.participant.data.activities
             ?.find(({activityCode}) => activityCode === 'CONSENT_ADDENDUM_PEDIATRIC');
 
+          const consentAddendumPediatricStatus = consentAddendumPediatric?.status;
+
           const somaticConsentTumorPediatric = consentAddendumPediatric?.questionsAnswers
-            ?.find(({answer, stableId}) => stableId === 'SOMATIC_CONSENT_TUMOR_PEDIATRIC' && answer);
+            ?.find(({answer, stableId}) => stableId === 'SOMATIC_CONSENT_TUMOR_PEDIATRIC');
           const somaticAssentAddendum = consentAddendumPediatric?.questionsAnswers
-            ?.find(({answer, stableId}) => stableId === 'SOMATIC_ASSENT_ADDENDUM' && answer);
+            ?.find(({answer, stableId}) => stableId === 'SOMATIC_ASSENT_ADDENDUM');
 
           const consentAddendum = this.participant.data.activities
             ?.find(({activityCode}) => activityCode === 'CONSENT_ADDENDUM');
@@ -1806,7 +1808,9 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
 
           return mercuryAllow && studyAllow && hasConsentedToTissueSample &&
             (somaticConsentAddendumTumorAdult?.answer ||
-              (somaticConsentTumorPediatric?.answer && somaticAssentAddendum?.answer)
+              (somaticConsentTumorPediatric?.answer && somaticAssentAddendum?.answer) ||
+              (somaticConsentTumorPediatric?.answer && consentAddendumPediatricStatus === "COMPLETE"
+                && somaticAssentAddendum === undefined)
             );
         })
       );

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
@@ -1809,7 +1809,7 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
           return mercuryAllow && studyAllow && hasConsentedToTissueSample &&
             (somaticConsentAddendumTumorAdult?.answer ||
               (somaticConsentTumorPediatric?.answer && somaticAssentAddendum?.answer) ||
-              (somaticConsentTumorPediatric?.answer && consentAddendumPediatricStatus === "COMPLETE"
+              (somaticConsentTumorPediatric?.answer && consentAddendumPediatricStatus === 'COMPLETE'
                 && somaticAssentAddendum === undefined)
             );
         })


### PR DESCRIPTION
[PEPPER-925](https://broadworkbench.atlassian.net/browse/PEPPER-925) adds support for shared learnings tab being visible with participants under 7 who do not provide assent.

[PEPPER-925]: https://broadworkbench.atlassian.net/browse/PEPPER-925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ