### PR TITLE
[Playwright] Exclude playwright-e2e files in project deploy check

### DIFF
--- a/build-utils/findmodifiedprojects.sh
+++ b/build-utils/findmodifiedprojects.sh
@@ -4,7 +4,7 @@
 # If a file from a common area, like the root diretory was modified, we call that _SHARED_
 set +x
 #ignore these file name patterns when figuring out what modules changed
-declare -a exclude_patterns=( '^.*\.md' '^.*.pdf', '^.*\.spec\.ts' )
+declare -a exclude_patterns=( '^.*\.md' '^.*.pdf', '^.*\.spec\.ts', 'playwright' )
 
 EXCLUDE_CMD='grep -v -E'
 


### PR DESCRIPTION
Studies should not be re-deployed when PR contains playwright-e2e files only.