### PR TITLE
[DSM] [Playwright] Fix kit request failure

### DIFF
--- a/playwright-e2e/dsm/pages/kitsInfo-pages/kitsWithoutLabel-page.ts
+++ b/playwright-e2e/dsm/pages/kitsInfo-pages/kitsWithoutLabel-page.ts
@@ -69,14 +69,14 @@ export default class KitsWithoutLabelPage {
       await expect(async () => {
         await this.reloadKitList();
         await expect(pendingKit).not.toBeVisible();
-      }).toPass({ timeout: 90 * 1000 });
+      }).toPass({ timeout: 5 * 60 * 1000 });
     }
   }
 
   public async reloadKitList(): Promise<void> {
     const reloadKitListButton = this.page.locator(this.reloadKitListBtnXPath);
     await reloadKitListButton.click();
-    await waitForNoSpinner(this.page);
+    await waitForNoSpinner(this.page, { timeout: 2 * 60 * 1000 });
   }
 
   public async search(columnName: KitsColumnsEnum, value: string): Promise<void> {

--- a/playwright-e2e/playwright.config.ts
+++ b/playwright-e2e/playwright.config.ts
@@ -44,7 +44,7 @@ const testConfig: PlaywrightTestConfig = {
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!CI,
   retries: CI ? 1 : 0,
-  workers: CI ? 1 : 3,
+  workers: CI ? 2 : 3,
   maxFailures: 0,
 
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */


### PR DESCRIPTION
```
    Error: response.text: Protocol error (Network.getResponseBody): Request content was evicted from inspector cache

       at dsm/pages/kitUpload-page/kitUpload-page.ts:71

      69 |   private async handleKitUploadResponse(): Promise<void> {
      70 |     const response = await this.waitForKitUploadResponse();
    > 71 |     const responseBody: KitUploadResponse = JSON.parse(await response.text());
         |                                                                       ^
      72 |
      73 |     for (const [key, value] of Object.entries(responseBody)) {
      74 |       if (value instanceof Array && value.length) {

        at KitUploadPage.handleKitUploadResponse (/home/circleci/repo/playwright-e2e/dsm/pages/kitUpload-page/kitUpload-page.ts:71:71)
        at KitUploadPage.uploadFile (/home/circleci/repo/playwright-e2e/dsm/pages/kitUpload-page/kitUpload-page.ts:46:5)
        at /home/circleci/repo/playwright-e2e/tests/dsm/kitUploadFlow/blood-and-rna-kit-upload-flow.spec.ts:106:5`
```

Error caused by empty response body if upload was not completed in some cases. To complete the upload process in some cases, user must first handle displayed modal window.

