### PR TITLE
[Playwright] Test docker set timezone to Eastern time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,7 @@ executors:
     working_directory: *playwright_path
     environment:
       NODE_ENV: development # Needed if playwright is in devDependencies
+      TZ: America/New_York
 
 commands:
   checkout-code:


### PR DESCRIPTION
If tests are run on CircleCI after 9 PM, couple tests will fail with following error due to the timezone difference.

```
lms-parental-consent-assent-enrollment.spec.ts:27:7 Consent & Assent @visual @enrollment @lms
[chromium] › tests/lms/lms-parental-consent-assent-enrollment.spec.ts:27:7 › LMS Child Enrollment › Consent & Assent @visual @enrollment @lms › Asserting contents on Additional Consent Form: Learning About Your Child's Tumor 

    Error: expect(received).toBe(expected) // Object.is equality

    Expected: "07/16/2023"
    Received: "07/15/2023"

      242 |       const uiDate = await additionalConsentPage.getDisplayedDate();
      243 |       const todayDate = getDate();
    > 244 |       expect(uiDate).toBe(todayDate);
          |                      ^
      245 |
      246 |       await additionalConsentPage.next();
      247 |

        at /home/circleci/repo/playwright-e2e/tests/lms/lms-parental-consent-assent-enrollment.spec.ts:244:22
        at /home/circleci/repo/playwright-e2e/tests/lms/lms-parental-consent-assent-enrollment.spec.ts:213:5

```