### PR TITLE
[DSM] PEPPER-1221 frontend sm id delete fix

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/tissue/tissue.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/tissue/tissue.component.html
@@ -1,9 +1,9 @@
 <!--information added by assigneeMr-->
 <div class="Display--block" *ngIf="!tissue.deleted" [ngClass]="{'Green-background': tissue.tissueId === tissueId}">
   <table class="Width--100" style="border: 1px solid black;">
-    <tr *ngIf="this.tissue.errorMessage">
+    <tr *ngIf="tissue.errorMessage">
       <td colspan="6" align="left" class="TD--Padding">
-        <p class="delete-error">{{this.tissue.errorMessage}}</p>
+        <p class="delete-error">{{tissue.errorMessage}}</p>
       </td>
     </tr>
     <tr>

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/tissue/tissue.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/tissue/tissue.component.ts
@@ -170,7 +170,7 @@ export class TissueComponent {
           this.tissue.errorMessage = null;
           this.patchFinished = true;
           this.currentPatchField = null;
-          if (parameterName === 'deleted') {
+          if (parameterName === 'deleted' && tAlias ===  Statics.TISSUE_ALIAS) {
             this.tissue.deleted = true;
           }
           if ( data && this.tissue.tissueId == null ) {


### PR DESCRIPTION
Sometimes when deleting a sm id the tissue disappears as well, it is not deleted from the backend and a refresh retrieves the tissue back and the sm id was also deleted appropriately, so this is just a fix to stop removing the tissue 