### PR TITLE
CircleCI config update: nodejs install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -693,8 +693,18 @@ jobs:
       - run:
           name: "Update node.js and npm"
           command: |
-            curl -sSL "https://nodejs.org/dist/latest-v18.x//node-v18.18.0-linux-x64.tar.xz" | tar --strip-components=2 -xJ -C /usr/local/bin/ node-v18.18.0-linux-x64/bin/node
-            curl https://www.npmjs.com/install.sh | bash
+            set +e
+            wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.36.0/install.sh | bash
+            
+            export NVM_DIR="$HOME/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+
+            nvm install v18
+            nvm alias default 18.18.0
+
+            echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
+            echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
       - run:
           name: Check current version of node
           command: node -v

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -696,19 +696,19 @@ jobs:
       - run:
           working_directory: *playwright_path
           command: npm ci
-      #- run:
-      #    working_directory: *playwright_path
-      #    command: npx playwright install --with-deps chromium # Only need Chrome browser
+      - run:
+          working_directory: *playwright_path
+          command: npx playwright install --with-deps chromium # Only need Chrome browser
 
-      #- run:
-      #    name: Running Playwright tests on << parameters.env >>
-      #    working_directory: *playwright_path
-      #    command: |            
-      #      npx playwright test --list | grep -o 'tests/.*.spec.ts' | sort | uniq > e2e_tests.txt
-      #      TESTS_FILE=$(circleci tests split --split-by=timings --timings-type=classname e2e_tests.txt)
-      #      echo $TESTS_FILE
-      #      npm run test:ci $TESTS_FILE
-      #    no_output_timeout: 5m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
+      - run:
+          name: Running Playwright tests on << parameters.env >>
+          working_directory: *playwright_path
+          command: |            
+            npx playwright test --list | grep -o 'tests/.*.spec.ts' | sort | uniq > e2e_tests.txt
+            TESTS_FILE=$(circleci tests split --split-by=timings --timings-type=classname e2e_tests.txt)
+            echo $TESTS_FILE
+            npm run test:ci $TESTS_FILE
+          no_output_timeout: 5m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
       - store_test_results:
           path: playwright-e2e/junit
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -693,8 +693,8 @@ jobs:
       - run:
           name: "Update node.js and npm"
           command: |
-            curl -sSL "https://nodejs.org/dist/latest-v18.x//node-v18.18.0-linux-x64.tar.xz" | sudo tar --strip-components=2 -xJ -C /usr/local/bin/ node-v18.18.0-linux-x64/bin/node
-            curl https://www.npmjs.com/install.sh | sudo bash
+            curl -sSL "https://nodejs.org/dist/latest-v18.x//node-v18.18.0-linux-x64.tar.xz" | tar --strip-components=2 -xJ -C /usr/local/bin/ node-v18.18.0-linux-x64/bin/node
+            curl https://www.npmjs.com/install.sh | bash
       - run:
           name: Check current version of node
           command: node -v

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -691,21 +691,6 @@ jobs:
             cat playwright-env/envvars | awk '{print "export " $0}' >> "$BASH_ENV"
             source $BASH_ENV
       - run:
-          name: "Update node.js and npm"
-          command: |
-            set +e
-            wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.36.0/install.sh | bash
-            
-            export NVM_DIR="$HOME/.nvm"
-            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-            [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
-
-            nvm install v18
-            nvm alias default 18.18.0
-
-            echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
-            echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
-      - run:
           name: Check current version of node
           command: node -v
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -690,25 +690,30 @@ jobs:
             # export env from file (created in build-playwright-job)
             cat playwright-env/envvars | awk '{print "export " $0}' >> "$BASH_ENV"
             source $BASH_ENV
-      - node/install:
-          install-yarn: false
-          node-version: '18.13.0' # LTS version
+      - run:
+          name: "Update node.js and npm"
+          command: |
+            curl -sSL "https://nodejs.org/dist/latest-v18.x//node-v18.18.0-linux-x64.tar.xz" | sudo tar --strip-components=2 -xJ -C /usr/local/bin/ node-v18.18.0-linux-x64/bin/node
+            curl https://www.npmjs.com/install.sh | sudo bash
+      - run:
+          name: Check current version of node
+          command: node -v
       - run:
           working_directory: *playwright_path
-          command: npm install --quiet
-      - run:
-          working_directory: *playwright_path
-          command: npx playwright install --with-deps chromium # Only need Chrome browser
+          command: npm ci
+      #- run:
+      #    working_directory: *playwright_path
+      #    command: npx playwright install --with-deps chromium # Only need Chrome browser
 
-      - run:
-          name: Running Playwright tests on << parameters.env >>
-          working_directory: *playwright_path
-          command: |            
-            npx playwright test --list | grep -o 'tests/.*.spec.ts' | sort | uniq > e2e_tests.txt
-            TESTS_FILE=$(circleci tests split --split-by=timings --timings-type=classname e2e_tests.txt)
-            echo $TESTS_FILE
-            npm run test:ci $TESTS_FILE
-          no_output_timeout: 5m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
+      #- run:
+      #    name: Running Playwright tests on << parameters.env >>
+      #    working_directory: *playwright_path
+      #    command: |            
+      #      npx playwright test --list | grep -o 'tests/.*.spec.ts' | sort | uniq > e2e_tests.txt
+      #      TESTS_FILE=$(circleci tests split --split-by=timings --timings-type=classname e2e_tests.txt)
+      #      echo $TESTS_FILE
+      #      npm run test:ci $TESTS_FILE
+      #    no_output_timeout: 5m # Default is 10m. Set shorter time to ensure CI fails faster if test hangs
       - store_test_results:
           path: playwright-e2e/junit
       - store_artifacts:


### PR DESCRIPTION
Don't install custom nodejs version on CircleCI because downloading keeps failing lately. Instead, uses the default version which is provided by CircleCI VM.

Currently, default nodejs vesion is 
<img width="739" alt="Screenshot 2023-09-25 at 2 53 51 PM" src="https://github.com/broadinstitute/ddp-angular/assets/35533885/29004ca3-0686-418b-b255-55da583012c3">
