### PR TITLE
Update CI config for scheduled playwright test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -891,9 +891,9 @@ workflows:
         - not:
             - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         - not:
-            - equal: ["run-tests", << pipeline.parameters.api_call >>]
+            - equal: [ "run-tests", << pipeline.parameters.api_call >> ]
         - not:
-            - equal: ["run-e2e-tests", << pipeline.parameters.api_call >>]
+            - equal: [ "run-e2e-tests", << pipeline.parameters.api_call >> ]
     jobs:
       - api-unit-test:
           <<: *filter-develop-branch
@@ -1035,7 +1035,7 @@ workflows:
     when:
       and:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-        - equal: [ true, << pipeline.parameters.scheduled-playwright >> ]
+        - equal: << pipeline.parameters.scheduled-playwright >>
     jobs:
       - playwright-build:
           <<: *filter-develop-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -888,11 +888,11 @@ workflows:
       and:
         - not: << pipeline.parameters.do-builds >>
         - not:
-          and:
-            - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-            - equal: [ nightly-playwright-test, << pipeline.schedule.name >> ]
-            - equal: [ weekly-playwright-test, << pipeline.schedule.name >> ]
-            - << pipeline.parameters.scheduled-playwright >>
+            and:
+              - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+              - equal: [ nightly-playwright-test, << pipeline.schedule.name >> ]
+              - equal: [ weekly-playwright-test, << pipeline.schedule.name >> ]
+              - << pipeline.parameters.scheduled-playwright >>
     jobs:
       - api-unit-test:
           <<: *filter-develop-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -887,10 +887,9 @@ workflows:
     when:
       and:
         - not: << pipeline.parameters.do-builds >>
+        - not: << pipeline.parameters.scheduled-playwright >>
         - not:
             - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-        - not:
-            - << pipeline.parameters.scheduled-playwright >>
         - not:
             - equal: ["run-tests", << pipeline.parameters.api_call >>]
         - not:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -888,10 +888,6 @@ workflows:
       and:
         - not: << pipeline.parameters.do-builds >>
         - not: << pipeline.parameters.scheduled-playwright >>
-        - not:
-            - equal: [ "run-tests", << pipeline.parameters.api_call >> ]
-        - not:
-            - equal: [ "run-e2e-tests", << pipeline.parameters.api_call >> ]
     jobs:
       - api-unit-test:
           <<: *filter-develop-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -888,8 +888,13 @@ workflows:
       and:
         - not: << pipeline.parameters.do-builds >>
         - not:
-            and:
-              - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+            - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+        - not:
+            or:
+              - equal: ["run-tests", << pipeline.parameters.api_call >>]
+              - equal: ["run-e2e-tests", << pipeline.parameters.api_call >>]
+        - not:
+            or:         
               - equal: [ nightly-playwright-test, << pipeline.schedule.name >> ]
               - equal: [ weekly-playwright-test, << pipeline.schedule.name >> ]
               - << pipeline.parameters.scheduled-playwright >>
@@ -1034,8 +1039,10 @@ workflows:
     when:
       and:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-        - equal: [ nightly-playwright-test, << pipeline.schedule.name >> ]
         - << pipeline.parameters.scheduled-playwright >>
+        or:
+          - equal: [ weekly-playwright-test, << pipeline.schedule.name >> ]
+          - equal: [ nightly-playwright-test, << pipeline.schedule.name >> ]
     jobs:
       - playwright-build:
           <<: *filter-develop-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1040,9 +1040,9 @@ workflows:
       and:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         - << pipeline.parameters.scheduled-playwright >>
-        or:
-          - equal: [ weekly-playwright-test, << pipeline.schedule.name >> ]
-          - equal: [ nightly-playwright-test, << pipeline.schedule.name >> ]
+        - or:
+            - equal: [ weekly-playwright-test, << pipeline.schedule.name >> ]
+            - equal: [ nightly-playwright-test, << pipeline.schedule.name >> ]
     jobs:
       - playwright-build:
           <<: *filter-develop-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -890,14 +890,11 @@ workflows:
         - not:
             - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         - not:
-            or:
-              - equal: ["run-tests", << pipeline.parameters.api_call >>]
-              - equal: ["run-e2e-tests", << pipeline.parameters.api_call >>]
+            - equal: [ true, << pipeline.parameters.scheduled-playwright >> ]
         - not:
-            or:         
-              - equal: [ nightly-playwright-test, << pipeline.schedule.name >> ]
-              - equal: [ weekly-playwright-test, << pipeline.schedule.name >> ]
-              - << pipeline.parameters.scheduled-playwright >>
+            - equal: ["run-tests", << pipeline.parameters.api_call >>]
+        - not:
+            - equal: ["run-e2e-tests", << pipeline.parameters.api_call >>]
     jobs:
       - api-unit-test:
           <<: *filter-develop-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -888,10 +888,11 @@ workflows:
       and:
         - not: << pipeline.parameters.do-builds >>
         - not:
-          - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-          - equal: [ nightly-playwright-test, << pipeline.schedule.name >> ]
-          - equal: [ weekly-playwright-test, << pipeline.schedule.name >> ]
-          - << pipeline.parameters.scheduled-playwright >>
+          and:
+            - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+            - equal: [ nightly-playwright-test, << pipeline.schedule.name >> ]
+            - equal: [ weekly-playwright-test, << pipeline.schedule.name >> ]
+            - << pipeline.parameters.scheduled-playwright >>
     jobs:
       - api-unit-test:
           <<: *filter-develop-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -888,6 +888,10 @@ workflows:
       and:
         - not: << pipeline.parameters.do-builds >>
         - not: << pipeline.parameters.scheduled-playwright >>
+        - not:
+            - equal: [ "run-tests", << pipeline.parameters.api_call >> ]
+        - not:
+            - equal: [ "run-e2e-tests", << pipeline.parameters.api_call >> ]
     jobs:
       - api-unit-test:
           <<: *filter-develop-branch
@@ -1029,7 +1033,7 @@ workflows:
     when:
       and:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-        - equal: << pipeline.parameters.scheduled-playwright >>
+        - << pipeline.parameters.scheduled-playwright >>
     jobs:
       - playwright-build:
           <<: *filter-develop-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -888,6 +888,10 @@ workflows:
       and:
         - not: << pipeline.parameters.do-builds >>
         - not: << pipeline.parameters.scheduled-playwright >>
+        - not:
+            matches:
+              pattern: ".*-tests$"
+              value: << pipeline.parameters.api_call >>
     jobs:
       - api-unit-test:
           <<: *filter-develop-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1039,10 +1039,7 @@ workflows:
     when:
       and:
         - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-        - << pipeline.parameters.scheduled-playwright >>
-        - or:
-            - equal: [ weekly-playwright-test, << pipeline.schedule.name >> ]
-            - equal: [ nightly-playwright-test, << pipeline.schedule.name >> ]
+        - equal: [ true, << pipeline.parameters.scheduled-playwright >> ]
     jobs:
       - playwright-build:
           <<: *filter-develop-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -888,12 +888,6 @@ workflows:
       and:
         - not: << pipeline.parameters.do-builds >>
         - not: << pipeline.parameters.scheduled-playwright >>
-        - not:
-            - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
-        - not:
-            - equal: [ "run-tests", << pipeline.parameters.api_call >> ]
-        - not:
-            - equal: [ "run-e2e-tests", << pipeline.parameters.api_call >> ]
     jobs:
       - api-unit-test:
           <<: *filter-develop-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -883,11 +883,15 @@ workflows:
             - playwright-build
 
   build-and-deploy-all-apps-workflow:
-    # check all studies, launch GAE deploy if a study has changed.
+    # check all studies, launch GAE deploy only if a study has changed.
     when:
       and:
         - not: << pipeline.parameters.do-builds >>
-        - not: << pipeline.parameters.scheduled-playwright >>
+        - not:
+          - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
+          - equal: [ nightly-playwright-test, << pipeline.schedule.name >> ]
+          - equal: [ weekly-playwright-test, << pipeline.schedule.name >> ]
+          - << pipeline.parameters.scheduled-playwright >>
     jobs:
       - api-unit-test:
           <<: *filter-develop-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -890,7 +890,7 @@ workflows:
         - not:
             - equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
         - not:
-            - equal: [ true, << pipeline.parameters.scheduled-playwright >> ]
+            - << pipeline.parameters.scheduled-playwright >>
         - not:
             - equal: ["run-tests", << pipeline.parameters.api_call >>]
         - not:


### PR DESCRIPTION
Prevents `build-and-deploy-all-apps-workflow` from running at the time when launching `playwright-test-workflow` on `develop` branch by this CircleCI api call cmd:

```
./build-utils/run_ci.sh run-e2e-tests UNKNOWN develop test
```

<img width="756" alt="Screenshot 2023-12-06 at 3 16 31 PM" src="https://github.com/broadinstitute/ddp-angular/assets/35533885/6e144e1b-7197-405c-8745-f54302f109f1">
