### PR TITLE
Playwright_LMS Germline test_Extend timeout from 30 seconds to a minute

### DIFF
--- a/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
+++ b/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
@@ -143,7 +143,7 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
         const participantListTable = participantListPage.participantListTable;
         const amountOfParticipants = await participantListTable.rowsCount;
         expect(amountOfParticipants).toBe(1);
-      }).toPass({intervals: [10_000], timeout: 30_000});
+      }).toPass({intervals: [10_000], timeout: 60_000});
 
       const participantListTable = participantListPage.participantListTable;
       const germlineInfo = (await participantListTable.getParticipantDataAt(0, 'GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created')).trim();
@@ -248,7 +248,7 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
         const participantListTable = participantListPage.participantListTable;
         const amountOfParticipants = await participantListTable.rowsCount;
         expect(amountOfParticipants).toBe(1);
-      }).toPass({intervals: [10_000], timeout: 30_000});
+      }).toPass({intervals: [10_000], timeout: 60_000});
 
       const participantListTable = participantListPage.participantListTable;
       const germlineInfo = (await participantListTable.getParticipantDataAt(0, 'GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created')).trim();
@@ -353,7 +353,7 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
         const participantListTable = participantListPage.participantListTable;
         const amountOfParticipants = await participantListTable.rowsCount;
         expect(amountOfParticipants).toBe(1);
-      }).toPass({intervals: [10_000], timeout: 30_000});
+      }).toPass({intervals: [10_000], timeout: 60_000});
 
       const participantListTable = participantListPage.participantListTable;
       const germlineInfo = (await participantListTable.getParticipantDataAt(0, 'GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created')).trim();
@@ -459,7 +459,7 @@ test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
         const participantListTable = participantListPage.participantListTable;
         const amountOfParticipants = await participantListTable.rowsCount;
         expect(amountOfParticipants).toBe(1);
-      }).toPass({intervals: [10_000], timeout: 30_000});
+      }).toPass({intervals: [10_000], timeout: 60_000});
 
       const participantListTable = participantListPage.participantListTable;
       const germlineInfo = (await participantListTable.getParticipantDataAt(0, 'GERMLINE_CONSENT_ADDENDUM_PEDIATRIC Survey Created')).trim();


### PR DESCRIPTION
Small PR to give the tests more time to search for germline activity being created - at least 1 test failure in the past seems to be because it looked every 10 seconds (for up to 30 seconds) - but germline activity creation date wasn't in DSM yet