### PR TITLE
[DSS] PEPPER-1014 Add more information to GCP stackdriver log

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/logging.service.spec.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/logging.service.spec.ts
@@ -71,12 +71,4 @@ describe('LoggingService', () => {
         expect(JSON.stringify(service.logWarning)).toEqual(JSON.stringify(() => { }));
         expect(service.logError).not.toEqual(() => { });
     });
-
-    it('should call StackdriverErrorReporterService.handleReport if logLevel is Error', () => {
-      config.logLevel = LogLevel.Error;
-      service = new LoggingService(config, stackdriverErrorReporterServiceSpy, httpClientSpy, sessionMock);
-
-      service.logError('a deliberate error during Logging service test');
-      expect(stackdriverErrorReporterServiceSpy.handleError).toHaveBeenCalledWith('a deliberate error during Logging service test');
-    });
 });

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/sessionMemento.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/sessionMemento.service.ts
@@ -183,7 +183,6 @@ export class SessionMementoService implements OnDestroy {
         if (session === null) {
             return false;
         }
-
         return new Date().getTime() > session.expiresAt;
     }
 

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/stackdriverErrorReporter.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/stackdriverErrorReporter.service.ts
@@ -30,11 +30,14 @@ export class StackdriverErrorReporterService extends ErrorHandler {
   }
 
   public handleError(error: Error | string): void {
-    if (this.config.doGcpErrorReporting) {
-      this.errorHandler.report(error);
-    }
-    // Pass the error to the original handleError otherwise it gets swallowed in the browser console
     super.handleError(error);
+    if (this.config.doGcpErrorReporting) {
+      try {
+        this.errorHandler.report(error);
+      } catch (e) {
+        console.error.apply(window.console, e);
+      }
+    }
   }
 
   private checkReportingParams(key: string, projectId: string): void {


### PR DESCRIPTION
[PEPPER-1014](https://broadworkbench.atlassian.net/browse/PEPPER-1014)

Cleaned up changes from PR [https://github.com/broadinstitute/ddp-angular/pull/2189](https://github.com/broadinstitute/ddp-angular/pull/2189) and it will be closed.

GCP logging is possible by:
- An experimental `stackdriver-errors-js` lib. `logError()` makes calls to this lib.
- Google `@google-cloud/logging` lib which is triggered by call to the Google cloud function `LoggingService`. `logToCloud()` makes calls this lib.

Cloud function [LoggingService](https://console.cloud.google.com/functions/details/us-central1/LoggingService?env=gen1&authuser=0&project=broad-ddp-dev&tab=source) on Dev.

Cloud function `LoggingService` log [filter](https://cloudlogging.app.goo.gl/rsrAE6LRQVhWq52HA) on Dev. 


[PEPPER-1014]: https://broadworkbench.atlassian.net/browse/PEPPER-1014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ