### PR TITLE
[Playwright] New tests for kits deactivation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -718,7 +718,7 @@ jobs:
             echo ${TESTS_FILE}
             
             npm run test:ci ${TESTS_FILE}
-          no_output_timeout: 5m
+          no_output_timeout: 10m
       - store_test_results:
           path: playwright-e2e/junit
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -924,7 +924,7 @@ workflows:
           <<: *filter-develop-branch
           env: dev
           test_suite: UNKNOWN
-          parallelism_num: 2
+          parallelism_num: 1
           requires:
             - playwright-build
             - app-deploy

--- a/playwright-e2e/dsm/component/cohort-tag.ts
+++ b/playwright-e2e/dsm/component/cohort-tag.ts
@@ -5,23 +5,24 @@ export default class CohortTag {
   constructor(private readonly page: Page) {}
 
   public async add(tagName: string, waitForResponse = true): Promise<void> {
+    const waitPromise = waitForResponse ? this.waitForOKResponse('createCohortTag') : Promise.resolve();
     await this.inputField.fill(tagName);
     await this.inputField.blur();
-    waitForResponse && (await this.waitForOKResponse('createCohortTag'));
+    await waitPromise;
   }
 
   public async remove(tagName: string): Promise<void> {
-    await Promise.all([
-      this.waitForOKResponse('deleteCohortTag'),
-      this.getRemoveButtonFor(tagName).click(),
-      this.assertCohortTagToHaveCount(tagName, 0),
-    ]);
+    const waitPromise = this.waitForOKResponse('deleteCohortTag');
+    await this.getRemoveButtonFor(tagName).click();
+    await waitPromise;
+    await this.assertCohortTagToHaveCount(tagName, 0);
   }
 
   public async submitAndExit(): Promise<void> {
     const submitButton = this.page.locator(this.getSubmitButtonXPath);
-    !(await submitButton.isDisabled()) && (await submitButton.click());
-    await this.waitForOKResponse('bulkCreateCohortTags');
+    const waitPromise = this.waitForOKResponse('bulkCreateCohortTags');
+    await submitButton.click();
+    await waitPromise;
     await this.page.keyboard.press('Escape');
   }
 

--- a/playwright-e2e/dsm/component/kitType/kitType.ts
+++ b/playwright-e2e/dsm/component/kitType/kitType.ts
@@ -15,7 +15,7 @@ export class KitType {
   }
 
   /* XPaths */
-  private kitTypeCheckbox(kitType: KitTypeEnum): Checkbox {
+  public kitTypeCheckbox(kitType: KitTypeEnum): Checkbox {
     return new Checkbox(this.page, { label: kitType, root: 'app-root' });
   }
 }

--- a/playwright-e2e/dsm/component/kitType/kitType.ts
+++ b/playwright-e2e/dsm/component/kitType/kitType.ts
@@ -1,20 +1,21 @@
 import {Locator, Page} from '@playwright/test';
 import {KitTypeEnum} from 'dsm/component/kitType/enums/kitType-enum';
+import Checkbox from 'dss/component/checkbox';
 
 export class KitType {
   constructor(private readonly page: Page) {}
 
   public async selectKitType(kitType: KitTypeEnum): Promise<void> {
-    await this.page.locator(this.kitTypeCheckbox(kitType)).click();
+    await this.kitTypeCheckbox(kitType).check();
   }
 
   /* Locators */
   public displayedKitType(kitType: KitTypeEnum): Locator {
-    return this.page.locator(this.kitTypeCheckbox(kitType));
+    return this.kitTypeCheckbox(kitType).toLocator();
   }
 
   /* XPaths */
-  private kitTypeCheckbox(kitType: KitTypeEnum): string {
-    return `//mat-checkbox[.//label/span[text()[normalize-space()='${kitType}']]]`;
+  private kitTypeCheckbox(kitType: KitTypeEnum): Checkbox {
+    return new Checkbox(this.page, { label: kitType, root: 'app-root' });
   }
 }

--- a/playwright-e2e/dsm/component/tables/onc-history-table.ts
+++ b/playwright-e2e/dsm/component/tables/onc-history-table.ts
@@ -251,7 +251,7 @@ export default class OncHistoryTable extends Table {
     return this.page.locator('app-onc-history-detail').locator('app-modal').locator('.modal-content');
   }
 
-  private deleteRowButton(index = 0): Locator {
+  private deleteRowButton(index: number): Locator {
     return this.row(index).locator('td').last().getByRole('button');
   }
 

--- a/playwright-e2e/dsm/pages/kits-page-base.ts
+++ b/playwright-e2e/dsm/pages/kits-page-base.ts
@@ -39,14 +39,20 @@ export default abstract class KitsPageBase extends DsmPageBase {
     await waitForNoSpinner(this.page);
   }
 
-  public async selectKitType(kitType: KitTypeEnum): Promise<void> {
+  public async reloadKit(kitType: KitTypeEnum): Promise<void> {
+    await this.page.reload();
+    await this.waitForReady();
+    await this.selectKitType(kitType);
+  }
+
+  public async selectKitType(kitType: KitTypeEnum): Promise<boolean> {
     await waitForNoSpinner(this.page);
     await Promise.all([
       waitForResponse(this.page, { uri: 'ui/kitRequests' }),
       this.kitType.selectKitType(kitType)
     ]);
     await waitForNoSpinner(this.page);
-    await this.hasKitRequests();
+    return await this.hasKitRequests();
   }
 
   public async deactivateKitFor(opts: { shortId?: string, shippingId?: string } = {}): Promise<string> {
@@ -133,9 +139,6 @@ export default abstract class KitsPageBase extends DsmPageBase {
     // Most studies have Blood and Saliva kits; RGP has Blood and 'Blood & RNA' kits; Pancan has Blood, Saliva, and Stool kits
     let kitTypes;
     switch (studyName) {
-      case StudyEnum.LMS:
-        kitTypes = [KitTypeEnum.SALIVA, KitTypeEnum.BLOOD];
-        break;
       case StudyEnum.RGP:
         kitTypes = [KitTypeEnum.BLOOD, KitTypeEnum.BLOOD_AND_RNA];
         break;
@@ -143,14 +146,16 @@ export default abstract class KitsPageBase extends DsmPageBase {
         kitTypes = [KitTypeEnum.BLOOD, KitTypeEnum.SALIVA, KitTypeEnum.STOOL];
         break;
       default:
-        kitTypes = [KitTypeEnum.BLOOD, KitTypeEnum.SALIVA];
+        kitTypes = [KitTypeEnum.SALIVA, KitTypeEnum.BLOOD];
         break;
     }
     return kitTypes;
   }
 
   public async reloadKitList(): Promise<void> {
+    const waitPromise = waitForResponse(this.page, {uri: '/kitRequests'});
     await this.getReloadKitListBtn.click();
+    await waitPromise;
     await waitForNoSpinner(this.page);
   }
 

--- a/playwright-e2e/dsm/pages/kits-page-base.ts
+++ b/playwright-e2e/dsm/pages/kits-page-base.ts
@@ -192,8 +192,4 @@ export default abstract class KitsPageBase extends DsmPageBase {
   public get getReloadKitListBtn(): Locator {
     return this.page.getByRole('button', {name: 'Reload Kit List'});
   }
-
-  public async assertTableHeader(): Promise<void> {
-    assertTableHeaders(await this.kitsTable.getHeaderTexts(), this.TABLE_HEADERS);
-  }
 }

--- a/playwright-e2e/dsm/pages/kits-page-base.ts
+++ b/playwright-e2e/dsm/pages/kits-page-base.ts
@@ -1,0 +1,202 @@
+import { Locator, Page, expect } from '@playwright/test';
+import DsmPageBase from './dsm-page-base';
+import { KitsTable } from 'dsm/component/tables/kits-table';
+import { KitTypeEnum } from 'dsm/component/kitType/enums/kitType-enum';
+import { waitForNoSpinner, waitForResponse } from 'utils/test-utils';
+import { StudyEnum } from 'dsm/component/navigation/enums/selectStudyNav-enum';
+import { KitType } from 'dsm/component/kitType/kitType';
+import { logInfo } from 'utils/log-utils';
+import { KitsColumnsEnum } from './kitsInfo-pages/enums/kitsColumns-enum';
+import Modal from 'dsm/component/modal';
+import { assertTableHeaders } from 'utils/assertion-helper';
+
+export default abstract class KitsPageBase extends DsmPageBase {
+  protected abstract PAGE_TITLE: string;
+  protected abstract TABLE_HEADERS: string[];
+  protected readonly kitType: KitType;
+  protected readonly kitsTable: KitsTable;
+
+  constructor(readonly page: Page) {
+    super(page);
+    this.kitType = new KitType(this.page);
+    this.kitsTable = new KitsTable(this.page);
+  }
+
+  public get getKitsTable(): KitsTable {
+    return this.kitsTable;
+  }
+
+  public async waitForReady(): Promise<void> {
+    await Promise.all([
+      this.page.waitForLoadState(),
+      expect(this.page.locator('h1')).toHaveText(this.PAGE_TITLE),
+    ]);
+    await expect(async () => expect(await this.page.locator('mat-checkbox[id]').count()).toBeGreaterThanOrEqual(1)).toPass({ timeout: 60000 });
+    const kits = await this.getStudyKitTypes()
+    for (const kit of kits) {
+      await expect(this.kitType.displayedKitType(kit)).toBeVisible();
+    }
+    await waitForNoSpinner(this.page);
+  }
+
+  public async selectKitType(kitType: KitTypeEnum): Promise<void> {
+    await waitForNoSpinner(this.page);
+    await Promise.all([
+      waitForResponse(this.page, { uri: 'ui/kitRequests' }),
+      this.kitType.selectKitType(kitType)
+    ]);
+    await waitForNoSpinner(this.page);
+    await this.hasKitRequests();
+  }
+
+  public async deactivateKitFor(opts: { shortId?: string, shippingId?: string } = {}): Promise<string> {
+    let { shortId, shippingId } = opts;
+    expect(shortId || shippingId).toBeTruthy(); // At least one param must be provided
+
+    expect(await this.kitsTable.exists()).toBeTruthy();
+    const kitsCount = await this.kitsTable.rowLocator().count();
+    expect(kitsCount).toBeGreaterThanOrEqual(1);
+
+    let rowIndex = 0;
+    if (shortId) {
+      await this.kitsTable.searchByColumn(KitsColumnsEnum.SHORT_ID, shortId, { column2Name: KitsColumnsEnum.SHIPPING_ID, value2: shippingId });
+      expect(await this.kitsTable.rowLocator().count()).toBeGreaterThanOrEqual(1);
+      const [actualShortId] = await this.kitsTable.getTextAt(rowIndex, KitsColumnsEnum.SHORT_ID);
+      expect(actualShortId).toStrictEqual(shortId);
+      [shippingId] = await this.kitsTable.getTextAt(rowIndex, KitsColumnsEnum.SHIPPING_ID);
+    } else {
+      // Selects a random Short ID
+      rowIndex = await this.kitsTable.getRandomRowIndex();
+      [shortId] = await this.kitsTable.getTextAt(rowIndex, KitsColumnsEnum.SHORT_ID);
+      [shippingId] = await this.kitsTable.getTextAt(rowIndex, KitsColumnsEnum.SHIPPING_ID);
+    }
+    expect(shortId.length).toBeTruthy();
+    expect(shippingId.length).toBeTruthy();
+
+    await this.deactivate(rowIndex);
+    logInfo(`Deactivated kit. Short ID: ${shortId}, Shipping ID: ${shippingId}`);
+    return shippingId;
+  }
+
+/*
+  public async deactivateKitFor(shortId?: string): Promise<string> {
+    expect(await this.kitsTable.exists()).toBeTruthy();
+    let kitsCount = await this.kitsTable.rows.count();
+    expect(kitsCount).toBeGreaterThanOrEqual(1);
+
+    if (!shortId) {
+      // Selects a random Short ID
+      const rowIndex = await this.kitsTable.getRandomRowIndex();
+      [shortId] = await this.kitsTable.getTextAt(rowIndex, KitsColumnsEnum.SHORT_ID);
+    }
+    expect(shortId.length).toBeTruthy();
+    await this.kitsTable.searchBy(KitsColumnsEnum.SHORT_ID, shortId);
+    await waitForNoSpinner(this.page);
+
+    kitsCount = await this.kitsTable.rows.count();
+    expect(kitsCount).toBeGreaterThanOrEqual(1);
+
+    const [shippingID] = await this.kitsTable.getTextAt(0, KitsColumnsEnum.SHIPPING_ID);
+    await this.deactivate(0);
+
+    logInfo(`Deactivated Kit: Short ID: ${shortId}, Shipping ID: ${shippingID}`);
+    return shippingID;
+  }
+*/
+
+  public async deactivateAllKitsFor(shortId?: string): Promise<void> {
+    if (!shortId) {
+      // Selects a random Short ID
+      const rowIndex = await this.kitsTable.getRandomRowIndex();
+      [shortId] = await this.kitsTable.getTextAt(rowIndex, KitsColumnsEnum.SHORT_ID);
+    }
+    expect(shortId.length).toBeTruthy();
+
+    await this.kitsTable.searchByColumn(KitsColumnsEnum.SHORT_ID, shortId);
+    await waitForNoSpinner(this.page);
+
+    const kitsCount = await this.kitsTable.rows.count();
+    expect(kitsCount).toBeGreaterThanOrEqual(1);
+    for (let i = 0; i < kitsCount; i++) {
+      await this.deactivate(i);
+      await this.kitsTable.rows.count() && await this.deactivateAllKitsFor(shortId);
+    }
+    await expect(this.kitsTable.rows).toHaveCount(0);
+    logInfo(`Deactivated all kits. Short ID: ${shortId}`);
+  }
+
+  public async hasKitRequests(): Promise<boolean> {
+    const pageText = this.page.getByText('There are no kit requests');
+    await Promise.race([
+      expect(pageText).toBeVisible(),
+      expect(this.kitsTable.tableLocator()).toBeVisible(),
+    ]);
+    const existsText = await pageText.isVisible();
+    if (existsText) {
+      return false;
+    }
+    return true;
+  }
+
+  public async getStudyKitTypes(): Promise<KitTypeEnum[]> {
+    const studyNameLocation = this.page.locator(`//app-navigation//a[@data-toggle='dropdown']//i`);
+    const studyName = await studyNameLocation.innerText();
+    // Most studies have Blood and Saliva kits; RGP has Blood and 'Blood & RNA' kits; Pancan has Blood, Saliva, and Stool kits
+    let kitTypes;
+    switch (studyName) {
+      case StudyEnum.RGP:
+        kitTypes = [KitTypeEnum.BLOOD, KitTypeEnum.BLOOD_AND_RNA];
+        break;
+      case StudyEnum.PANCAN:
+        kitTypes = [KitTypeEnum.BLOOD, KitTypeEnum.SALIVA, KitTypeEnum.STOOL];
+        break;
+      default:
+        kitTypes = [KitTypeEnum.BLOOD, KitTypeEnum.SALIVA];
+        break;
+    }
+    return kitTypes;
+  }
+
+  public async reloadKitList(): Promise<void> {
+    await this.getReloadKitListBtn.click();
+    await waitForNoSpinner(this.page);
+  }
+
+  private async deactivate(row = 0): Promise<string> {
+    const deactivateButton = this.kitsTable.deactivateButtons.nth(row);
+    await deactivateButton.click();
+
+    await expect(this.deactivateReasonInput).toBeVisible();
+    await expect(this.deactivateReasonBtn).toBeVisible();
+
+    const reason = `testDeactivate-${new Date().getTime()}`;
+    await Promise.all([
+      waitForResponse(this.page, {uri: '/deactivateKit'}),
+      waitForResponse(this.page, {uri: '/kitRequests'}),
+      this.deactivateReasonInput.fill(reason),
+      this.deactivateReasonBtn.click(),
+    ]);
+
+    await expect(new Modal(this.page).toLocator()).not.toBeVisible();
+    await waitForNoSpinner(this.page);
+    return reason;
+  }
+
+  public get deactivateReasonInput(): Locator {
+    return this.page.locator("//app-modal/div[@class='modal fade in']//table/tr"
+      + "[td[1][text()[normalize-space()='Reason:']]]/td[2]/mat-form-field//input");
+  }
+
+  public get deactivateReasonBtn(): Locator {
+    return this.page.locator('//app-modal/div[@class="modal fade in"]'
+      + '//div[@class="app-modal-footer"]/button[text()[normalize-space()="Deactivate"]]');
+  }
+
+  public get getReloadKitListBtn(): Locator {
+    return this.page.getByRole('button', {name: 'Reload Kit List'});
+  }
+
+  public async assertTableHeader(): Promise<void> {
+    assertTableHeaders(await this.kitsTable.getHeaderTexts(), this.TABLE_HEADERS);
+  }
+}

--- a/playwright-e2e/dsm/pages/kits-page-base.ts
+++ b/playwright-e2e/dsm/pages/kits-page-base.ts
@@ -133,6 +133,9 @@ export default abstract class KitsPageBase extends DsmPageBase {
     // Most studies have Blood and Saliva kits; RGP has Blood and 'Blood & RNA' kits; Pancan has Blood, Saliva, and Stool kits
     let kitTypes;
     switch (studyName) {
+      case StudyEnum.LMS:
+        kitTypes = [KitTypeEnum.SALIVA, KitTypeEnum.BLOOD];
+        break;
       case StudyEnum.RGP:
         kitTypes = [KitTypeEnum.BLOOD, KitTypeEnum.BLOOD_AND_RNA];
         break;

--- a/playwright-e2e/dsm/pages/kits-page-base.ts
+++ b/playwright-e2e/dsm/pages/kits-page-base.ts
@@ -39,10 +39,17 @@ export default abstract class KitsPageBase extends DsmPageBase {
     await waitForNoSpinner(this.page);
   }
 
-  public async reloadKit(kitType: KitTypeEnum): Promise<void> {
+  public async reloadKitPage(kitType: KitTypeEnum): Promise<void> {
     await this.page.reload();
     await this.waitForReady();
     await this.selectKitType(kitType);
+  }
+
+  public async reloadKitList(): Promise<void> {
+    const waitPromise = waitForResponse(this.page, {uri: '/kitRequests'});
+    await this.getReloadKitListBtn.click();
+    await waitPromise;
+    await waitForNoSpinner(this.page);
   }
 
   public async selectKitType(kitType: KitTypeEnum): Promise<boolean> {
@@ -150,13 +157,6 @@ export default abstract class KitsPageBase extends DsmPageBase {
         break;
     }
     return kitTypes;
-  }
-
-  public async reloadKitList(): Promise<void> {
-    const waitPromise = waitForResponse(this.page, {uri: '/kitRequests'});
-    await this.getReloadKitListBtn.click();
-    await waitPromise;
-    await waitForNoSpinner(this.page);
   }
 
   private async deactivate(row = 0): Promise<string> {

--- a/playwright-e2e/dsm/pages/kitsInfo-pages/kit-queue-page.ts
+++ b/playwright-e2e/dsm/pages/kitsInfo-pages/kit-queue-page.ts
@@ -1,26 +1,23 @@
-import { KitType } from 'dsm/component/kitType/kitType';
 import { KitsColumnsEnum } from './enums/kitsColumns-enum';
-import { expect, Locator, Page } from '@playwright/test';
-import { KitsTable } from 'dsm/component/tables/kits-table';
-import { waitForNoSpinner, waitForResponse } from 'utils/test-utils';
+import { Locator, Page } from '@playwright/test';
 import {rows} from 'lib/component/dsm/paginators/types/rowsPerPage';
-import { KitTypeEnum } from 'dsm/component/kitType/enums/kitType-enum';
-import { assertTableHeaders } from 'utils/assertion-helper';
+import KitsPageBase from 'dsm/pages/kits-page-base';
 
-export default class KitsQueuePage {
-  private readonly PAGE_TITLE = 'Kit Queue';
-  private readonly TABLE_HEADERS = [KitsColumnsEnum.PRINT_KIT,
-    KitsColumnsEnum.SHORT_ID, KitsColumnsEnum.PREFERRED_LANGUAGE,
-    KitsColumnsEnum.SHIPPING_ID, KitsColumnsEnum.DDP_REALM,
-    KitsColumnsEnum.TYPE, '', '']; //'Deactivate' and 'Generate Express Label' do not have column header names
+export default class KitsQueuePage extends KitsPageBase {
+  PAGE_TITLE = 'Kit Queue';
+  TABLE_HEADERS = [
+    KitsColumnsEnum.PRINT_KIT,
+    KitsColumnsEnum.SHORT_ID,
+    KitsColumnsEnum.PREFERRED_LANGUAGE,
+    KitsColumnsEnum.SHIPPING_ID,
+    KitsColumnsEnum.DDP_REALM,
+    KitsColumnsEnum.TYPE,
+    '',
+    ''
+  ]; //'Deactivate' and 'Generate Express Label' do not have column header names
 
-  private readonly kitType = new KitType(this.page);
-  private readonly kitsTable = new KitsTable(this.page);
-
-  constructor(private readonly page: Page) {}
-
-  public get getKitsTable(): KitsTable {
-    return this.kitsTable;
+  constructor(page: Page) {
+    super(page);
   }
 
   public async goToPage(page: number): Promise<void> {
@@ -31,19 +28,6 @@ export default class KitsQueuePage {
     await this.kitsTable.rowsPerPage(rows);
   }
 
-  public async waitForLoad(): Promise<void> {
-    await this.page.waitForLoadState('networkidle');
-    await waitForNoSpinner(this.page);
-  }
-
-  public async hasExistingKitRequests(): Promise<boolean> {
-    const noCurrentKitRequests = this.page.getByText('There are no kit requests');
-    if (await noCurrentKitRequests.isVisible()) {
-      return false;
-    }
-    return true;
-  }
-
   public async getAllSamplesOnPage(): Promise<Locator[]> {
     return this.page.locator('//table//tbody//tr').all();
   }
@@ -52,54 +36,11 @@ export default class KitsQueuePage {
     return await this.page.locator('//table//tbody//tr').count();
   }
 
-  public async selectKitType(kitType: KitTypeEnum): Promise<void> {
-    await waitForNoSpinner(this.page);
-    await this.kitType.selectKitType(kitType);
-    await waitForResponse(this.page, {uri: '/kitRequests'});
-    await waitForNoSpinner(this.page);
-  }
-
   public async search(columnName: KitsColumnsEnum, value: string): Promise<void> {
     await this.kitsTable.searchBy(columnName, value);
   }
 
   public async getData(columnName: KitsColumnsEnum): Promise<string> {
     return await this.kitsTable.getData(columnName);
-  }
-
-  public async reloadKitList(): Promise<void> {
-    await this.getReloadKitListButton().click();
-    await waitForNoSpinner(this.page);
-  }
-
-  /* Assertions */
-  public async assertPageTitle(): Promise<void> {
-    await expect(this.page.locator('h1'),
-      'Kits Received page - page title is wrong')
-      .toHaveText(this.PAGE_TITLE);
-  }
-
-  public async assertReloadKitListBtn(): Promise<void> {
-    const reloadKitListButton = this.getReloadKitListButton();
-    await expect(reloadKitListButton,
-      'Kits Received page - Reload Kit List Button is not visible')
-      .toBeVisible();
-  }
-
-  public async assertDisplayedKitTypes(kitTypes: KitTypeEnum[]): Promise<void> {
-    await waitForNoSpinner(this.page);
-    for (const kitType of kitTypes) {
-      await expect(this.kitType.displayedKitType(kitType),
-        'Kits Received page - Displayed kit types checkboxes are wrong').toBeVisible()
-    }
-  }
-
-  public async assertTableHeader(): Promise<void> {
-    assertTableHeaders(await this.kitsTable.getHeaderTexts(), this.TABLE_HEADERS);
-  }
-
-  /* Locators */
-  private getReloadKitListButton(): Locator {
-    return this.page.getByRole('button', { name: 'Reload Kit List'});
   }
 }

--- a/playwright-e2e/dsm/pages/kitsInfo-pages/kitsWithoutLabel-page.ts
+++ b/playwright-e2e/dsm/pages/kitsInfo-pages/kitsWithoutLabel-page.ts
@@ -1,28 +1,26 @@
 import {expect, Locator, Page} from '@playwright/test';
-import {KitType} from 'dsm/component/kitType/kitType';
-import {KitTypeEnum} from 'dsm/component/kitType/enums/kitType-enum';
 import {waitForNoSpinner, waitForResponse} from 'utils/test-utils';
-import {KitsTable} from 'dsm/component/tables/kits-table';
 import {KitsColumnsEnum} from 'dsm/pages/kitsInfo-pages/enums/kitsColumns-enum';
-import {assertTableHeaders} from 'utils/assertion-helper';
 import {rows} from 'lib/component/dsm/paginators/types/rowsPerPage';
-import Modal from 'dsm/component/modal';
+import KitsPageBase from 'dsm/pages/kits-page-base';
 
 
-export default class KitsWithoutLabelPage {
-  private readonly PAGE_TITLE = 'Kits without label';
-  private readonly TABLE_HEADERS = [KitsColumnsEnum.PRINT_KIT, KitsColumnsEnum.SHORT_ID,
-    KitsColumnsEnum.PREFERRED_LANGUAGE, KitsColumnsEnum.SHIPPING_ID,
-    KitsColumnsEnum.DDP_REALM, KitsColumnsEnum.TYPE, ''];
+export default class KitsWithoutLabelPage extends KitsPageBase {
+  PAGE_TITLE = 'Kits without label';
+  TABLE_HEADERS = [
+    KitsColumnsEnum.PRINT_KIT,
+    KitsColumnsEnum.SHORT_ID,
+    KitsColumnsEnum.PREFERRED_LANGUAGE,
+    KitsColumnsEnum.SHIPPING_ID,
+    KitsColumnsEnum.DDP_REALM,
+    KitsColumnsEnum.TYPE,
+    ''
+  ];
   // the last item is empty string because the deactivate buttons columns doesn't have one
 
-  private readonly kitType = new KitType(this.page);
-  private readonly kitsTable = new KitsTable(this.page);
 
-  constructor(private readonly page: Page) {}
-
-  public get kitsWithoutLabelTable(): KitsTable {
-    return this.kitsTable;
+  constructor(page: Page) {
+    super(page);
   }
 
   public async goToPage(page: number): Promise<void> {
@@ -31,35 +29,6 @@ export default class KitsWithoutLabelPage {
 
   public async rowsPerPage(rows: rows): Promise<void> {
     await this.kitsTable.rowsPerPage(rows);
-  }
-
-  public async waitForReady(): Promise<void> {
-    await this.assertPageTitle();
-    await waitForNoSpinner(this.page);
-    await expect(async () => expect(await this.page.locator('mat-checkbox[id]').count()).toBeGreaterThanOrEqual(1))
-      .toPass({ timeout: 60000 });
-  }
-
-  public async selectKitType(kitType: KitTypeEnum): Promise<void> {
-    await waitForNoSpinner(this.page);
-    await Promise.all([
-      waitForResponse(this.page, { uri: 'ui/kitRequests' }),
-      this.kitType.selectKitType(kitType)
-    ]);
-    await waitForNoSpinner(this.page);
-  }
-
-  public async deactivateAllKitsFor(shortId: string) {
-    await this.kitsTable.searchBy(KitsColumnsEnum.SHORT_ID, shortId);
-    await waitForNoSpinner(this.page);
-    const kitsCount = await this.kitsTable.rows.count();
-    if (kitsCount) {
-      await this.deactivateKit(this.kitsTable.deactivateButtons.nth(0));
-      await this.kitsTable.rows.count() && await this.deactivateAllKitsFor(shortId)
-    }
-    await expect(this.kitsTable.rows,
-      'Kits Without Label page - All kits were not removed')
-      .toHaveCount(0)
   }
 
   public async waitUntilAllKitLabelCreationRequestsAreProcessed(): Promise<void> {
@@ -73,49 +42,12 @@ export default class KitsWithoutLabelPage {
     }
   }
 
-  public async reloadKitList(): Promise<void> {
-    const reloadKitListButton = this.page.locator(this.reloadKitListBtnXPath);
-    await reloadKitListButton.click();
-    await waitForNoSpinner(this.page, { timeout: 2 * 60 * 1000 });
-  }
-
   public async search(columnName: KitsColumnsEnum, value: string): Promise<void> {
     await this.kitsTable.searchBy(columnName, value);
   }
 
   public async getData(columnName: KitsColumnsEnum): Promise<string> {
     return await this.kitsTable.getData(columnName);
-  }
-
-  private async deactivateKit(deactivateButton: Locator): Promise<void> {
-    await deactivateButton.click();
-    const deactivateReasonInput = this.page.locator(this.deactivateReasonInputXPath);
-    const deactivateReasonButton = this.page.locator(this.deactivateReasonBtnXPath);
-
-    await expect(deactivateReasonInput,
-      'Kits Without Label page - Deactivate reason input field is not visible')
-      .toBeVisible();
-    await expect(deactivateReasonButton,
-      'Kits Without Label page - Deactivate reason button is not visible')
-      .toBeVisible();
-
-    await Promise.all([
-      waitForResponse(this.page, {uri: '/deactivateKit'}),
-      waitForResponse(this.page, {uri: '/kitRequests'}),
-      deactivateReasonInput.fill(`testDeactivate-${new Date().getTime()}`),
-      deactivateReasonButton.click(),
-    ]);
-
-    await expect(new Modal(this.page).toLocator()).not.toBeVisible();
-    await waitForNoSpinner(this.page);
-  }
-
-  public async hasExistingKitRequests(): Promise<boolean> {
-    const noCurrentKitRequests = this.page.getByText('There are no kit requests');
-    if (await noCurrentKitRequests.isVisible()) {
-      return false;
-    }
-    return true;
   }
 
   public async clickCreateLabels(): Promise<void> {
@@ -128,14 +60,8 @@ export default class KitsWithoutLabelPage {
   }
 
   /* Assertions */
-  public async assertPageTitle(): Promise<void> {
-    await expect(this.page.locator('h1'),
-      "Kits Without Label page - page title doesn't match the expected one")
-      .toHaveText(this.PAGE_TITLE);
-  }
-
   public async assertReloadKitListBtn(): Promise<void> {
-    await expect(this.page.locator(this.reloadKitListBtnXPath),
+    await expect(this.getReloadKitListBtn,
       'Kits Without Label page - Reload Kit List Button is not visible').toBeVisible();
   }
 
@@ -145,29 +71,11 @@ export default class KitsWithoutLabelPage {
       .toBeVisible();
   }
 
-  public async assertTableHeader(): Promise<void> {
-    assertTableHeaders(await this.kitsTable.getHeaderTexts(), this.TABLE_HEADERS);
-  }
-
   public get createLabelsButton(): Locator {
     return this.page.locator(this.createLabelsBtnXPath);
   }
 
   /* XPaths */
-  private get deactivateReasonInputXPath(): string {
-    return "//app-modal/div[@class='modal fade in']//table/tr"
-      + "[td[1][text()[normalize-space()='Reason:']]]/td[2]/mat-form-field//input";
-  }
-
-  private get deactivateReasonBtnXPath(): string {
-    return "//app-modal/div[@class='modal fade in']"
-      + "//div[@class='app-modal-footer']/button[text()[normalize-space()='Deactivate']]";
-  }
-
-  private get reloadKitListBtnXPath(): string {
-    return '//button[normalize-space()="Reload Kit List"]';
-  }
-
   private get createLabelsBtnXPath(): string {
     return '//button[normalize-space()="Create Labels"]';
   }

--- a/playwright-e2e/dsm/pages/kitsInfo-pages/kitsWithoutLabel-page.ts
+++ b/playwright-e2e/dsm/pages/kitsInfo-pages/kitsWithoutLabel-page.ts
@@ -14,10 +14,7 @@ export default class KitsWithoutLabelPage extends KitsPageBase {
     KitsColumnsEnum.SHIPPING_ID,
     KitsColumnsEnum.DDP_REALM,
     KitsColumnsEnum.TYPE,
-    ''
   ];
-  // the last item is empty string because the deactivate buttons columns doesn't have one
-
 
   constructor(page: Page) {
     super(page);

--- a/playwright-e2e/dsm/pages/participant-list-page.ts
+++ b/playwright-e2e/dsm/pages/participant-list-page.ts
@@ -93,13 +93,13 @@ export default class ParticipantListPage {
     await saveButton.click();
 
     const saveModal = new Modal(this.page);
+    await expect(saveModal.toLocator()).toBeVisible();
     expect(await saveModal.getHeader()).toBe('Please enter a name for your filter');
     await saveModal.getInput({ label: 'Filter Name' }).fill(viewName);
     await Promise.all([
       waitForResponse(this.page, {uri: '/ui/saveFilter'}),
       saveModal.getButton({ label: /Save Filter/ }).click()
     ]);
-    await waitForNoSpinner(this.page);
     await waitForNoSpinner(this.page);
   }
 

--- a/playwright-e2e/dsm/pages/participant-list-page.ts
+++ b/playwright-e2e/dsm/pages/participant-list-page.ts
@@ -95,11 +95,11 @@ export default class ParticipantListPage {
     const saveModal = new Modal(this.page);
     expect(await saveModal.getHeader()).toBe('Please enter a name for your filter');
     await saveModal.getInput({ label: 'Filter Name' }).fill(viewName);
-    console.log(`New filter name: ${viewName}`);
     await Promise.all([
-      saveModal.getButton({ label: /Save Filter/ }).click(),
-      waitForResponse(this.page, {uri: '/ui/saveFilter?'})
+      waitForResponse(this.page, {uri: '/ui/saveFilter'}),
+      saveModal.getButton({ label: /Save Filter/ }).click()
     ]);
+    await waitForNoSpinner(this.page);
     await waitForNoSpinner(this.page);
   }
 

--- a/playwright-e2e/dsm/pages/samples/error-page.ts
+++ b/playwright-e2e/dsm/pages/samples/error-page.ts
@@ -1,10 +1,6 @@
-import { expect, Locator, Page } from '@playwright/test';
-import { KitTypeEnum } from 'dsm/component/kitType/enums/kitType-enum';
-import { KitType } from 'dsm/component/kitType/kitType';
-import { KitsTable } from 'dsm/component/tables/kits-table';
-import { waitForNoSpinner, waitForResponse } from 'utils/test-utils';
+import { Page } from '@playwright/test';
+import KitsPageBase from 'dsm/pages/kits-page-base';
 import { KitsColumnsEnum } from 'dsm/pages/kitsInfo-pages/enums/kitsColumns-enum';
-import { StudyEnum } from 'dsm/component/navigation/enums/selectStudyNav-enum';
 
 export enum SearchByField {
   SHORT_ID = 'Short ID',
@@ -12,111 +8,20 @@ export enum SearchByField {
   MANUFACTURE_BARCODE = 'Manufacturer Barcode'
 }
 
-export default class ErrorPage {
-  private readonly kitType: KitType;
-  private readonly kitsTable: KitsTable;
-  private expectedKitTypes: KitTypeEnum[];
+export default class ErrorPage extends KitsPageBase {
+  protected PAGE_TITLE = 'Kits with Error';
+  TABLE_HEADERS = [
+    KitsColumnsEnum.PRINT_KIT,
+    KitsColumnsEnum.SHORT_ID,
+    KitsColumnsEnum.SHIPPING_ID,
+    KitsColumnsEnum.ERROR_REASON,
+    KitsColumnsEnum.DDP_REALM,
+    KitsColumnsEnum.TYPE,
+    '',
+    ''
+  ];
 
-  constructor(private readonly page: Page) {
-    this.kitType = new KitType(this.page)
-    this.kitsTable = new KitsTable(this.page);
-    this.expectedKitTypes = [];
-  }
-
-  public async waitForReady(): Promise<void> {
-    await expect(this.page.locator('h1')).toHaveText('Kits with Error');
-    await Promise.all([
-      this.page.waitForLoadState('networkidle'),
-      waitForNoSpinner(this.page)
-    ]);
-    this.expectedKitTypes = await this.getAvailableKitTypes();
-    for (const kit of this.expectedKitTypes) {
-      await Promise.all([
-        expect(this.kitType.displayedKitType(kit)).toBeVisible()
-      ]);
-    }
-  }
-
-  public async selectKitType(kitType: KitTypeEnum): Promise<void> {
-    await Promise.all([
-      waitForResponse(this.page, { uri: '/kitRequests' }),
-      this.kitType.selectKitType(kitType)
-    ]);
-    await waitForNoSpinner(this.page);
-    await expect(this.reloadKitListButton).toBeVisible();
-  }
-
-  public get reloadKitListButton(): Locator {
-    return this.page.getByRole('button', {name: 'Reload Kit List'});
-  }
-
-  public async reloadKitList(): Promise<void> {
-    await this.reloadKitListButton.click();
-    await waitForNoSpinner(this.page);
-  }
-
-  public get kitListTable(): KitsTable {
-    return this.kitsTable;
-  }
-
-  public async deactivateKitsFor(shortId: string, shippingId?: string) {
-    if (shippingId) {
-      await this.kitsTable.searchByColumn(KitsColumnsEnum.SHORT_ID, shortId, { column2Name: 'Shipping ID', value2: shippingId });
-    } else {
-      await this.kitsTable.searchByColumn(KitsColumnsEnum.SHORT_ID, shortId);
-    }
-    await expect(this.kitsTable.rowLocator()).toHaveCount(1);
-
-    const deactivateButton = this.kitsTable.deactivateButtons.nth(0);
-    await deactivateButton.click();
-
-    const deactivateReasonInput = this.page.locator(this.deactivateReasonInputXPath);
-    const deactivateReasonButton = this.page.locator(this.deactivateReasonBtnXPath);
-
-    await expect(deactivateReasonInput,
-      'Kits Without Label page - Deactivate reason input field is not visible')
-      .toBeVisible();
-
-    await expect(deactivateReasonButton,
-      'Kits Without Label page - Deactivate reason button is not visible')
-      .toBeVisible();
-
-    await deactivateReasonInput.fill(`test-deactivate-${new Date().getTime()}`);
-    await deactivateReasonButton.click();
-
-    await Promise.all([
-      waitForResponse(this.page, { uri: '/deactivateKit' }),
-      waitForResponse(this.page, { uri: '/kitRequests' })
-    ]);
-    await expect(this.kitsTable.rowLocator()).toHaveCount(0)
-  }
-
-  private get deactivateReasonInputXPath(): string {
-    return "//app-modal/div[@class='modal fade in']//table/tr"
-      + "[td[1][text()[normalize-space()='Reason:']]]/td[2]/mat-form-field//input";
-  }
-
-  private get deactivateReasonBtnXPath(): string {
-    return "//app-modal/div[@class='modal fade in']"
-      + "//div[@class='app-modal-footer']/button[text()[normalize-space()='Deactivate']]";
-  }
-
-  private async getAvailableKitTypes(): Promise<KitTypeEnum[]> {
-    const studyNameLocation = this.page.locator(`//app-navigation//a[@data-toggle='dropdown']//i`);
-    const studyName = await studyNameLocation.innerText();
-    //Most studies have Blood and Saliva kits; RGP has Blood and 'Blood & RNA' kits; Pancan has Blood, Saliva, and Stool kits
-    let kitTypes;
-    switch (studyName) {
-      case StudyEnum.RGP:
-        kitTypes = [KitTypeEnum.BLOOD, KitTypeEnum.BLOOD_AND_RNA];
-        break;
-      case StudyEnum.PANCAN:
-        kitTypes = [KitTypeEnum.BLOOD, KitTypeEnum.SALIVA, KitTypeEnum.STOOL];
-        break;
-      default:
-        kitTypes = [KitTypeEnum.BLOOD, KitTypeEnum.SALIVA];
-        break;
-    }
-    return kitTypes;
+  constructor(page: Page) {
+    super(page);
   }
 }

--- a/playwright-e2e/dsm/pages/scanner-pages/finalScan-page.ts
+++ b/playwright-e2e/dsm/pages/scanner-pages/finalScan-page.ts
@@ -32,10 +32,10 @@ export default class FinalScanPage {
 
     await expect(saveButton, 'Final Scan page - Save Scan Pairs button is not enabled').toBeEnabled();
 
+    const waitPromise = waitForResponse(this.page, {uri: 'finalScan'});
     await saveButton.focus();
     await saveButton.click();
-
-    await waitForResponse(this.page, {uri: 'finalScan'});
+    await waitPromise;
 
     if (verifySuccess) {
       const textUnderScanPair = this.page.locator(this.textUnderScanPairXPath);

--- a/playwright-e2e/dsm/pages/scanner-pages/trackingScan-page.ts
+++ b/playwright-e2e/dsm/pages/scanner-pages/trackingScan-page.ts
@@ -26,10 +26,10 @@ export default class TrackingScanPage {
     const saveButton = this.page.locator(this.saveButtonXPath);
     await expect(saveButton, 'Tracking Scan page - Save Scan Pairs button is not enabled').toBeEnabled();
 
+    const waitPromise = waitForResponse(this.page, {uri: 'trackingScan'});
     await saveButton.focus();
     await saveButton.click();
-
-    await waitForResponse(this.page, {uri: 'trackingScan'});
+    await waitPromise;
 
     if (verifySuccess) {
       const textUnderScanPair = this.page.locator(this.textUnderScanPairXPath);

--- a/playwright-e2e/dss/component/table.ts
+++ b/playwright-e2e/dss/component/table.ts
@@ -251,8 +251,13 @@ export default class Table {
   }
 
   async changeRowCount(rowCount = 10): Promise<void> {
-    await this.rowCountButton(rowCount).click();
-    await waitForNoSpinner(this.page);
+    try {
+      await expect(this.rowCountButton(rowCount)).toBeVisible();
+      await this.rowCountButton(rowCount).click();
+      await waitForNoSpinner(this.page);
+    } catch (err) {
+      // Ignored
+    }
   }
 
   /**

--- a/playwright-e2e/lib/component/dsm/paginators/participantsListPaginator.ts
+++ b/playwright-e2e/lib/component/dsm/paginators/participantsListPaginator.ts
@@ -8,8 +8,9 @@ export class ParticipantsListPaginator {
   public async rowsPerPage(rows: rows): Promise<void> {
     const rowsPerPageLocator = this.page.locator(this.rowsPerPageXPath(rows));
     await expect(rowsPerPageLocator, `The row - ${rows} is not visible`).toBeVisible();
+    const waitPromise = this.waitForReady();
     await rowsPerPageLocator.click();
-    await this.waitForReady();
+    await waitPromise;
   }
 
   public async pageAt(page: number): Promise<void> {
@@ -37,15 +38,17 @@ export class ParticipantsListPaginator {
     if (isDisabled) {
       throw new Error('Table "Next Page" link is disabled.');
     }
+    const waitPromise = this.waitForReady();
     await paginatorLocator.click();
-    await this.waitForReady();
+    await waitPromise;
   }
 
   private async paginateAt(page: number): Promise<void> {
     const pageLocator = this.page.locator(this.pageAtXPath(page));
     await expect(pageLocator, `The page - ${page} is not visible`).toBeVisible();
+    const waitPromise = this.waitForReady();
     await pageLocator.click();
-    await this.waitForReady();
+    await waitPromise;
   }
 
   private async waitForReady(): Promise<void> {

--- a/playwright-e2e/playwright.config.ts
+++ b/playwright-e2e/playwright.config.ts
@@ -44,7 +44,7 @@ const testConfig: PlaywrightTestConfig = {
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!CI,
   retries: CI ? 1 : 0,
-  workers: CI ? 2 : 3,
+  workers: CI ? 1 : 2,
   maxFailures: 0,
 
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */

--- a/playwright-e2e/playwright.config.ts
+++ b/playwright-e2e/playwright.config.ts
@@ -43,7 +43,7 @@ const testConfig: PlaywrightTestConfig = {
   fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!CI,
-  retries: CI ? 1 : 0,
+  retries: CI ? 0 : 0,
   workers: CI ? 1 : 2,
   maxFailures: 0,
 

--- a/playwright-e2e/tests/dsm/kitUploadFlow/blood-and-rna-kit-upload-flow.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/blood-and-rna-kit-upload-flow.spec.ts
@@ -82,7 +82,6 @@ test.describe('Blood & RNA Kit Upload', () => {
     if (await kitsWithoutLabelPage.hasKitRequests()) {
       await kitsWithoutLabelPage.assertCreateLabelsBtn();
       await kitsWithoutLabelPage.assertReloadKitListBtn();
-      await kitsWithoutLabelPage.assertTableHeader();
       await kitsWithoutLabelPage.deactivateAllKitsFor(simpleShortId);
     }
 

--- a/playwright-e2e/tests/dsm/kitUploadFlow/blood-and-rna-kit-upload-flow.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/blood-and-rna-kit-upload-flow.spec.ts
@@ -28,6 +28,8 @@ import ErrorPage from 'dsm/pages/samples/error-page';
 
 test.describe('Blood & RNA Kit Upload', () => {
   test('Verify that a blood & rna kit can be uploaded @dsm @rgp @functional @upload', async ({ page, request}, testInfo) => {
+    test.slow();
+
     const testResultDirectory = testInfo.outputDir;
 
     const study = StudyEnum.RGP;

--- a/playwright-e2e/tests/dsm/kitUploadFlow/blood-kit-prefix-check.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/blood-kit-prefix-check.spec.ts
@@ -73,6 +73,7 @@ test.describe.serial('Blood Kit Upload', () => {
   for (const [index, study] of studies.entries()) {
     test(`Kit prefix check @cmi @dsm @${study} @kit`, async ({ page }, testInfo) => {
       test.slow();
+
       const testResultDir = testInfo.outputDir;
 
       await welcomePage.selectStudy(study);
@@ -169,7 +170,7 @@ test.describe.serial('Blood Kit Upload', () => {
           // create label could take some time
           await errorPage.reloadKitList();
           await expect(kitListTable.rows).toHaveCount(1, { timeout: 10 * 1000 });
-        }).toPass({ timeout: 90 * 1000 });
+        }).toPass({ timeout: 3 * 60 * 1000 });
       });
 
       // For blood kit, requires tracking label

--- a/playwright-e2e/tests/dsm/kitUploadFlow/blood-kit-prefix-check.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/blood-kit-prefix-check.spec.ts
@@ -133,7 +133,6 @@ test.describe.serial('Blood Kit Upload', () => {
         await kitsWithoutLabelPage.selectKitType(kitType);
         await kitsWithoutLabelPage.assertCreateLabelsBtn();
         await kitsWithoutLabelPage.assertReloadKitListBtn();
-        await kitsWithoutLabelPage.assertTableHeader();
 
         const kitsTable = kitsWithoutLabelPage.getKitsTable;
         await kitsTable.searchByColumn(KitsColumnsEnum.SHORT_ID, shortID);

--- a/playwright-e2e/tests/dsm/kitUploadFlow/blood-kit-prefix-check.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/blood-kit-prefix-check.spec.ts
@@ -134,9 +134,8 @@ test.describe.serial('Blood Kit Upload', () => {
         await kitsWithoutLabelPage.assertCreateLabelsBtn();
         await kitsWithoutLabelPage.assertReloadKitListBtn();
         await kitsWithoutLabelPage.assertTableHeader();
-        await kitsWithoutLabelPage.assertPageTitle();
 
-        const kitsTable = kitsWithoutLabelPage.kitsWithoutLabelTable;
+        const kitsTable = kitsWithoutLabelPage.getKitsTable;
         await kitsTable.searchByColumn(KitsColumnsEnum.SHORT_ID, shortID);
         await expect(kitsTable.rowLocator()).toHaveCount(1);
         shippingID = (await kitsTable.getRowText(0, KitsColumnsEnum.SHIPPING_ID)).trim();
@@ -156,7 +155,7 @@ test.describe.serial('Blood Kit Upload', () => {
       // New kit will be listed on Error page because address is in either Canada or New York
       await test.step('New kit will be listed on Error page', async () => {
         const errorPage = await navigation.selectFromSamples<ErrorPage>(SamplesNavEnum.ERROR);
-        const kitListTable = errorPage.kitListTable;
+        const kitListTable = errorPage.getKitsTable;
         await errorPage.waitForReady();
         await errorPage.selectKitType(kitType);
         await expect(async () => {
@@ -193,7 +192,7 @@ test.describe.serial('Blood Kit Upload', () => {
         const kitsWithoutLabelPage = await navigation.selectFromSamples<KitsWithoutLabelPage>(SamplesNavEnum.KITS_WITHOUT_LABELS);
         await kitsWithoutLabelPage.waitForReady();
         await kitsWithoutLabelPage.selectKitType(kitType);
-        const kitsTable = kitsWithoutLabelPage.kitsWithoutLabelTable;
+        const kitsTable = kitsWithoutLabelPage.getKitsTable;
         await kitsTable.searchByColumn(KitsColumnsEnum.SHORT_ID, shortID);
         await expect(kitsTable.rowLocator()).toHaveCount(0);
       });

--- a/playwright-e2e/tests/dsm/kitUploadFlow/blood-kit-prefix-check.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/blood-kit-prefix-check.spec.ts
@@ -217,9 +217,8 @@ test.describe.serial('Blood Kit Upload', () => {
     await trackingScanPage.save({ verifySuccess: false });
 
     // Enter the same pair again to trigger the scan error
+    const errMsg = `Error occurred sending this scan pair!  Kit ${kitLabel} was already associated with tracking id ${trackingLabel}`;
     await expect(page.locator('//h3[contains(@class, "Color--warn")]')).toHaveText('Error - Failed to save all changes');
-    await expect(page.locator('//p[contains(@class, "Color--warn")]')).toHaveText(
-      `Error occurred sending this scan pair!  Error occured for Kit Label "${kitLabel}" ` +
-      'For more information please contact your DSM developer');
+    await expect(page.locator('//p[contains(@class, "Color--warn")]')).toHaveText(new RegExp(errMsg));
   });
 })

--- a/playwright-e2e/tests/dsm/kitUploadFlow/blood-kit-upload-flow.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/blood-kit-upload-flow.spec.ts
@@ -93,7 +93,6 @@ test.describe.serial('Blood Kits upload flow', () => {
       await kitsWithoutLabelPage.selectKitType(kitType);
       await kitsWithoutLabelPage.assertCreateLabelsBtn();
       await kitsWithoutLabelPage.assertReloadKitListBtn();
-      await kitsWithoutLabelPage.assertTableHeader();
       await kitsWithoutLabelPage.deactivateAllKitsFor(shortID);
 
       // Uploads kit
@@ -119,7 +118,6 @@ test.describe.serial('Blood Kits upload flow', () => {
       await kitsWithoutLabelPage.selectKitType(kitType);
       await kitsWithoutLabelPage.assertCreateLabelsBtn();
       await kitsWithoutLabelPage.assertReloadKitListBtn();
-      await kitsWithoutLabelPage.assertTableHeader();
       await kitsWithoutLabelPage.search(KitsColumnsEnum.SHORT_ID, shortID);
       shippingID = (await kitsWithoutLabelPage.getData(KitsColumnsEnum.SHIPPING_ID)).trim();
 

--- a/playwright-e2e/tests/dsm/kitUploadFlow/blood-kit-upload-flow.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/blood-kit-upload-flow.spec.ts
@@ -120,7 +120,6 @@ test.describe.serial('Blood Kits upload flow', () => {
       await kitsWithoutLabelPage.assertCreateLabelsBtn();
       await kitsWithoutLabelPage.assertReloadKitListBtn();
       await kitsWithoutLabelPage.assertTableHeader();
-      await kitsWithoutLabelPage.assertPageTitle();
       await kitsWithoutLabelPage.search(KitsColumnsEnum.SHORT_ID, shortID);
       shippingID = (await kitsWithoutLabelPage.getData(KitsColumnsEnum.SHIPPING_ID)).trim();
 

--- a/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-error.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-error.spec.ts
@@ -47,7 +47,7 @@ test.describe.serial('Kit Deactivation', () => {
 
             shippingId = await kitsErrorPage.deactivateKitFor({ shortId });
 
-            await kitsErrorPage.reloadKit(kit);
+            await kitsErrorPage.reloadKitPage(kit);
 
             // Deactivated kit should be removed from the table
             const kitsExists = await kitsErrorPage.hasKitRequests();

--- a/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-error.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-error.spec.ts
@@ -1,0 +1,72 @@
+import { expect } from '@playwright/test';
+import { test } from 'fixtures/dsm-fixture';
+import { KitTypeEnum } from 'dsm/component/kitType/enums/kitType-enum';
+import { SamplesNavEnum } from 'dsm/component/navigation/enums/samplesNav-enum';
+import { StudyEnum } from 'dsm/component/navigation/enums/selectStudyNav-enum';
+import { Navigation } from 'dsm/component/navigation/navigation';
+import { KitsColumnsEnum } from 'dsm/pages/kitsInfo-pages/enums/kitsColumns-enum';
+import { WelcomePage } from 'dsm/pages/welcome-page';
+import { logInfo } from 'utils/log-utils';
+import { KitsTable } from 'dsm/component/tables/kits-table';
+import ErrorPage from 'dsm/pages/samples/error-page';
+
+// don't run in parallel
+test.describe.serial('Kit Deactivation', () => {
+  const studies = [StudyEnum.LMS, StudyEnum.OSTEO2];
+
+  for (const study of studies) {
+    test(`From Error page @dsm @${study} @kit`, async ({ page, request }) => {
+      let shortId: string;
+      let shippingId: string;
+      let kits: KitTypeEnum[];
+
+      switch (study) {
+        case StudyEnum.LMS:
+          kits = [KitTypeEnum.SALIVA, KitTypeEnum.BLOOD];
+          break;
+        case StudyEnum.RGP:
+          kits = [KitTypeEnum.BLOOD_AND_RNA, KitTypeEnum.BLOOD];
+          break;
+        default:
+          throw new Error(`Unhandled case of StudyEnum: ${study}`);
+      }
+
+      const welcomePage = new WelcomePage(page);
+      const navigation = new Navigation(page, request);
+      await welcomePage.selectStudy(study);
+
+      let kitsErrorPage: ErrorPage;
+      let kitsTable: KitsTable;
+
+      await test.step('Deactivate and verify', async () => {
+        kitsErrorPage = await navigation.selectFromSamples<ErrorPage>(SamplesNavEnum.ERROR);
+        await kitsErrorPage.waitForReady();
+        kitsTable = kitsErrorPage.getKitsTable;
+
+        // Deactivated all kit types for one randomly selected participant
+        for (const kit of kits) {
+          await page.reload();
+          await kitsErrorPage.waitForReady();
+
+          await kitsErrorPage.selectKitType(kit);
+          const rowCount = await kitsTable.getRowsCount();
+          logInfo(`${kit} kits table has ${rowCount} rows`);
+          if (rowCount > 0) {
+            const rowIndex = await kitsTable.getRandomRowIndex();
+            [shortId] = await kitsTable.getTextAt(rowIndex, 'Short ID');
+            shippingId = await kitsErrorPage.deactivateKitFor({ shortId });
+
+            // Deactivated kit should be removed from the table
+            const kitsExists = await kitsErrorPage.hasKitRequests();
+            if (kitsExists) {
+              await kitsTable.searchByColumn(KitsColumnsEnum.SHIPPING_ID, shippingId);
+              await expect(kitsTable.rowLocator()).toHaveCount(0);
+            }
+          } else {
+            logInfo(`${kit} kits table is empty. No kit to deactivate.`);
+          }
+        }
+      });
+    });
+  }
+})

--- a/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-error.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-error.spec.ts
@@ -44,7 +44,10 @@ test.describe.serial('Kit Deactivation', () => {
           if (rowCount > 0) {
             const rowIndex = await kitsTable.getRandomRowIndex();
             [shortId] = await kitsTable.getTextAt(rowIndex, 'Short ID');
+
             shippingId = await kitsErrorPage.deactivateKitFor({ shortId });
+
+            await kitsErrorPage.reloadKit(kit);
 
             // Deactivated kit should be removed from the table
             const kitsExists = await kitsErrorPage.hasKitRequests();

--- a/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-error.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-error.spec.ts
@@ -20,17 +20,6 @@ test.describe.serial('Kit Deactivation', () => {
       let shippingId: string;
       let kits: KitTypeEnum[];
 
-      switch (study) {
-        case StudyEnum.LMS:
-          kits = [KitTypeEnum.SALIVA, KitTypeEnum.BLOOD];
-          break;
-        case StudyEnum.RGP:
-          kits = [KitTypeEnum.BLOOD_AND_RNA, KitTypeEnum.BLOOD];
-          break;
-        default:
-          throw new Error(`Unhandled case of StudyEnum: ${study}`);
-      }
-
       const welcomePage = new WelcomePage(page);
       const navigation = new Navigation(page, request);
       await welcomePage.selectStudy(study);
@@ -42,6 +31,7 @@ test.describe.serial('Kit Deactivation', () => {
         kitsErrorPage = await navigation.selectFromSamples<ErrorPage>(SamplesNavEnum.ERROR);
         await kitsErrorPage.waitForReady();
         kitsTable = kitsErrorPage.getKitsTable;
+        kits = await kitsErrorPage.getStudyKitTypes();
 
         // Deactivated all kit types for one randomly selected participant
         for (const kit of kits) {

--- a/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-kits-without-label.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-kits-without-label.spec.ts
@@ -47,7 +47,7 @@ test.describe.serial('Kit Deactivation', () => {
 
             shippingId = await kitsWithoutLabelPage.deactivateKitFor({shortId});
 
-            await kitsWithoutLabelPage.reloadKit(kit);
+            await kitsWithoutLabelPage.reloadKitPage(kit);
 
             // Deactivated kit should be removed from the table
             const kitsExists = await kitsWithoutLabelPage.hasKitRequests();

--- a/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-kits-without-label.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-kits-without-label.spec.ts
@@ -1,0 +1,72 @@
+import { expect } from '@playwright/test';
+import { test } from 'fixtures/dsm-fixture';
+import { KitTypeEnum } from 'dsm/component/kitType/enums/kitType-enum';
+import { SamplesNavEnum } from 'dsm/component/navigation/enums/samplesNav-enum';
+import { StudyEnum } from 'dsm/component/navigation/enums/selectStudyNav-enum';
+import { Navigation } from 'dsm/component/navigation/navigation';
+import { KitsColumnsEnum } from 'dsm/pages/kitsInfo-pages/enums/kitsColumns-enum';
+import KitsWithoutLabelPage from 'dsm/pages/kitsInfo-pages/kitsWithoutLabel-page';
+import { WelcomePage } from 'dsm/pages/welcome-page';
+import { logInfo } from 'utils/log-utils';
+import { KitsTable } from 'dsm/component/tables/kits-table';
+
+// don't run in parallel
+test.describe.serial('Kit Deactivation', () => {
+  const studies = [StudyEnum.LMS, StudyEnum.RGP];
+
+  for (const study of studies) {
+    test(`From Kits Without Label page @dsm @${study} @kit`, async ({ page, request }) => {
+      let shortId: string;
+      let shippingId: string;
+      let kits: KitTypeEnum[];
+
+      switch (study) {
+        case StudyEnum.LMS:
+          kits = [KitTypeEnum.SALIVA, KitTypeEnum.BLOOD];
+          break;
+        case StudyEnum.RGP:
+          kits = [KitTypeEnum.BLOOD_AND_RNA, KitTypeEnum.BLOOD];
+          break;
+        default:
+          throw new Error(`Unhandled case of StudyEnum: ${study}`);
+      }
+
+      const welcomePage = new WelcomePage(page);
+      const navigation = new Navigation(page, request);
+      await welcomePage.selectStudy(study);
+
+      let kitsWithoutLabelPage: KitsWithoutLabelPage;
+      let kitsTable: KitsTable;
+
+      await test.step('Deactivate and verify', async () => {
+        kitsWithoutLabelPage = await navigation.selectFromSamples<KitsWithoutLabelPage>(SamplesNavEnum.KITS_WITHOUT_LABELS);
+        await kitsWithoutLabelPage.waitForReady();
+        kitsTable = kitsWithoutLabelPage.getKitsTable;
+
+        // Deactivated all kit types for one randomly selected participant
+        for (const kit of kits) {
+          await page.reload();
+          await kitsWithoutLabelPage.waitForReady();
+
+          await kitsWithoutLabelPage.selectKitType(kit);
+          const rowCount = await kitsTable.getRowsCount();
+          logInfo(`${kit} kits table has ${rowCount} rows`);
+          if (rowCount > 0) {
+            const rowIndex = await kitsTable.getRandomRowIndex();
+            [shortId] = await kitsTable.getTextAt(rowIndex, 'Short ID');
+            shippingId = await kitsWithoutLabelPage.deactivateKitFor({shortId});
+
+            // Deactivated kit should be removed from the table
+            const kitsExists = await kitsWithoutLabelPage.hasKitRequests();
+            if (kitsExists) {
+              await kitsTable.searchByColumn(KitsColumnsEnum.SHIPPING_ID, shippingId);
+              await expect(kitsTable.rowLocator()).toHaveCount(0);
+            }
+          } else {
+            logInfo(`${kit} kits table is empty. No kit to deactivate.`);
+          }
+        }
+      });
+    });
+  }
+})

--- a/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-kits-without-label.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-kits-without-label.spec.ts
@@ -44,7 +44,10 @@ test.describe.serial('Kit Deactivation', () => {
           if (rowCount > 0) {
             const rowIndex = await kitsTable.getRandomRowIndex();
             [shortId] = await kitsTable.getTextAt(rowIndex, 'Short ID');
+
             shippingId = await kitsWithoutLabelPage.deactivateKitFor({shortId});
+
+            await kitsWithoutLabelPage.reloadKit(kit);
 
             // Deactivated kit should be removed from the table
             const kitsExists = await kitsWithoutLabelPage.hasKitRequests();

--- a/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-kits-without-label.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-kits-without-label.spec.ts
@@ -20,17 +20,6 @@ test.describe.serial('Kit Deactivation', () => {
       let shippingId: string;
       let kits: KitTypeEnum[];
 
-      switch (study) {
-        case StudyEnum.LMS:
-          kits = [KitTypeEnum.SALIVA, KitTypeEnum.BLOOD];
-          break;
-        case StudyEnum.RGP:
-          kits = [KitTypeEnum.BLOOD_AND_RNA, KitTypeEnum.BLOOD];
-          break;
-        default:
-          throw new Error(`Unhandled case of StudyEnum: ${study}`);
-      }
-
       const welcomePage = new WelcomePage(page);
       const navigation = new Navigation(page, request);
       await welcomePage.selectStudy(study);
@@ -42,6 +31,7 @@ test.describe.serial('Kit Deactivation', () => {
         kitsWithoutLabelPage = await navigation.selectFromSamples<KitsWithoutLabelPage>(SamplesNavEnum.KITS_WITHOUT_LABELS);
         await kitsWithoutLabelPage.waitForReady();
         kitsTable = kitsWithoutLabelPage.getKitsTable;
+        kits = await kitsWithoutLabelPage.getStudyKitTypes();
 
         // Deactivated all kit types for one randomly selected participant
         for (const kit of kits) {

--- a/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-queue.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-queue.spec.ts
@@ -1,0 +1,72 @@
+import { expect } from '@playwright/test';
+import { test } from 'fixtures/dsm-fixture';
+import { KitTypeEnum } from 'dsm/component/kitType/enums/kitType-enum';
+import { SamplesNavEnum } from 'dsm/component/navigation/enums/samplesNav-enum';
+import { StudyEnum } from 'dsm/component/navigation/enums/selectStudyNav-enum';
+import { Navigation } from 'dsm/component/navigation/navigation';
+import { KitsColumnsEnum } from 'dsm/pages/kitsInfo-pages/enums/kitsColumns-enum';
+import { WelcomePage } from 'dsm/pages/welcome-page';
+import { logInfo } from 'utils/log-utils';
+import { KitsTable } from 'dsm/component/tables/kits-table';
+import KitsQueuePage from 'dsm/pages/kitsInfo-pages/kit-queue-page';
+
+// don't run in parallel
+test.describe.serial('Kit Deactivation', () => {
+  const studies = [StudyEnum.LMS, StudyEnum.RGP];
+
+  for (const study of studies) {
+    test(`From Queue page @dsm @${study} @kit`, async ({ page, request }) => {
+      let shortId: string;
+      let shippingId: string;
+      let kits: KitTypeEnum[];
+
+      switch (study) {
+        case StudyEnum.LMS:
+          kits = [KitTypeEnum.SALIVA, KitTypeEnum.BLOOD];
+          break;
+        case StudyEnum.RGP:
+          kits = [KitTypeEnum.BLOOD_AND_RNA, KitTypeEnum.BLOOD];
+          break;
+        default:
+          throw new Error(`Unhandled case of StudyEnum: ${study}`);
+      }
+
+      const welcomePage = new WelcomePage(page);
+      const navigation = new Navigation(page, request);
+      await welcomePage.selectStudy(study);
+
+      let kitsQueuePage: KitsQueuePage;
+      let kitsTable: KitsTable;
+
+      await test.step('Deactivate and verify', async () => {
+        kitsQueuePage = await navigation.selectFromSamples<KitsQueuePage>(SamplesNavEnum.QUEUE);
+        await kitsQueuePage.waitForReady();
+        kitsTable = kitsQueuePage.getKitsTable;
+
+        // Deactivated all kit types for one randomly selected participant
+        for (const kit of kits) {
+          await page.reload();
+          await kitsQueuePage.waitForReady();
+
+          await kitsQueuePage.selectKitType(kit);
+          const rowCount = await kitsTable.getRowsCount();
+          logInfo(`${kit} kits table has ${rowCount} rows`);
+          if (rowCount > 0) {
+            const rowIndex = await kitsTable.getRandomRowIndex();
+            [shortId] = await kitsTable.getTextAt(rowIndex, 'Short ID');
+            shippingId = await kitsQueuePage.deactivateKitFor({shortId});
+
+            // Deactivated kit should be removed from the table
+            const kitsExists = await kitsQueuePage.hasKitRequests();
+            if (kitsExists) {
+              await kitsTable.searchByColumn(KitsColumnsEnum.SHIPPING_ID, shippingId);
+              await expect(kitsTable.rowLocator()).toHaveCount(0);
+            }
+          } else {
+            logInfo(`${kit} kits table is empty. No kit to deactivate.`);
+          }
+        }
+      });
+    });
+  }
+})

--- a/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-queue.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-queue.spec.ts
@@ -47,7 +47,7 @@ test.describe.serial('Kit Deactivation', () => {
 
             shippingId = await kitsQueuePage.deactivateKitFor({shortId});
 
-            await kitsQueuePage.reloadKit(kit);
+            await kitsQueuePage.reloadKitPage(kit);
 
             // Deactivated kit should be removed from the table
             const kitsExists = await kitsQueuePage.hasKitRequests();

--- a/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-queue.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-queue.spec.ts
@@ -20,17 +20,6 @@ test.describe.serial('Kit Deactivation', () => {
       let shippingId: string;
       let kits: KitTypeEnum[];
 
-      switch (study) {
-        case StudyEnum.LMS:
-          kits = [KitTypeEnum.SALIVA, KitTypeEnum.BLOOD];
-          break;
-        case StudyEnum.RGP:
-          kits = [KitTypeEnum.BLOOD_AND_RNA, KitTypeEnum.BLOOD];
-          break;
-        default:
-          throw new Error(`Unhandled case of StudyEnum: ${study}`);
-      }
-
       const welcomePage = new WelcomePage(page);
       const navigation = new Navigation(page, request);
       await welcomePage.selectStudy(study);
@@ -42,6 +31,7 @@ test.describe.serial('Kit Deactivation', () => {
         kitsQueuePage = await navigation.selectFromSamples<KitsQueuePage>(SamplesNavEnum.QUEUE);
         await kitsQueuePage.waitForReady();
         kitsTable = kitsQueuePage.getKitsTable;
+        kits = await kitsQueuePage.getStudyKitTypes();
 
         // Deactivated all kit types for one randomly selected participant
         for (const kit of kits) {

--- a/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-queue.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/kit-deactivation-from-queue.spec.ts
@@ -44,7 +44,10 @@ test.describe.serial('Kit Deactivation', () => {
           if (rowCount > 0) {
             const rowIndex = await kitsTable.getRandomRowIndex();
             [shortId] = await kitsTable.getTextAt(rowIndex, 'Short ID');
+
             shippingId = await kitsQueuePage.deactivateKitFor({shortId});
+
+            await kitsQueuePage.reloadKit(kit);
 
             // Deactivated kit should be removed from the table
             const kitsExists = await kitsQueuePage.hasKitRequests();

--- a/playwright-e2e/tests/dsm/kitUploadFlow/saliva-kit-prefix-check.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/saliva-kit-prefix-check.spec.ts
@@ -131,7 +131,6 @@ test.describe.serial('Saliva Kit Upload with a Canadian or New York address', ()
         await kitsWithoutLabelPage.selectKitType(kitType);
         await kitsWithoutLabelPage.assertCreateLabelsBtn();
         await kitsWithoutLabelPage.assertReloadKitListBtn();
-        await kitsWithoutLabelPage.assertTableHeader();
 
         const kitsTable = kitsWithoutLabelPage.getKitsTable;
         await kitsTable.searchByColumn(KitsColumnsEnum.SHORT_ID, shortID);

--- a/playwright-e2e/tests/dsm/kitUploadFlow/saliva-kit-prefix-check.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/saliva-kit-prefix-check.spec.ts
@@ -132,9 +132,8 @@ test.describe.serial('Saliva Kit Upload with a Canadian or New York address', ()
         await kitsWithoutLabelPage.assertCreateLabelsBtn();
         await kitsWithoutLabelPage.assertReloadKitListBtn();
         await kitsWithoutLabelPage.assertTableHeader();
-        await kitsWithoutLabelPage.assertPageTitle();
 
-        const kitsTable = kitsWithoutLabelPage.kitsWithoutLabelTable;
+        const kitsTable = kitsWithoutLabelPage.getKitsTable;
         await kitsTable.searchByColumn(KitsColumnsEnum.SHORT_ID, shortID);
         await expect(kitsTable.rowLocator()).toHaveCount(1);
         shippingID = (await kitsTable.getRowText(0, KitsColumnsEnum.SHIPPING_ID)).trim();
@@ -148,7 +147,7 @@ test.describe.serial('Saliva Kit Upload with a Canadian or New York address', ()
       // New kit will be listed on Error page because address is in either Canada or New York
       await test.step('New kit will be listed on Error page', async () => {
         const errorPage = await navigation.selectFromSamples<ErrorPage>(SamplesNavEnum.ERROR);
-        const kitListTable = errorPage.kitListTable;
+        const kitListTable = errorPage.getKitsTable;
         await errorPage.waitForReady();
         await errorPage.selectKitType(kitType);
         await expect(async () => {
@@ -184,7 +183,7 @@ test.describe.serial('Saliva Kit Upload with a Canadian or New York address', ()
         const kitsWithoutLabelPage = await navigation.selectFromSamples<KitsWithoutLabelPage>(SamplesNavEnum.KITS_WITHOUT_LABELS);
         await kitsWithoutLabelPage.waitForReady();
         await kitsWithoutLabelPage.selectKitType(kitType);
-        const kitsTable = kitsWithoutLabelPage.kitsWithoutLabelTable;
+        const kitsTable = kitsWithoutLabelPage.getKitsTable;
         await kitsTable.searchByColumn(KitsColumnsEnum.SHORT_ID, shortID);
         await expect(kitsTable.rowLocator()).toHaveCount(0);
       });

--- a/playwright-e2e/tests/dsm/kitUploadFlow/saliva-kit-prefix-check.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/saliva-kit-prefix-check.spec.ts
@@ -71,6 +71,7 @@ test.describe.serial('Saliva Kit Upload with a Canadian or New York address', ()
   for (const [index, study] of studies.entries()) {
     test(`Kit prefix check @cmi @dsm @${study} @kit`, async ({ page }, testInfo) => {
       test.slow();
+
       const testResultDir = testInfo.outputDir;
 
       await welcomePage.selectStudy(study);
@@ -161,7 +162,7 @@ test.describe.serial('Saliva Kit Upload with a Canadian or New York address', ()
           // create label (previous step) could take some time
           await errorPage.reloadKitList();
           await expect(kitListTable.rows).toHaveCount(1, { timeout: 10 * 1000 });
-        }).toPass({ timeout: 90 * 1000 });
+        }).toPass({ timeout: 3 * 60 * 1000 });
       });
 
       await test.step('Initial scan', async () => {

--- a/playwright-e2e/tests/dsm/kitUploadFlow/saliva-kit-upload-flow.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/saliva-kit-upload-flow.spec.ts
@@ -119,7 +119,7 @@ test.describe.serial('Saliva Kits upload flow', () => {
       await kitsWithoutLabelPage.assertCreateLabelsBtn();
       await kitsWithoutLabelPage.assertReloadKitListBtn();
       await kitsWithoutLabelPage.assertTableHeader();
-      await kitsWithoutLabelPage.assertPageTitle();
+
       await kitsWithoutLabelPage.search(KitsColumnsEnum.SHORT_ID, shortID);
       const shippingID = (await kitsWithoutLabelPage.getData(KitsColumnsEnum.SHIPPING_ID)).trim();
 

--- a/playwright-e2e/tests/dsm/kitUploadFlow/saliva-kit-upload-flow.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/saliva-kit-upload-flow.spec.ts
@@ -91,7 +91,6 @@ test.describe.serial('Saliva Kits upload flow', () => {
       await kitsWithoutLabelPage.selectKitType(kitType);
       await kitsWithoutLabelPage.assertCreateLabelsBtn();
       await kitsWithoutLabelPage.assertReloadKitListBtn();
-      await kitsWithoutLabelPage.assertTableHeader();
       await kitsWithoutLabelPage.deactivateAllKitsFor(shortID);
 
       // Uploads kit
@@ -118,7 +117,6 @@ test.describe.serial('Saliva Kits upload flow', () => {
       await kitsWithoutLabelPage.selectKitType(kitType);
       await kitsWithoutLabelPage.assertCreateLabelsBtn();
       await kitsWithoutLabelPage.assertReloadKitListBtn();
-      await kitsWithoutLabelPage.assertTableHeader();
 
       await kitsWithoutLabelPage.search(KitsColumnsEnum.SHORT_ID, shortID);
       const shippingID = (await kitsWithoutLabelPage.getData(KitsColumnsEnum.SHIPPING_ID)).trim();

--- a/playwright-e2e/tests/dsm/medical-record-request.spec.ts
+++ b/playwright-e2e/tests/dsm/medical-record-request.spec.ts
@@ -29,8 +29,8 @@ test.describe.serial('Medical records request workflow', () => {
     'Boston Children\'s Hospital'
   ];
 
-  // Two CMI Clinical and two CMI Research studies
-  const studies: StudyEnum[] = [StudyEnum.MBC, StudyEnum.OSTEO2, StudyEnum.LMS, StudyEnum.PANCAN];
+  // One CMI Clinical and One CMI Research studies
+  const studies: StudyEnum[] = [StudyEnum.OSTEO2, StudyEnum.PANCAN];
 
   for (const study of studies) {
     test(`Update Institution @dsm @${study}`, async ({ page, request }) => {
@@ -73,6 +73,9 @@ test.describe.serial('Medical records request workflow', () => {
 
         const participantsCount = await participantListTable.numOfParticipants();
         expect(participantsCount).toBeGreaterThanOrEqual(1);
+        if (participantsCount >= 50) {
+          await participantListTable.changeRowCount(50);
+        }
 
         // Sort by Registration Date: newest first
         await participantListTable.sort(registrationDateColumn, SortOrder.ASC);

--- a/playwright-e2e/tests/dsm/multi-tabs.spec.ts
+++ b/playwright-e2e/tests/dsm/multi-tabs.spec.ts
@@ -17,7 +17,7 @@ const { DSM_USER_EMAIL, DSM_USER_PASSWORD } = process.env;
 
 test('Multiple browser tabs @dsm', async ({ browser, request }) => {
   const pancan = StudyEnum.PANCAN;
-  const brain = StudyEnum.BRAIN;
+  const angio = StudyEnum.ANGIO;
 
   // Create two pages in same browser
   const browserContext = await browser.newContext();
@@ -28,17 +28,17 @@ test('Multiple browser tabs @dsm', async ({ browser, request }) => {
   const pancanParticipantShortId = await findAnyParticipantShortId(pancanParticipantListPage);
   logInfo(`PanCan participant Short ID: ${pancanParticipantShortId}`);
 
-  // Tab B: Open Participant List page, realm matches expected study Brain
-  const brainPage = await browserContext.newPage();
-  const brainParticipantListPage = await logIntoStudy(brainPage, request, brain);
-  const brainParticipantShortId = await findAnyParticipantShortId(brainParticipantListPage);
-  logInfo(`Brain participant Short ID: ${brainParticipantShortId}`);
+  // Tab B: Open Participant List page, realm matches expected study angio
+  const angioPage = await browserContext.newPage();
+  const angioParticipantListPage = await logIntoStudy(angioPage, request, angio);
+  const angioParticipantShortId = await findAnyParticipantShortId(angioParticipantListPage);
+  logInfo(`angio participant Short ID: ${angioParticipantShortId}`);
 
   // Add new Onc History for study PanCan in tab A
   await addOncHistory(pancanPage, pancanParticipantListPage, pancan);
 
-  // Add new Onc History for study Brain in tab B
-  await addOncHistory(brainPage, brainParticipantListPage, brain);
+  // Add new Onc History for study angio in tab B
+  await addOncHistory(angioPage, angioParticipantListPage, angio);
 });
 
 async function findAnyParticipantShortId(participantListPage: ParticipantListPage): Promise<string> {
@@ -53,7 +53,7 @@ async function findAnyParticipantShortId(participantListPage: ParticipantListPag
     const searchPanel = participantListPage.filters.searchPanel;
     await searchPanel.open();
     await searchPanel.checkboxes('Status', { checkboxValues: ['Enrolled'] });
-    await searchPanel.checkboxes(oncHistoryRequestStatusColumn, { checkboxValues: ['Request'] });
+    // await searchPanel.checkboxes(oncHistoryRequestStatusColumn, { checkboxValues: ['Request'] });
     const filterListResponse = await searchPanel.search();
 
     const participantListTable = participantListPage.participantListTable;
@@ -85,6 +85,7 @@ async function addOncHistory(page: Page, participantListPage: ParticipantListPag
     const oncHistoryTab = await participantPage.clickTab<OncHistoryTab>(TabEnum.ONC_HISTORY);
     const oncHistoryTable = oncHistoryTab.table;
     const rowIndex = await oncHistoryTable.getRowsCount() - 1;
+    expect(rowIndex).toBeGreaterThanOrEqual(0);
     const cell = await oncHistoryTable.checkColumnAndCellValidity(OncHistoryInputColumnsEnum.DATE_OF_PX, rowIndex);
     const resp = await oncHistoryTable.fillDate(cell, {
       date: {

--- a/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
+++ b/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
@@ -597,7 +597,6 @@ async function prepareSentKit(shortID: string,
   if (await kitsWithoutLabelPage.hasKitRequests()) {
     await kitsWithoutLabelPage.assertCreateLabelsBtn();
     await kitsWithoutLabelPage.assertReloadKitListBtn();
-    await kitsWithoutLabelPage.assertTableHeader();
     await kitsWithoutLabelPage.deactivateAllKitsFor(shortID);
   }
 

--- a/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
+++ b/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
@@ -593,9 +593,8 @@ async function prepareSentKit(shortID: string,
   //Deactivate existing kits
   const kitsWithoutLabelPage = await navigation.selectFromSamples<KitsWithoutLabelPage>(SamplesNavEnum.KITS_WITHOUT_LABELS);
   await kitsWithoutLabelPage.waitForReady();
-  await kitsWithoutLabelPage.assertPageTitle();
   await kitsWithoutLabelPage.selectKitType(kitType);
-  if (await kitsWithoutLabelPage.hasExistingKitRequests()) {
+  if (await kitsWithoutLabelPage.hasKitRequests()) {
     await kitsWithoutLabelPage.assertCreateLabelsBtn();
     await kitsWithoutLabelPage.assertReloadKitListBtn();
     await kitsWithoutLabelPage.assertTableHeader();
@@ -639,12 +638,11 @@ async function prepareSentKit(shortID: string,
   await kitsWithoutLabelPage.selectKitType(kitType);
   await kitsWithoutLabelPage.assertCreateLabelsBtn();
   await kitsWithoutLabelPage.assertReloadKitListBtn();
-  await kitsWithoutLabelPage.assertPageTitle();
 
   await kitsWithoutLabelPage.search(KitsColumnsEnum.SHORT_ID, shortID);
   const shippingID = (await kitsWithoutLabelPage.getData(KitsColumnsEnum.SHIPPING_ID)).trim();
 
-  const kitsTable = kitsWithoutLabelPage.kitsWithoutLabelTable;
+  const kitsTable = kitsWithoutLabelPage.getKitsTable;
   await kitsTable.searchByColumn(KitsColumnsEnum.SHORT_ID, shortID);
   await expect(kitsTable.rowLocator()).toHaveCount(1);
 


### PR DESCRIPTION
Added three new tests:

1. `tests/dsm/kitUploadFlow/kit-deactivation-from-error.spec.ts`
2. `tests/dsm/kitUploadFlow/kit-deactivation-from-kits-without-label.spec.ts`
3. `tests/dsm/kitUploadFlow/kit-deactivation-from-queue.spec.ts`

Refactored to remove lots of duplicated code by creating new `dsm/pages/kits-page-base.ts` which all kits-* pages should extends from.