### PR TITLE
[Playwright] Fix test func getGuidOfMostRecentAutomatedParticipant

### DIFF
--- a/playwright-e2e/dsm/component/tables/participant-list-table.ts
+++ b/playwright-e2e/dsm/component/tables/participant-list-table.ts
@@ -63,16 +63,19 @@ export class ParticipantListTable extends Table {
     * @returns the guid of the most recently registered playwright participant
   */
   public async getGuidOfMostRecentAutomatedParticipant(participantName: string, isRGPStudy?: boolean): Promise<string> {
-    //Select the columns to be used to help find the most recent automated participant
     const participantListPage = new ParticipantListPage(this.page);
-    await participantListPage.addColumnsToParticipantList('Participant Columns', ['Participant ID', 'Registration Date', 'First Name']);
+    const customizeViewPanel = participantListPage.filters.customizeViewPanel;
+    await customizeViewPanel.open();
 
     // Only RGP has a default filter with a different First Name field (in Participant Info Columns) - make sure to deselect it before continuing
     // otherwise there will be 2 different First Name fields in the search section (and in the Participant List)
     if (isRGPStudy) {
-      const customizeViewPanel = participantListPage.filters.customizeViewPanel;
       await customizeViewPanel.deselectColumns('Participant Info Columns', ['First Name']);
+      await expect(this.getHeaderByName('First Name')).not.toBeVisible();
     }
+    // Add columns to be used to help find the most recent automated participant
+    await customizeViewPanel.selectColumns('Participant Columns', ['Participant ID', 'Registration Date', 'First Name']);
+    await customizeViewPanel.close();
 
     //First filter the participant list to only show participants registered within the past two weeks
     const searchPanel = participantListPage.filters.searchPanel;

--- a/playwright-e2e/dsm/pages/participant-list-page.ts
+++ b/playwright-e2e/dsm/pages/participant-list-page.ts
@@ -179,13 +179,6 @@ export default class ParticipantListPage {
     expect(await participantsTable.rowsCount).toBe(resultsCount);
   }
 
-  public async addColumnsToParticipantList(columnGroup: string, columnOptions: string[]): Promise<void> {
-    const customizeViewPanel = this.filters.customizeViewPanel;
-    await customizeViewPanel.open();
-    await customizeViewPanel.selectColumns(columnGroup, columnOptions);
-  }
-
-
   /* Locators */
   private get tableRowsLocator(): Locator {
     return this.page.locator('[role="row"]:not([mat-header-row]):not(mat-header-row), tbody tr');

--- a/playwright-e2e/dsm/pages/participant-list-page.ts
+++ b/playwright-e2e/dsm/pages/participant-list-page.ts
@@ -10,6 +10,8 @@ import { Filters } from 'dsm/component/filters/filters';
 import { ParticipantListTable } from 'dsm/component/tables/participant-list-table';
 import { SortOrder } from 'dss/component/table';
 import QuickFilters from 'dsm/component/filters/quick-filters';
+import { getDate, offsetDaysFromToday } from 'utils/date-utils';
+import { AdditionalFilter } from 'dsm/component/filters/sections/search/search-enums';
 
 export default class ParticipantListPage {
   private readonly PAGE_TITLE: string = 'Participant List';
@@ -358,5 +360,42 @@ export default class ParticipantListPage {
       }
     }
     throw new Error(`Failed to find a suitable participant for ${columnGroup}: ${columnName} = "${value}" within max waiting time 90 seconds.`);
+  }
+
+
+  /**
+    * Returns the guid of the most recently created playwright participant
+    * @param isRGPStudy mark as true or false if this is being ran in RGP - parameter is only needed if method is ran in RGP study
+    * @returns the guid of the most recently registered playwright participant
+  */
+  public async getGuidOfMostRecentAutomatedParticipant(participantName: string, isRGPStudy?: boolean): Promise<string> {
+    const customizeViewPanel = this.filters.customizeViewPanel;
+    await customizeViewPanel.open();
+
+    // Only RGP has a default filter with a different First Name field (in Participant Info Columns) - make sure to deselect it before continuing
+    // otherwise there will be 2 different First Name fields in the search section (and in the Participant List)
+    if (isRGPStudy) {
+      await customizeViewPanel.deselectColumns('Participant Info Columns', ['First Name']);
+      await expect(this.participantListTable.getHeaderByName('First Name')).not.toBeVisible();
+    }
+    // Add columns to be used to help find the most recent automated participant
+    await customizeViewPanel.selectColumns('Participant Columns', ['Participant ID', 'Registration Date', 'First Name']);
+    await customizeViewPanel.close();
+
+    //First filter the participant list to only show participants registered within the past two weeks
+    const searchPanel = this.filters.searchPanel;
+    await searchPanel.open();
+    const today = getDate(new Date());
+    const previousWeek = offsetDaysFromToday(2 * 7);
+    await searchPanel.dates('Registration Date', { from: previousWeek, to: today, additionalFilters: [AdditionalFilter.RANGE] });
+
+    //Also make sure to conduct the search for participants with the given first name of the automated participant
+    await searchPanel.text('First Name', { textValue: participantName });
+    await searchPanel.search();
+
+    //Get the first returned participant to use for testing - and verify at least one participant is returned
+    const numberOfParticipants = await this.participantListTable.rowsCount;
+    expect(numberOfParticipants, `No recent test participants were found with the given first name: ${participantName}`).toBeGreaterThanOrEqual(1);
+    return this.participantListTable.getCellDataForColumn('Participant ID', 1);
   }
 }

--- a/playwright-e2e/tests/dsm/kitUploadFlow/blood-and-rna-kit-upload-flow.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/blood-and-rna-kit-upload-flow.spec.ts
@@ -53,7 +53,7 @@ test.describe('Blood & RNA Kit Upload', () => {
     await participantListPage.waitForReady();
 
     const participantListTable = new ParticipantListTable(page);
-    const participantGuid = await participantListTable.getGuidOfMostRecentAutomatedParticipant(user.patient.firstName, true);
+    const participantGuid = await participantListPage.getGuidOfMostRecentAutomatedParticipant(user.patient.firstName, true);
     saveParticipantGuid(participantGuid);
 
     await participantListPage.filterListByParticipantGUID(user.patient.participantGuid);

--- a/playwright-e2e/tests/rgp/dsm-family-enrollment.spec.ts
+++ b/playwright-e2e/tests/rgp/dsm-family-enrollment.spec.ts
@@ -32,13 +32,14 @@ test.describe.serial('DSM Family Enrollment Handling', () => {
     await participantListPage.waitForReady();
 
     //Get the most recent automated test participant (searches for up to a week ago)
-    const participantListTable = new ParticipantListTable(page);
-    const participantGuid = await participantListTable.getGuidOfMostRecentAutomatedParticipant(user.patient.firstName, true);
+    const participantGuid = await participantListPage.getGuidOfMostRecentAutomatedParticipant(user.patient.firstName, true);
     expect(participantGuid).toBeTruthy();
     saveParticipantGuid(participantGuid);
 
     //Filter the Participant List by the given guid
     await participantListPage.filterListByParticipantGUID(participantGuid);
+
+    const participantListTable = new ParticipantListTable(page);
     const participantPage: ParticipantPage = await participantListTable.openParticipantPageAt(0);
 
     const guid = await participantPage.getGuid();
@@ -99,13 +100,15 @@ test.describe.serial('DSM Family Enrollment Handling', () => {
     const participantListPage = await navigation.selectFromStudy<ParticipantListPage>(StudyNavEnum.PARTICIPANT_LIST);
     await participantListPage.assertPageTitle();
     await participantListPage.waitForReady();
-    const participantListTable = new ParticipantListTable(page);
-    const participantGuid = await participantListTable.getGuidOfMostRecentAutomatedParticipant(user.patient.firstName, true);
+
+    const participantGuid = await participantListPage.getGuidOfMostRecentAutomatedParticipant(user.patient.firstName, true);
     saveParticipantGuid(participantGuid);
     await participantListPage.filterListByParticipantGUID(user.patient.participantGuid);
     //Check that the filtered list returns at least one participant
     const filteredList = page.locator('tr.ng-star-inserted');
     await expect(filteredList).toHaveCount(1);
+
+    const participantListTable = new ParticipantListTable(page);
     await participantListTable.openParticipantPageAt(0);
 
     //Verify that the proband tab is present (and includes the text RGP and 3 as proband subject ids have the format RGP_{family id}_3)
@@ -536,11 +539,12 @@ test.describe.serial('DSM Family Enrollment Handling', () => {
     await participantListPage.waitForReady();
 
     //Get the most recent automated test participant (searches for up to a week ago)
-    const participantListTable = new ParticipantListTable(page);
-    const participantGuid = await participantListTable.getGuidOfMostRecentAutomatedParticipant(user.patient.firstName, true);
+    const participantGuid = await participantListPage.getGuidOfMostRecentAutomatedParticipant(user.patient.firstName, true);
     saveParticipantGuid(participantGuid);
 
     await participantListPage.filterListByParticipantGUID(user.patient.participantGuid);
+
+    const participantListTable = new ParticipantListTable(page);
     await participantListTable.openParticipantPageAt(0);
     const rgpParticipantPage = new RgpParticipantPage(page);
 
@@ -621,11 +625,12 @@ test.describe.serial('DSM Family Enrollment Handling', () => {
     await participantListPage.waitForReady();
 
     //Get the most recent automated test participant (searches for up to a week ago)
-    const participantListTable = new ParticipantListTable(page);
-    const participantGuid = await participantListTable.getGuidOfMostRecentAutomatedParticipant(user.patient.firstName, true);
+    const participantGuid = await participantListPage.getGuidOfMostRecentAutomatedParticipant(user.patient.firstName, true);
     saveParticipantGuid(participantGuid);
 
     await participantListPage.filterListByParticipantGUID(user.patient.participantGuid);
+
+    const participantListTable = new ParticipantListTable(page);
     await participantListTable.openParticipantPageAt(0);
 
     //Setup family members - for creation and comparison


### PR DESCRIPTION
Error relates to flaky `getGuidOfMostRecentAutomatedParticipant()` function:

```
Error: No recent test participants were found with the given first name: E2E

expect(received).toBeGreaterThanOrEqual(expected)

Expected: >= 1
Received:    0

   at dsm/component/tables/participant-list-table.ts:90

  88 |     //Get the first returned participant to use for testing - and verify at least one participant is returned
  89 |     const numberOfParticipants = await this.rowsCount;
> 90 |     expect(numberOfParticipants, `No recent test participants were found with the given first name: ${participantName}`).toBeGreaterThanOrEqual(1);
     |                                                                                                                          ^
  91 |     return this.getCellDataForColumn('Participant ID', 1);
  92 |   }
  93 |

    at ParticipantListTable.getGuidOfMostRecentAutomatedParticipant (/home/circleci/repo/playwright-e2e/dsm/component/tables/participant-list-table.ts:90:122)
    at /home/circleci/repo/playwright-e2e/tests/dsm/kitUploadFlow/blood-and-rna-kit-upload-flow.spec.ts:56:29
```