### PR TITLE
Playwright_Pepper 902_Test to check the sending sample recevied event to dss

### DIFF
--- a/playwright-e2e/dsm/component/filters/sections/customize-view.ts
+++ b/playwright-e2e/dsm/component/filters/sections/customize-view.ts
@@ -28,6 +28,17 @@ export class CustomizeView {
     await this.closeColumnsGroup();
   }
 
+  public async selectColumnsByID(columnsGroupName: string, columns: string[], id: string, opts: { nth?: number } = {}): Promise<void> {
+    const { nth } = opts;
+    this.activeColumnsGroup = columnsGroupName;
+    await this.openColumnsGroup({nth});
+    for (const column of columns) {
+      const columnOption = this.page.locator(`//ul[@id='${id}']//mat-checkbox[contains(.,'${column}')]`);
+      await columnOption.click();
+    }
+    await this.closeColumnsGroup();
+  }
+
   public async deselectColumns(columnsGroupName: string, columns: string[], opts: { nth?: number } = {}): Promise<void> {
     const { nth } = opts;
     this.activeColumnsGroup = columnsGroupName;
@@ -110,6 +121,6 @@ export class CustomizeView {
   }
 
   private columnCheckbox(columnName: string): Checkbox {
-    return new Checkbox(this.page, { root: this.columnsGroupXPath, label: columnName, exactMatch: true })
+    return new Checkbox(this.page, { root: this.columnsGroupXPath, label: columnName, exactMatch: true });
   }
 }

--- a/playwright-e2e/dsm/pages/kitsInfo-pages/kitsReceived-page/kitsReceivedPage.ts
+++ b/playwright-e2e/dsm/pages/kitsInfo-pages/kitsReceived-page/kitsReceivedPage.ts
@@ -46,11 +46,14 @@ export default class KitsReceivedPage {
     await waitForNoSpinner(this.page);
   }
 
-  public async kitReceivedRequest(kitLabel: string): Promise<void> {
+  public async kitReceivedRequest(opts: { mfCode: string, isTumorSample?: boolean,
+    accessionNumber?: string,
+    tumorCollaboratorSampleID?: string }): Promise<void> {
+    const { mfCode = '', isTumorSample = false, accessionNumber = null, tumorCollaboratorSampleID = null } = opts;
     if (!BSP_TOKEN) {
       throw Error('Invalid parameter: DSM BSP token is not provided.');
     }
-    const response = await this.request.get(`${DSM_BASE_URL}/ddp/ClinicalKits/${kitLabel}`, {
+    const response = await this.request.get(`${DSM_BASE_URL}/ddp/ClinicalKits/${mfCode}`, {
       headers: {
         Authorization: `Bearer ${BSP_TOKEN}`
       }
@@ -62,7 +65,15 @@ export default class KitsReceivedPage {
       throw new Error(`Couldn't send the kit received request - something went wrong\n${error}`)
     }
     expect(response.ok()).toBeTruthy();
-    expect(jsonResponse).toHaveProperty('kit_label', kitLabel);
+
+    if (!isTumorSample) {
+      expect(jsonResponse).toHaveProperty('kit_label', mfCode); //only kits get this
+    }
+
+    if (isTumorSample && accessionNumber != null && tumorCollaboratorSampleID != null) {
+      expect(jsonResponse).toHaveProperty('accession_number', accessionNumber);
+      expect(jsonResponse).toHaveProperty('sample_id', tumorCollaboratorSampleID);
+    }
   }
 
   public async kitReceivedRequestForRGPKits(kitLabel: string, subjectID: string): Promise<void> {

--- a/playwright-e2e/dsm/pages/tissue/tissue-information-page.ts
+++ b/playwright-e2e/dsm/pages/tissue/tissue-information-page.ts
@@ -175,7 +175,6 @@ export default class TissueInformationPage {
       isDisabled = await selectElement.isSelectDisabled();
       expect(isDisabled).toBe(false); //Test goes too fast, it still thinks dropdown is disabled after inputting Tissue Received Date
    }).toPass({ intervals: [10_000], timeout: 30_000 });
-   console.log(`isDisabled: ${isDisabled}`);
 
     if (!isDisabled && selectedValue?.trim() !== gender) {
       await selectElement.selectOption(gender);

--- a/playwright-e2e/dsm/pages/tissue/tissue-information-page.ts
+++ b/playwright-e2e/dsm/pages/tissue/tissue-information-page.ts
@@ -170,7 +170,12 @@ export default class TissueInformationPage {
 
     const selectElement = new Select(this.page, { root: genderLocator });
     const selectedValue = await selectElement.currentValue();
-    const isDisabled = await selectElement.isSelectDisabled();
+    let isDisabled;
+    await expect(async () => {
+      isDisabled = await selectElement.isSelectDisabled();
+      expect(isDisabled).toBe(false); //Test goes too fast, it still thinks dropdown is disabled after inputting Tissue Received Date
+   }).toPass({ intervals: [10_000], timeout: 30_000 });
+   console.log(`isDisabled: ${isDisabled}`);
 
     if (!isDisabled && selectedValue?.trim() !== gender) {
       await selectElement.selectOption(gender);

--- a/playwright-e2e/tests/dsm/kitUploadFlow/blood-kit-upload-flow.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/blood-kit-upload-flow.spec.ts
@@ -162,7 +162,7 @@ test.describe.serial('Blood Kits upload flow', () => {
 
       // kits received page
       const kitsReceivedPage = await navigation.selectFromSamples<KitsReceivedPage>(SamplesNavEnum.RECEIVED);
-      await kitsReceivedPage.kitReceivedRequest(kitLabel);
+      await kitsReceivedPage.kitReceivedRequest({mfCode: kitLabel});
       await kitsReceivedPage.waitForLoad();
       await kitsReceivedPage.selectKitType(kitType);
       await kitsReceivedPage.assertPageTitle();

--- a/playwright-e2e/tests/dsm/kitUploadFlow/saliva-kit-upload-flow.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/saliva-kit-upload-flow.spec.ts
@@ -154,7 +154,7 @@ test.describe.serial('Saliva Kits upload flow', () => {
 
       // kits received page
       const kitsReceivedPage = await navigation.selectFromSamples<KitsReceivedPage>(SamplesNavEnum.RECEIVED);
-      await kitsReceivedPage.kitReceivedRequest(kitLabel);
+      await kitsReceivedPage.kitReceivedRequest({mfCode: kitLabel});
       await kitsReceivedPage.waitForLoad();
       await kitsReceivedPage.selectKitType(kitType);
       await kitsReceivedPage.assertPageTitle();

--- a/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
+++ b/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
@@ -143,13 +143,14 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
       await expect(async () => {
         await searchPanel.search();
         const participantListTable = participantListPage.participantListTable;
-        const germlineInfo = (await participantListTable.getParticipantDataAt(0, 'GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created')).trim();
-        console.log(`Germline Info: ${germlineInfo}`);
-        expect(germlineInfo).toBeTruthy();
-      }).toPass({
-        intervals: [10_000],
-        timeout: 30_000
-      });
+        const amountOfParticipants = await participantListTable.rowsCount;
+        expect(amountOfParticipants).toBe(1);
+      }).toPass({intervals: [10_000], timeout: 30_000});
+
+      const participantListTable = participantListPage.participantListTable;
+      const germlineInfo = (await participantListTable.getParticipantDataAt(0, 'GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created')).trim();
+      console.log(`Germline Info: ${germlineInfo}`);
+      expect(germlineInfo).toBeTruthy();
     });
 
     test(`${study} - Scenario 2: BLOOD kit received first, TUMOR sample received second`, async ({ page, request }, testInfo) => {
@@ -243,18 +244,17 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
       await searchPanel.open();
       await searchPanel.text('Short ID', { textValue: shortID });
       await searchPanel.dates('GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created', { additionalFilters: [AdditionalFilter.NOT_EMPTY] });
-      let participantListTable;
-      let germlineInfo;
 
       //Occasionally, it will take a couple of seconds (and participant list refreshes) before info about the germline consent activity being created shows up
       await expect(async () => {
         await searchPanel.search();
-        participantListTable = participantListPage.participantListTable;
+        const participantListTable = participantListPage.participantListTable;
         const amountOfParticipants = await participantListTable.rowsCount;
-        germlineInfo = (await participantListTable.getParticipantDataAt(0, 'GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created')).trim();
         expect(amountOfParticipants).toBe(1);
       }).toPass({intervals: [10_000], timeout: 30_000});
 
+      const participantListTable = participantListPage.participantListTable;
+      const germlineInfo = (await participantListTable.getParticipantDataAt(0, 'GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created')).trim();
       console.log(`Germline Info: ${germlineInfo}`);
       expect(germlineInfo).toBeTruthy();
     });
@@ -350,17 +350,19 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
       await searchPanel.open();
       await searchPanel.text('Short ID', { textValue: shortID });
       await searchPanel.dates('GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created', { additionalFilters: [AdditionalFilter.NOT_EMPTY] });
-      await searchPanel.search();
+
+      //Occasionally, it will take a couple of seconds (and participant list refreshes) before info about the germline consent activity being created shows up
+      await expect(async () => {
+        await searchPanel.search();
+        const participantListTable = participantListPage.participantListTable;
+        const amountOfParticipants = await participantListTable.rowsCount;
+        expect(amountOfParticipants).toBe(1);
+      }).toPass({intervals: [10_000], timeout: 30_000});
 
       const participantListTable = participantListPage.participantListTable;
       const germlineInfo = (await participantListTable.getParticipantDataAt(0, 'GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created')).trim();
-
-      await expect(() => {
-        expect(germlineInfo).toBeTruthy();
-      }).toPass({
-        intervals: [5_000],
-        timeout: 30_000
-      });
+      console.log(`Germline Info: ${germlineInfo}`);
+      expect(germlineInfo).toBeTruthy();
     });
 
     test(`${study} - Scenario 4: TUMOR sample received first, BLOOD kit received second`, async ({ page, request }, testInfo) => {
@@ -454,17 +456,20 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
       await searchPanel.open();
       await searchPanel.text('Short ID', { textValue: shortID });
       await searchPanel.dates('GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created', { additionalFilters: [AdditionalFilter.NOT_EMPTY] });
-      await searchPanel.search();
+
+
+      //Occasionally, it will take a couple of seconds (and participant list refreshes) before info about the germline consent activity being created shows up
+      await expect(async () => {
+        await searchPanel.search();
+        const participantListTable = participantListPage.participantListTable;
+        const amountOfParticipants = await participantListTable.rowsCount;
+        expect(amountOfParticipants).toBe(1);
+      }).toPass({intervals: [10_000], timeout: 30_000});
 
       const participantListTable = participantListPage.participantListTable;
       const germlineInfo = (await participantListTable.getParticipantDataAt(0, 'GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created')).trim();
-
-      await expect(() => {
-        expect(germlineInfo).toBeTruthy();
-      }).toPass({
-        intervals: [5_000],
-        timeout: 30_000
-      });
+      console.log(`Germline Info: ${germlineInfo}`);
+      expect(germlineInfo).toBeTruthy();
     });
   }
 });

--- a/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
+++ b/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
@@ -48,6 +48,7 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
 
   for (const study of studies) {
     test(`${study} - Scenario 1: SALIVA kit received first, TUMOR sample received second`, async ({ page, request }, testInfo) => {
+      test.slow();
       navigation = new Navigation(page, request);
       await new Select(page, { label: 'Select study' }).selectOption(`${study}`);
 
@@ -145,6 +146,7 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
     });
 
     test(`${study} - Scenario 2: BLOOD kit received first, TUMOR sample received second`, async ({ page, request }, testInfo) => {
+      test.slow();
       navigation = new Navigation(page, request);
       await new Select(page, { label: 'Select study' }).selectOption(`${study}`);
 
@@ -242,6 +244,7 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
     });
 
     test(`${study} - Scenario 3: TUMOR sample received first, SALIVA kit received second`, async ({ page, request }, testInfo) => {
+      test.slow();
       navigation = new Navigation(page, request);
       await new Select(page, { label: 'Select study' }).selectOption(`${study}`);
 
@@ -339,6 +342,7 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
     });
 
     test(`${study} - Scenario 4: TUMOR sample received first, BLOOD kit received second`, async ({ page, request }, testInfo) => {
+      test.slow();
       navigation = new Navigation(page, request);
       await new Select(page, { label: 'Select study' }).selectOption(`${study}`);
 

--- a/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
+++ b/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
@@ -1,70 +1,201 @@
+import { APIRequestContext, Page, TestInfo, expect } from '@playwright/test';
+import { AdditionalFilter } from 'dsm/component/filters/sections/search/search-enums';
+import { KitTypeEnum } from 'dsm/component/kitType/enums/kitType-enum';
+import { SamplesNavEnum } from 'dsm/component/navigation/enums/samplesNav-enum';
 import { StudyEnum } from 'dsm/component/navigation/enums/selectStudyNav-enum';
 import { StudyNavEnum } from 'dsm/component/navigation/enums/studyNav-enum';
 import { Navigation } from 'dsm/component/navigation/navigation';
+import KitsWithoutLabelPage from 'dsm/pages/kitsInfo-pages/kitsWithoutLabel-page';
 import ParticipantListPage from 'dsm/pages/participant-list-page';
 import Select from 'dss/component/select';
 import { test } from 'fixtures/dsm-fixture';
-import { logInfo } from 'utils/log-utils';
+import * as user from 'data/fake-user.json';
+import { KitUploadInfo } from 'dsm/pages/kitUpload-page/models/kitUpload-model';
+import KitUploadPage from 'dsm/pages/kitUpload-page/kitUpload-page';
+import { KitsColumnsEnum } from 'dsm/pages/kitsInfo-pages/enums/kitsColumns-enum';
 
 test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
   const studies = [StudyEnum.OSTEO2, StudyEnum.LMS]; //Only clinical (pecgs) studies get this event
   let navigation;
-  let participantListPage;
-  let customizeViewPanel;
+  let shortID = '';
+  let mfCode = '';
 
   for (const study of studies) {
-    /**
-     * TODO Use an adult study participant after PEPPER-1210 is fixed
-     * Find an E2E playwright participant who meets the following criteria:
-     * Answered 'Yes' in consent
-     * Answered 'Yes' in consent addendum
-     * Submitted medical release with at least one physician or institution
-     * Does not already have a germline consent addendum
-     * Does not already have a normal kit (i.e. a blood or saliva kit) sent out (for ease of testing)
-     */
-    test.beforeEach(async ({ page, request }) => {
+    test(`${study} - Scenario 1: SALIVA kit received first, TUMOR sample received second`, async ({ page, request }, testInfo) => {
       navigation = new Navigation(page, request);
       await new Select(page, { label: 'Select study' }).selectOption(`${study}`);
 
-      participantListPage = await navigation.selectFromStudy<ParticipantListPage>(StudyNavEnum.PARTICIPANT_LIST);
+      const participantListPage = await navigation.selectFromStudy<ParticipantListPage>(StudyNavEnum.PARTICIPANT_LIST);
       await participantListPage.assertPageTitle();
       await participantListPage.waitForReady();
 
-      customizeViewPanel = participantListPage.filters.customizeViewPanel;
-      await customizeViewPanel.open();
-      await customizeViewPanel.selectColumns('Research Consent & Assent Form Columns', ['CONSENT_ASSENT_BLOOD', 'CONSENT_ASSENT_TISSUE']);
-      await customizeViewPanel.selectColumns('Medical Release Form Columns', ['PHYSICIAN']);
-      await customizeViewPanel.selectColumns('Sample Columns', ['Sample Type', 'Status']);
-      await customizeViewPanel.selectColumns(
-        `Additional Consent & Assent: Learning About Your Child’s Tumor Columns`,
-        ['SOMATIC_CONSENT_TUMOR_PEDIATRIC', 'SOMATIC_ASSENT_ADDENDUM']
-      );
-      await customizeViewPanel.selectColumns(
-        `Additional Consent & Assent: Learning More About Your Child's DNA with Invitae Columns`,
-        ['GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created']
-      );
-
-      const searchPanel = participantListPage.filters.searchPanel;
+      shortID = await findParticipantForGermlineConsentCreation(participantListPage);
+      console.log(`Chosen short id: ${shortID}`);
+      mfCode = await prepareSentKit(shortID, KitTypeEnum.SALIVA, study, page, request, testInfo);
     });
 
-    test(`${study} - Scenario 1: SALIVA kit received first, TUMOR sample received second`, ({ page, request }) => {
-      //stuff here
-      logInfo('stuff');
+    test(`${study} - Scenario 2: BLOOD kit received first, TUMOR sample received second`, async ({ page, request }) => {
+      navigation = new Navigation(page, request);
+      await new Select(page, { label: 'Select study' }).selectOption(`${study}`);
+
+      const participantListPage = await navigation.selectFromStudy<ParticipantListPage>(StudyNavEnum.PARTICIPANT_LIST);
+      await participantListPage.assertPageTitle();
+      await participantListPage.waitForReady();
+
+      shortID = await findParticipantForGermlineConsentCreation(participantListPage);
     });
 
-    test(`${study} - Scenario 2: BLOOD kit received first, TUMOR sample received second`, ({ page, request }) => {
-      //stuff here
-      logInfo('stuff');
+    test(`${study} - Scenario 3: TUMOR sample received first, SALIVA kit received second`, async ({ page, request }) => {
+      navigation = new Navigation(page, request);
+      await new Select(page, { label: 'Select study' }).selectOption(`${study}`);
+
+      const participantListPage = await navigation.selectFromStudy<ParticipantListPage>(StudyNavEnum.PARTICIPANT_LIST);
+      await participantListPage.assertPageTitle();
+      await participantListPage.waitForReady();
+
+      shortID = await findParticipantForGermlineConsentCreation(participantListPage);
     });
 
-    test(`${study} - Scenario 3: TUMOR sample received first, SALIVA kit received second`, ({ page, request }) => {
-      //Stuff here
-      logInfo('stuff');
-    });
+    test(`${study} - Scenario 4: TUMOR sample received first, BLOOD kit received second`, async ({ page, request }) => {
+      navigation = new Navigation(page, request);
+      await new Select(page, { label: 'Select study' }).selectOption(`${study}`);
 
-    test(`${study} - Scenario 4: TUMOR sample received first, BLOOD kit received second`, ({ page, request }) => {
-      //Stuff here
-      logInfo('stuff');
+      const participantListPage = await navigation.selectFromStudy<ParticipantListPage>(StudyNavEnum.PARTICIPANT_LIST);
+      await participantListPage.assertPageTitle();
+      await participantListPage.waitForReady();
+
+      shortID = await findParticipantForGermlineConsentCreation(participantListPage);
     });
   }
 });
+
+/**
+ * TODO Use an adult study participant after PEPPER-1210 is fixed
+ * Find an E2E playwright participant who meets the following criteria:
+ * Answered 'Yes' in consent
+ * Answered 'Yes' in consent addendum
+ * Submitted medical release with at least one physician or institution
+ * Does not already have a germline consent addendum
+ * Does not already have a normal kit (i.e. a blood or saliva kit) sent out (for ease of testing)
+ */
+async function findParticipantForGermlineConsentCreation(participantListPage: ParticipantListPage): Promise<string> {
+  const searchPanel = participantListPage.filters.searchPanel;
+  await searchPanel.open();
+  await searchPanel.checkboxes('Status', { checkboxValues: ['Enrolled'] });
+  await searchPanel.search();
+
+  const customizeViewPanel = participantListPage.filters.customizeViewPanel;
+  await customizeViewPanel.open();
+  await customizeViewPanel.selectColumns('Research Consent & Assent Form Columns', ['CONSENT_ASSENT_BLOOD', 'CONSENT_ASSENT_TISSUE']);
+  await customizeViewPanel.selectColumnsByID('Medical Release Form Columns', ['PHYSICIAN'], 'RELEASE_MINOR', { nth: 1 });
+  await customizeViewPanel.selectColumns('Sample Columns', ['Sample Type', 'Status']);
+  await customizeViewPanel.selectColumns(
+    `Additional Consent & Assent: Learning About Your Child’s Tumor Columns`,
+    ['SOMATIC_CONSENT_TUMOR_PEDIATRIC', 'SOMATIC_ASSENT_ADDENDUM']
+  );
+  await customizeViewPanel.selectColumns(
+    `Additional Consent & Assent: Learning More About Your Child's DNA with Invitae Columns`,
+    ['GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created']
+  );
+
+  await searchPanel.open();
+  await searchPanel.checkboxes('CONSENT_ASSENT_BLOOD', { checkboxValues: ['Yes'] });
+  await searchPanel.checkboxes('CONSENT_ASSENT_TISSUE', { checkboxValues: ['Yes'] });
+  await searchPanel.search();
+
+  const participantListTable = participantListPage.participantListTable;
+  const resultsPerPage = await participantListTable.rowsCount;
+  let shortID = '';
+  for (let index = 0; index < resultsPerPage; index++) {
+    const consentAssentTissue = (await participantListTable.getParticipantDataAt(index, 'CONSENT_ASSENT_TISSUE')).trim();
+    const consentAssentBlood = (await participantListTable.getParticipantDataAt(index, 'CONSENT_ASSENT_BLOOD')).trim();
+    const somaticAssentAddendum = (await participantListTable.getParticipantDataAt(index, 'SOMATIC_ASSENT_ADDENDUM')).trim();
+    const somaticConsentTumorPediatric = (await participantListTable.getParticipantDataAt(index, 'SOMATIC_CONSENT_TUMOR_PEDIATRIC')).trim();
+    const physician = (await participantListTable.getParticipantDataAt(index, 'PHYSICIAN')).trim();
+    const germlineInfo = (await participantListTable.getParticipantDataAt(index, 'GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created')).trim();
+
+    if ((consentAssentTissue === 'Yes') &&
+        (consentAssentBlood === 'Yes') &&
+        (somaticAssentAddendum === 'Yes') &&
+        (somaticConsentTumorPediatric === 'Yes') &&
+        (physician != null) &&
+        (germlineInfo === '')
+      ) {
+        shortID = await participantListTable.getParticipantDataAt(index, 'Short ID');
+        break;
+    }
+
+    if (index === (resultsPerPage - 1)) {
+      index = 0;
+      await participantListTable.nextPage();
+    }
+
+    //TODO add logic for if there are no more pages to use to search for participants
+  }
+
+  return shortID;
+}
+
+async function prepareSentKit(shortID: string,
+  kitType: KitTypeEnum,
+  study: StudyEnum,
+  page: Page,
+  request: APIRequestContext,
+  testInfo: TestInfo): Promise<string> {
+  const navigation = new Navigation(page, request);
+  const expectedKitTypes = [KitTypeEnum.SALIVA, KitTypeEnum.BLOOD]; //Studies used for the current test only have Saliva and Blood kits
+  const testResultDirectory = testInfo.outputDir;
+  let mfCode = '';
+
+  //Deactivate existing kits
+  const kitsWithoutLabelPage = await navigation.selectFromSamples<KitsWithoutLabelPage>(SamplesNavEnum.KITS_WITHOUT_LABELS);
+  await kitsWithoutLabelPage.waitForReady();
+  await kitsWithoutLabelPage.assertPageTitle();
+  await kitsWithoutLabelPage.selectKitType(kitType);
+  if (await kitsWithoutLabelPage.hasExistingKitRequests()) {
+    await kitsWithoutLabelPage.assertCreateLabelsBtn();
+    await kitsWithoutLabelPage.assertReloadKitListBtn();
+    await kitsWithoutLabelPage.assertTableHeader();
+    await kitsWithoutLabelPage.deactivateAllKitsFor(shortID);
+  }
+
+  //Upload saliva kit
+  const kitUploadInfo = new KitUploadInfo(shortID, user.patient.firstName, user.patient.lastName);
+  kitUploadInfo.address.street1 = user.patient.streetAddress;
+  kitUploadInfo.address.city = user.patient.city;
+  kitUploadInfo.address.postalCode = user.patient.zip;
+  kitUploadInfo.address.state = user.patient.state.abbreviation;
+  kitUploadInfo.address.country = user.patient.country.abbreviation;
+
+  const kitUploadPage = await navigation.selectFromSamples<KitUploadPage>(SamplesNavEnum.KIT_UPLOAD);
+  await kitUploadPage.waitForReady(expectedKitTypes);
+  await kitUploadPage.assertPageTitle();
+  await kitUploadPage.selectKitType(kitType);
+  await kitUploadPage.assertBrowseBtn();
+  await kitUploadPage.assertUploadKitsBtn();
+  await kitUploadPage.uploadFile(kitType, [kitUploadInfo], study, testResultDirectory);
+
+  //Check for kit in Kits w.o Label and get the shipping ID
+  await navigation.selectFromSamples<KitsWithoutLabelPage>(SamplesNavEnum.KITS_WITHOUT_LABELS);
+  await kitsWithoutLabelPage.waitForReady();
+  await kitsWithoutLabelPage.selectKitType(kitType);
+  await kitsWithoutLabelPage.assertCreateLabelsBtn();
+  await kitsWithoutLabelPage.assertReloadKitListBtn();
+  await kitsWithoutLabelPage.assertPageTitle();
+
+  await kitsWithoutLabelPage.search(KitsColumnsEnum.SHORT_ID, shortID);
+  const shippingID = (await kitsWithoutLabelPage.getData(KitsColumnsEnum.SHIPPING_ID)).trim();
+
+  const kitsTable = kitsWithoutLabelPage.kitsWithoutLabelTable;
+  await kitsTable.searchByColumn(KitsColumnsEnum.SHORT_ID, shortID);
+  await expect(kitsTable.rowLocator()).toHaveCount(1);
+
+  //Scan saliva kit in Initial Scan
+
+  //If uploading a blood kit - make sure to also scan the kit in Tracking Scan page
+
+  //Scan saliva kit in Final Scan - which marks the kit as sent
+
+  //Return the mf code so that the kit can later be marked as received
+  return mfCode;
+}

--- a/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
+++ b/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
@@ -1,0 +1,63 @@
+import { StudyEnum } from 'dsm/component/navigation/enums/selectStudyNav-enum';
+import { StudyNavEnum } from 'dsm/component/navigation/enums/studyNav-enum';
+import { Navigation } from 'dsm/component/navigation/navigation';
+import ParticipantListPage from 'dsm/pages/participant-list-page';
+import Select from 'dss/component/select';
+import { test } from 'fixtures/dsm-fixture';
+
+test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
+  const studies = [StudyEnum.OSTEO2, StudyEnum.LMS]; //Only clinical (pecgs) studies get this event
+  let navigation;
+  let participantListPage;
+  let customizeViewPanel;
+
+  for (const study of studies) {
+    /**
+     * TODO Use an adult study participant after PEPPER-1210 is fixed
+     * Find an E2E playwright participant who meets the following criteria:
+     * Answered 'Yes' in consent
+     * Answered 'Yes' in consent addendum
+     * Submitted medical release with at least one physician or institution
+     * Does not already have a germline consent addendum
+     * Does not already have a normal kit (i.e. a blood or saliva kit) sent out (for ease of testing)
+     */
+    test.beforeEach(async ({ page, request }) => {
+      navigation = new Navigation(page, request);
+      await new Select(page, { label: 'Select study' }).selectOption(`${study}`);
+
+      participantListPage = await navigation.selectFromStudy<ParticipantListPage>(StudyNavEnum.PARTICIPANT_LIST);
+      await participantListPage.assertPageTitle();
+      await participantListPage.waitForReady();
+
+      customizeViewPanel = participantListPage.filters.customizeViewPanel;
+      await customizeViewPanel.open();
+      await customizeViewPanel.selectColumns('Research Consent & Assent Form Columns', ['CONSENT_ASSENT_BLOOD', 'CONSENT_ASSENT_TISSUE']);
+      await customizeViewPanel.selectColumns('Medical Release Form Columns', ['PHYSICIAN']);
+      await customizeViewPanel.selectColumns('Sample Columns', ['Sample Type', 'Status']);
+      await customizeViewPanel.selectColumns(
+        `Additional Consent & Assent: Learning About Your Child’s Tumor Columns`,
+        ['SOMATIC_CONSENT_TUMOR_PEDIATRIC', 'SOMATIC_ASSENT_ADDENDUM']
+      );
+      await customizeViewPanel.selectColumns(
+        'Additional Consent: Learning More About Your DNA with Invitae Columns',
+        ['GERMLINE_CONSENT_ADDENDUM Survey Created']
+      );
+    });
+
+    test(`${study} - Scenario 1: SALIVA kit received first, TUMOR sample received second`, async ({ page, request }) => {
+      //stuff here
+    });
+
+    test(`${study} - Scenario 2: BLOOD kit received first, TUMOR sample received second`, async ({ page, request }) => {
+      //stuff here
+    });
+
+    test(`${study} - Scenario 3: TUMOR sample received first, SALIVA kit received second`, async ({ page, request }) => {
+      //Stuff here
+    });
+
+    test(`${study} - Scenario 4: TUMOR sample received first, BLOOD kit received second`, async ({ page, request }) => {
+      //Stuff here
+    });
+  }
+});

--- a/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
+++ b/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
@@ -1,5 +1,4 @@
 import { APIRequestContext, Page, TestInfo, expect } from '@playwright/test';
-import { AdditionalFilter } from 'dsm/component/filters/sections/search/search-enums';
 import { KitTypeEnum } from 'dsm/component/kitType/enums/kitType-enum';
 import { SamplesNavEnum } from 'dsm/component/navigation/enums/samplesNav-enum';
 import { StudyEnum } from 'dsm/component/navigation/enums/selectStudyNav-enum';
@@ -18,12 +17,21 @@ import TrackingScanPage from 'dsm/pages/scanner-pages/trackingScan-page';
 import FinalScanPage from 'dsm/pages/scanner-pages/finalScan-page';
 import { getDate } from 'utils/date-utils';
 import KitsSentPage from 'dsm/pages/kitsInfo-pages/kitsSentPage';
+import ParticipantPage from 'dsm/pages/participant-page/participant-page';
+import OncHistoryTab from 'dsm/component/tabs/onc-history-tab';
+import { TabEnum } from 'dsm/component/tabs/enums/tab-enum';
 
 test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
   const studies = [StudyEnum.OSTEO2, StudyEnum.LMS]; //Only clinical (pecgs) studies get this event
   let navigation;
   let shortID = '';
   let mfCode = '';
+  let participantListTable;
+  let participantPage: ParticipantPage;
+  let searchPanel;
+  let oncHistoryTab;
+  let oncHistoryTable;
+  let smID = '';
 
   for (const study of studies) {
     test(`${study} - Scenario 1: SALIVA kit received first, TUMOR sample received second`, async ({ page, request }, testInfo) => {
@@ -34,9 +42,34 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
       await participantListPage.assertPageTitle();
       await participantListPage.waitForReady();
 
+      //Prep the Saliva kit
       shortID = await findParticipantForGermlineConsentCreation(participantListPage);
       console.log(`Chosen short id: ${shortID}`);
       mfCode = await prepareSentKit(shortID, KitTypeEnum.SALIVA, study, page, request, testInfo);
+
+      //Get the Participant Page of the chosen test participant
+      searchPanel = participantListPage.filters.searchPanel;
+      await searchPanel.open();
+      await searchPanel.clear();
+      await searchPanel.text('Short ID', { textValue: shortID });
+      await searchPanel.search();
+
+      participantListTable = participantListPage.participantListTable;
+      participantPage = await participantListTable.openParticipantPageAt(0);
+
+      //Input Onc History
+      const oncHistoryTab = await participantPage.clickTab<OncHistoryTab>(TabEnum.ONC_HISTORY);
+      const oncHistoryTable = oncHistoryTab.table;
+
+      //Navigate to the Onc History -> Tissue Request Page
+
+      //Create a tumor sample
+
+      //Receive the saliva kit
+
+      //Accession the tumor sample (just receive the sample using the SM-ID)
+
+      //Confirm that the germline consent addendum was created
     });
 
     test(`${study} - Scenario 2: BLOOD kit received first, TUMOR sample received second`, async ({ page, request }) => {

--- a/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
+++ b/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
@@ -25,7 +25,7 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
   const studies = [StudyEnum.OSTEO2, StudyEnum.LMS]; //Only clinical (pecgs) studies get this event
   let navigation;
   let shortID = '';
-  let mfCode = '';
+  let kitLabel = '';
   let participantListTable;
   let participantPage: ParticipantPage;
   let searchPanel;
@@ -45,7 +45,7 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
       //Prep the Saliva kit
       shortID = await findParticipantForGermlineConsentCreation(participantListPage);
       console.log(`Chosen short id: ${shortID}`);
-      mfCode = await prepareSentKit(shortID, KitTypeEnum.SALIVA, study, page, request, testInfo);
+      kitLabel = await prepareSentKit(shortID, KitTypeEnum.SALIVA, study, page, request, testInfo);
 
       //Get the Participant Page of the chosen test participant
       searchPanel = participantListPage.filters.searchPanel;
@@ -57,13 +57,29 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
       participantListTable = participantListPage.participantListTable;
       participantPage = await participantListTable.openParticipantPageAt(0);
 
-      //Input Onc History
+      /**
+       * Input Onc History - the following need to be inputted before accessioning a SM-ID / tumor sample:
+       * Date of PX (required)
+       * An Accession Number (required)
+       * Facility Name (Optional)
+       * Facilty Phone Number (Optional)
+       * Facility Fax Number (Optional)
+       */
       const oncHistoryTab = await participantPage.clickTab<OncHistoryTab>(TabEnum.ONC_HISTORY);
       const oncHistoryTable = oncHistoryTab.table;
 
-      //Navigate to the Onc History -> Tissue Request Page
+      //Mark Onc History as 'Request' status and navigate to the Onc History -> Tissue Request Page
 
-      //Create a tumor sample
+      /**
+       * Create Tumor Sample - the following need to be inputted in Tissue Request page before accessioning a SM-ID / tumor sample:
+       * Fax Sent Date (Automatically filled out when clicking Download Request Documents)
+       * Tissue Received Date
+       * Gender
+       * Materials Received amount (either USS [unstained slides] or Scrolls type)
+       * SM-IDs (either USS [unstained slides] or Scrolls)
+       * Tumor Collaborator Sample ID
+       * Date Sent to GP
+       */
 
       //Receive the saliva kit
 

--- a/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
+++ b/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
@@ -470,6 +470,7 @@ async function findParticipantForGermlineConsentCreation(participantListPage: Pa
   const lastnamePrefix = getPlaywrightParticipantLastNamePrefix(study);
 
   await searchPanel.open();
+  await searchPanel.text('Last Name', { textValue: lastnamePrefix, additionalFilters: [AdditionalFilter.EXACT_MATCH], exactMatch: false });
   await searchPanel.checkboxes('CONSENT_ASSENT_BLOOD', { checkboxValues: ['Yes'] });
   await searchPanel.checkboxes('CONSENT_ASSENT_TISSUE', { checkboxValues: ['Yes'] });
   await searchPanel.search();
@@ -517,7 +518,7 @@ function getPlaywrightParticipantLastNamePrefix(study: StudyEnum): string {
       prefix = 'testLastName';
       break;
     case StudyEnum.OSTEO2:
-      prefix = 'OS';
+      prefix = 'KidLast';
       break;
     case StudyEnum.ANGIO:
     case StudyEnum.AT:

--- a/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
+++ b/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
@@ -4,6 +4,7 @@ import { Navigation } from 'dsm/component/navigation/navigation';
 import ParticipantListPage from 'dsm/pages/participant-list-page';
 import Select from 'dss/component/select';
 import { test } from 'fixtures/dsm-fixture';
+import { logInfo } from 'utils/log-utils';
 
 test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
   const studies = [StudyEnum.OSTEO2, StudyEnum.LMS]; //Only clinical (pecgs) studies get this event
@@ -39,25 +40,31 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
         ['SOMATIC_CONSENT_TUMOR_PEDIATRIC', 'SOMATIC_ASSENT_ADDENDUM']
       );
       await customizeViewPanel.selectColumns(
-        'Additional Consent: Learning More About Your DNA with Invitae Columns',
-        ['GERMLINE_CONSENT_ADDENDUM Survey Created']
+        `Additional Consent & Assent: Learning More About Your Child's DNA with Invitae Columns`,
+        ['GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created']
       );
+
+      const searchPanel = participantListPage.filters.searchPanel;
     });
 
-    test(`${study} - Scenario 1: SALIVA kit received first, TUMOR sample received second`, async ({ page, request }) => {
+    test(`${study} - Scenario 1: SALIVA kit received first, TUMOR sample received second`, ({ page, request }) => {
       //stuff here
+      logInfo('stuff');
     });
 
-    test(`${study} - Scenario 2: BLOOD kit received first, TUMOR sample received second`, async ({ page, request }) => {
+    test(`${study} - Scenario 2: BLOOD kit received first, TUMOR sample received second`, ({ page, request }) => {
       //stuff here
+      logInfo('stuff');
     });
 
-    test(`${study} - Scenario 3: TUMOR sample received first, SALIVA kit received second`, async ({ page, request }) => {
+    test(`${study} - Scenario 3: TUMOR sample received first, SALIVA kit received second`, ({ page, request }) => {
       //Stuff here
+      logInfo('stuff');
     });
 
-    test(`${study} - Scenario 4: TUMOR sample received first, BLOOD kit received second`, async ({ page, request }) => {
+    test(`${study} - Scenario 4: TUMOR sample received first, BLOOD kit received second`, ({ page, request }) => {
       //Stuff here
+      logInfo('stuff');
     });
   }
 });

--- a/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
+++ b/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
@@ -144,9 +144,10 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
         await searchPanel.search();
         const participantListTable = participantListPage.participantListTable;
         const germlineInfo = (await participantListTable.getParticipantDataAt(0, 'GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created')).trim();
+        console.log(`Germline Info: ${germlineInfo}`);
         expect(germlineInfo).toBeTruthy();
       }).toPass({
-        intervals: [5_000],
+        intervals: [10_000],
         timeout: 30_000
       });
     });
@@ -466,7 +467,7 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
 });
 
 /**
- * TODO Use an adult study participant after PEPPER-1210 is fixed
+ * TODO Use an adult study participant after PEPPER-1210 is fixed - currently uses pediatric participants since search works better for them
  * Find an E2E playwright participant who meets the following criteria:
  * Answered 'Yes' in consent
  * Answered 'Yes' in consent addendum

--- a/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
+++ b/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
@@ -141,6 +141,17 @@ async function findParticipantForGermlineConsentCreation(participantListPage: Pa
   return shortID;
 }
 
+/**
+ * Uploads and sends the given type of kit e.g. Saliva kit or Blood kit - method is used in order to not repeat
+ * similar steps for 4 test scenarios
+ * @param shortID the short id of the participant who is having a kit uploaded
+ * @param kitType the kit type of the upload
+ * @param study the study for which the kit is uploaded
+ * @param page
+ * @param request
+ * @param testInfo
+ * @returns the mf code a.k.a the kit label to be used to later mark the kit as sent
+ */
 async function prepareSentKit(shortID: string,
   kitType: KitTypeEnum,
   study: StudyEnum,

--- a/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
+++ b/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
@@ -35,11 +35,8 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
   let navigation;
   let shortID = '';
   let kitLabel = '';
-  let participantListTable;
   let participantPage: ParticipantPage;
-  let searchPanel;
   let oncHistoryTab;
-  let oncHistoryTable;
   let today;
   let randomAccessionNumber = '';
   let smID = '';
@@ -149,7 +146,6 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
 
       const participantListTable = participantListPage.participantListTable;
       const germlineInfo = (await participantListTable.getParticipantDataAt(0, 'GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created')).trim();
-      console.log(`Germline Info: ${germlineInfo}`);
       expect(germlineInfo).toBeTruthy();
     });
 
@@ -255,7 +251,6 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
 
       const participantListTable = participantListPage.participantListTable;
       const germlineInfo = (await participantListTable.getParticipantDataAt(0, 'GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created')).trim();
-      console.log(`Germline Info: ${germlineInfo}`);
       expect(germlineInfo).toBeTruthy();
     });
 
@@ -361,7 +356,6 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
 
       const participantListTable = participantListPage.participantListTable;
       const germlineInfo = (await participantListTable.getParticipantDataAt(0, 'GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created')).trim();
-      console.log(`Germline Info: ${germlineInfo}`);
       expect(germlineInfo).toBeTruthy();
     });
 
@@ -468,7 +462,6 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
 
       const participantListTable = participantListPage.participantListTable;
       const germlineInfo = (await participantListTable.getParticipantDataAt(0, 'GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created')).trim();
-      console.log(`Germline Info: ${germlineInfo}`);
       expect(germlineInfo).toBeTruthy();
     });
   }

--- a/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
+++ b/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
@@ -138,11 +138,17 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
       await searchPanel.open();
       await searchPanel.text('Short ID', { textValue: shortID });
       await searchPanel.dates('GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created', { additionalFilters: [AdditionalFilter.NOT_EMPTY] });
-      await searchPanel.search();
 
-      const participantListTable = participantListPage.participantListTable;
-      const germlineInfo = (await participantListTable.getParticipantDataAt(0, 'GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created')).trim();
-      expect(germlineInfo).toBeTruthy();
+      //Occasionally, it will take a couple of seconds (and participant list refreshes) before info about the germline consent activity being created shows up
+      await expect(async () => {
+        await searchPanel.search();
+        const participantListTable = participantListPage.participantListTable;
+        const germlineInfo = (await participantListTable.getParticipantDataAt(0, 'GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created')).trim();
+        expect(germlineInfo).toBeTruthy();
+      }).toPass({
+        intervals: [5_000],
+        timeout: 30_000
+      });
     });
 
     test(`${study} - Scenario 2: BLOOD kit received first, TUMOR sample received second`, async ({ page, request }, testInfo) => {
@@ -240,7 +246,13 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
 
       const participantListTable = participantListPage.participantListTable;
       const germlineInfo = (await participantListTable.getParticipantDataAt(0, 'GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created')).trim();
-      expect(germlineInfo).toBeTruthy();
+
+      await expect(() => {
+        expect(germlineInfo).toBeTruthy();
+      }).toPass({
+        intervals: [5_000],
+        timeout: 30_000
+      });
     });
 
     test(`${study} - Scenario 3: TUMOR sample received first, SALIVA kit received second`, async ({ page, request }, testInfo) => {
@@ -338,7 +350,13 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
 
       const participantListTable = participantListPage.participantListTable;
       const germlineInfo = (await participantListTable.getParticipantDataAt(0, 'GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created')).trim();
-      expect(germlineInfo).toBeTruthy();
+
+      await expect(() => {
+        expect(germlineInfo).toBeTruthy();
+      }).toPass({
+        intervals: [5_000],
+        timeout: 30_000
+      });
     });
 
     test(`${study} - Scenario 4: TUMOR sample received first, BLOOD kit received second`, async ({ page, request }, testInfo) => {
@@ -436,7 +454,13 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
 
       const participantListTable = participantListPage.participantListTable;
       const germlineInfo = (await participantListTable.getParticipantDataAt(0, 'GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created')).trim();
-      expect(germlineInfo).toBeTruthy();
+
+      await expect(() => {
+        expect(germlineInfo).toBeTruthy();
+      }).toPass({
+        intervals: [5_000],
+        timeout: 30_000
+      });
     });
   }
 });


### PR DESCRIPTION
Relevant ticket: [https://broadworkbench.atlassian.net/browse/PEPPER-902](url)

Playwright test to check that the SAMPLE_RECEIVED event occurs regardless of normal kits (saliva or blood kits) being received first, with tumor samples second - will also check it the other way around (tumor samples received first, normal kits second)