### PR TITLE
[PEPPER-1014] GCP Log more information

### DIFF
--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/logging.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/logging.service.ts
@@ -22,14 +22,9 @@ export class LoggingService {
 
     public logError: Logger = this.showEvent(LogLevel.Error) ?
         (...args) => {
-            const stringifiedArgs = args.map(arg => {
-                if (arg instanceof Error) {
-                    return arg.stack ? arg.stack : arg.message;
-                }
-                if (arg instanceof Object) {
-                    return this.stringify(arg);
-                }
-                return arg;
+            const stringifiedArgs = args.map((arg) => {
+                let str = (typeof arg === 'object') ? this.stringify(arg) : arg;
+                return str += arg instanceof Error ? `, ${arg.stack}` : '';
             });
             this.logToCloud(stringifiedArgs.join(',\n'), null, 'ERROR').pipe(take(1)).subscribe();
             console.error.apply(window.console, stringifiedArgs);
@@ -47,7 +42,8 @@ export class LoggingService {
     }
 
     private stringify(obj: object): string {
-        return Object.keys(obj).map(key => `${key}: ${obj[key]}`).join(', ');
+        return Object.keys(obj).map(key => (typeof obj[key] === 'object') ? `${key}: ${JSON.stringify(obj[key])}` : `${key}: ${obj[key]}`)
+            .join(', ');
     }
 
     public logToCloud(payload: string, labels?: {[key: string]: string}, severity = 'INFO'): Observable<void> {

--- a/ddp-workspace/projects/ddp-sdk/src/lib/services/logging.service.ts
+++ b/ddp-workspace/projects/ddp-sdk/src/lib/services/logging.service.ts
@@ -42,8 +42,10 @@ export class LoggingService {
     }
 
     private stringify(obj: object): string {
-        return Object.keys(obj).map(key => (typeof obj[key] === 'object') ? `${key}: ${JSON.stringify(obj[key])}` : `${key}: ${obj[key]}`)
-            .join(', ');
+        return Object.keys(obj).map(key => {
+            const value = obj[key];
+            return (typeof value === 'object') ? `${key}: ${JSON.stringify(value)}` : `${key}: ${value}`;
+        }).join(', ');
     }
 
     public logToCloud(payload: string, labels?: {[key: string]: string}, severity = 'INFO'): Observable<void> {


### PR DESCRIPTION
[PEPPER-1014](https://broadworkbench.atlassian.net/browse/PEPPER-1014)

Fix an issue with log where `error` object shows as `[object, object]`, found it in error from `/address/verify` call.

<img width="1299" alt="Screenshot 2023-08-25 at 5 11 50 PM" src="https://github.com/broadinstitute/ddp-angular/assets/35533885/5b1284cb-d89a-40ad-adea-4326a339578f">




[PEPPER-1014]: https://broadworkbench.atlassian.net/browse/PEPPER-1014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ