### PR TITLE
PEPPER-585-NPM-vulnarability-fix

### DIFF
--- a/ddp-workspace/package.json
+++ b/ddp-workspace/package.json
@@ -8,7 +8,11 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "convert-atcp-auth-build-to-UMD": "rollup --config projects/ddp-atcp/src/auth0/auth0-scripts/rollup.config.js"
+    "convert-atcp-auth-build-to-UMD": "rollup --config projects/ddp-atcp/src/auth0/auth0-scripts/rollup.config.js",
+    "preinstall": "npx npm-force-resolutions"
+  },
+  "resolutions": {
+      "ua-parser-js": "0.7.33"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
[PEPPER-585](https://broadworkbench.atlassian.net/browse/PEPPER-585)

I followed the instructions provided in the ticket. 
The `ua-parserp-js` library has been updated to the newer version (0.7.33)

[PEPPER-585]: https://broadworkbench.atlassian.net/browse/PEPPER-585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ