### PR TITLE
[DSM] Fix for Onc History patch for legacy participant

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/filter-column/filter-column.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/filter-column/filter-column.component.ts
@@ -16,7 +16,7 @@ export class FilterColumnComponent implements OnInit {
 
   // Hide a search parameter for the following RGP columns
   rgpHideSearchParamColumns = [
-    { displayName: "Specialty Project: R21", name: "r21", tableAlias: "r" }
+    { displayName: 'Specialty Project: R21', name: 'r21', tableAlias: 'r' }
   ];
 
   ngOnInit(): void {
@@ -99,11 +99,9 @@ export class FilterColumnComponent implements OnInit {
    * @returns Return true if dataFilter column is not found in hardcoded rgpHideSearchParamColumns array.
    */
   showSearchParameter(dataFilter: Filter): boolean {
-    const found = this.rgpHideSearchParamColumns.findIndex(column => {
-      return dataFilter?.participantColumn?.display === column.displayName 
+    const found = this.rgpHideSearchParamColumns.findIndex(column => dataFilter?.participantColumn?.display === column.displayName
         && dataFilter?.participantColumn?.name === column.name
-        && dataFilter?.participantColumn?.tableAlias === column.tableAlias
-    });
+        && dataFilter?.participantColumn?.tableAlias === column.tableAlias);
     return found === -1;
   }
 }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/onc-history-detail/onc-history-detail.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/onc-history-detail/onc-history-detail.component.ts
@@ -86,6 +86,10 @@ export class OncHistoryDetailComponent implements OnInit {
       }
     }
     if (v != null) {
+      let ddpParticipantId = this.participant.data.profile['guid'];
+      if (this.participant.data.profile['legacyAltPid']) {
+        ddpParticipantId = this.participant.data.profile['legacyAltPid'];
+      }
       const realm: string = sessionStorage.getItem(ComponentService.MENU_SELECTED_REALM);
       const patch1 = new PatchUtil(
         this.oncHistory[index].oncHistoryDetailId, this.role.userMail(),
@@ -93,7 +97,7 @@ export class OncHistoryDetailComponent implements OnInit {
           name: parameterName,
           value: v
         }, null, 'participantId', this.participant.participant.participantId,
-        Statics.ONCDETAIL_ALIAS, null, realm, this.participant.data.profile['guid']
+        Statics.ONCDETAIL_ALIAS, null, realm, ddpParticipantId
       );
       const patch = patch1.getPatch();
       this.patchFinished = false;


### PR DESCRIPTION
Making sure that for legacy particiapnts the legacy id is included in the patch instead of guid since this is how they are added in the ddp_particiapnt table.