### PR TITLE
DSM-PEPPER-981-outline-on-mat-select

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/shipping-search/shipping-search.component.css
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/shipping-search/shipping-search.component.css
@@ -1,3 +1,8 @@
+mat-select {
+  border: 1px solid #1d59b7ab;
+  border-radius: 5px;
+  padding: 10px;
+}
 
 .highlight_sample {
   background-color: rgb(255,233,168, 0.6);

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/survey/survey.component.css
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/survey/survey.component.css
@@ -1,0 +1,5 @@
+mat-select {
+  border: 1px solid #1d59b7ab;
+  border-radius: 5px;
+  padding: 10px;
+}


### PR DESCRIPTION
[PEPPER-981](https://broadworkbench.atlassian.net/browse/PEPPER-981)

More visible outline around mat-select component:
<img width="713" alt="Screenshot 2023-07-24 at 11 59 51" src="https://github.com/broadinstitute/ddp-angular/assets/77500504/bedeba44-6275-4870-af30-9d973058a923">
<img width="744" alt="Screenshot 2023-07-24 at 11 59 58" src="https://github.com/broadinstitute/ddp-angular/assets/77500504/4f9ebae1-b964-44f7-90eb-820971182693">



[PEPPER-981]: https://broadworkbench.atlassian.net/browse/PEPPER-981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ