### PR TITLE
Playwright_PEPPER-1201_Fix sequencing permission test by checking for lowercase email

### DIFF
--- a/playwright-e2e/dsm/pages/miscellaneous-pages/user-and-permissions-page.ts
+++ b/playwright-e2e/dsm/pages/miscellaneous-pages/user-and-permissions-page.ts
@@ -76,7 +76,7 @@ export default class UserPermissionPage {
 
     //Verify the email is as expected
     const studyAdminEmail = await studyAdmin.innerText();
-    expect(studyAdminEmail).toBe(email);
+    expect(studyAdminEmail).toBe(studyAdminEmail.toLowerCase());
 
     //Verify the name is as expected
     const studyAdminName = await this.getStudyAdminName(name);

--- a/playwright-e2e/dsm/pages/miscellaneous-pages/user-and-permissions-page.ts
+++ b/playwright-e2e/dsm/pages/miscellaneous-pages/user-and-permissions-page.ts
@@ -76,7 +76,7 @@ export default class UserPermissionPage {
 
     //Verify the email is as expected
     const studyAdminEmail = await studyAdmin.innerText();
-    expect(studyAdminEmail).toBe(studyAdminEmail.toLowerCase());
+    expect(studyAdminEmail).toBe(email.toLowerCase());
 
     //Verify the name is as expected
     const studyAdminName = await this.getStudyAdminName(name);

--- a/playwright-e2e/dsm/pages/miscellaneous-pages/user-and-permissions-page.ts
+++ b/playwright-e2e/dsm/pages/miscellaneous-pages/user-and-permissions-page.ts
@@ -76,7 +76,7 @@ export default class UserPermissionPage {
 
     //Verify the email is as expected
     const studyAdminEmail = await studyAdmin.innerText();
-    expect(studyAdminEmail).toBe(email.toLowerCase());
+    expect(studyAdminEmail.toLowerCase()).toBe(email.toLowerCase());
 
     //Verify the name is as expected
     const studyAdminName = await this.getStudyAdminName(name);


### PR DESCRIPTION
Fixes the test so that it passes in dev where the email in User & Permissions page gets turned to lowercase soon after being added to the page
Related ticket: https://broadworkbench.atlassian.net/browse/PEPPER-1201 