### PR TITLE
Playwright_Adding tracking label for saliva kits

### DIFF
--- a/playwright-e2e/dsm/pages/kits-page-base.ts
+++ b/playwright-e2e/dsm/pages/kits-page-base.ts
@@ -97,6 +97,12 @@ export default abstract class KitsPageBase extends DsmPageBase {
   }
 
   public async deactivateAllKitsFor(shortId?: string): Promise<void> {
+    const hasKitRequests = await this.hasKitRequests();
+    if (!hasKitRequests) {
+      logInfo(`No kit requests available on the page`);
+      return;
+    }
+
     if (!shortId) {
       // Selects a random Short ID
       const rowIndex = await this.kitsTable.getRandomRowIndex();
@@ -107,7 +113,6 @@ export default abstract class KitsPageBase extends DsmPageBase {
     await this.kitsTable.searchByColumn(KitsColumnsEnum.SHORT_ID, shortId);
     await waitForNoSpinner(this.page);
 
-    const hasKitRequests = await this.hasKitRequests();
     if (hasKitRequests) {
       const kitsCount = await this.kitsTable.rowLocator().count();
       for (let i = 0; i < kitsCount; i++) {

--- a/playwright-e2e/dsm/pages/participant-list-page.ts
+++ b/playwright-e2e/dsm/pages/participant-list-page.ts
@@ -234,12 +234,14 @@ export default class ParticipantListPage extends DsmPageBase {
     await waitForNoSpinner(this.page);
   }
 
-  async findParticipantWithTab(opts: { findPediatricParticipant: boolean, tab?: TabEnum, rgpProbandTab?: boolean }): Promise<string> {
-    const { findPediatricParticipant = false, tab, rgpProbandTab = false } = opts;
+  async findParticipantWithTab(
+    opts: { findPediatricParticipant: boolean, tab?: TabEnum, rgpProbandTab?: boolean, uriString?: string }
+    ): Promise<string> {
+    const { findPediatricParticipant = false, tab, rgpProbandTab = false, uriString = '/ui/applyFilter' } = opts;
 
     const searchPanel = this.filters.searchPanel;
     await searchPanel.open();
-    const applyFilterResponse = await searchPanel.search({ uri: '/ui/applyFilter' });
+    const applyFilterResponse = await searchPanel.search({ uri: uriString });
 
     let foundShortID = '';
     let unformattedFirstName = '';

--- a/playwright-e2e/tests/dsm/kitUploadFlow/saliva-kit-prefix-check.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/saliva-kit-prefix-check.spec.ts
@@ -172,6 +172,14 @@ test.describe.serial('Saliva Kit Upload with a Canadian or New York address', ()
         await initialScanPage.save();
       });
 
+      await test.step('Tracking Scan', async () => {
+        const trackingScanPage = await navigation.selectFromSamples<TrackingScanPage>(SamplesNavEnum.TRACKING_SCAN);
+        await trackingScanPage.assertPageTitle();
+        const trackingLabel = `trackingLabel-${crypto.randomUUID().toString().substring(0, 10)}`;
+        await trackingScanPage.fillScanPairs([trackingLabel, kitLabel]);
+        await trackingScanPage.save();
+      });
+
       await test.step('Final scan', async () => {
         const finalScanPage = await navigation.selectFromSamples<FinalScanPage>(SamplesNavEnum.FINAL_SCAN);
         await finalScanPage.waitForReady();

--- a/playwright-e2e/tests/dsm/kitUploadFlow/saliva-kit-prefix-check.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/saliva-kit-prefix-check.spec.ts
@@ -19,6 +19,7 @@ import FinalScanPage from 'dsm/pages/scanner-pages/finalScan-page';
 import { WelcomePage } from 'dsm/pages/welcome-page';
 import { logInfo } from 'utils/log-utils';
 import InitialScanPage from 'dsm/pages/scanner-pages/initialScan-page';
+import TrackingScanPage from 'dsm/pages/scanner-pages/trackingScan-page';
 
 /**
  * Prefix check for Saliva kit with Canada and New York address for Osteo2

--- a/playwright-e2e/tests/dsm/kitUploadFlow/saliva-kit-prefix-check.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/saliva-kit-prefix-check.spec.ts
@@ -114,6 +114,11 @@ test.describe.serial('Saliva Kit Upload with a Canadian or New York address', ()
           await kitsWithoutLabelPage.selectKitType(kit);
           await kitsWithoutLabelPage.deactivateAllKitsFor(shortID);
         }
+
+        const kitErrorPage = await navigation.selectFromSamples<ErrorPage>(SamplesNavEnum.ERROR);
+        await kitErrorPage.waitForReady();
+        await kitErrorPage.selectKitType(kitType);
+        await kitErrorPage.deactivateAllKitsFor(shortID);
       });
 
       await test.step('Upload new saliva kit', async () => {

--- a/playwright-e2e/tests/dsm/kitUploadFlow/saliva-kit-upload-flow.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/saliva-kit-upload-flow.spec.ts
@@ -26,6 +26,7 @@ import KitsReceivedPage from 'dsm/pages/kitsInfo-pages/kitsReceived-page/kitsRec
 import {SampleTypesEnum} from 'dsm/pages/kitsInfo-pages/enums/sampleTypes-enum';
 import {getDate} from 'utils/date-utils';
 import {logInfo} from 'utils/log-utils';
+import TrackingScanPage from 'dsm/pages/scanner-pages/trackingScan-page';
 
 // don't run in parallel
 test.describe.serial('Saliva Kits upload flow', () => {
@@ -122,6 +123,13 @@ test.describe.serial('Saliva Kits upload flow', () => {
 
       await kitsWithoutLabelPage.search(KitsColumnsEnum.SHORT_ID, shortID);
       const shippingID = (await kitsWithoutLabelPage.getData(KitsColumnsEnum.SHIPPING_ID)).trim();
+
+      //Tracking Scan
+      const trackingScanPage = await navigation.selectFromSamples<TrackingScanPage>(SamplesNavEnum.TRACKING_SCAN);
+      await trackingScanPage.assertPageTitle();
+      const trackingLabel = `trackingLabel-${crypto.randomUUID().toString().substring(0, 10)}`;
+      await trackingScanPage.fillScanPairs([trackingLabel, kitLabel]);
+      await trackingScanPage.save();
 
       // Final scan
       const finalScanPage = await navigation.selectFromSamples<FinalScanPage>(SamplesNavEnum.FINAL_SCAN);

--- a/playwright-e2e/tests/dsm/kitUploadFlow/saliva-kit-upload-flow.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/saliva-kit-upload-flow.spec.ts
@@ -27,6 +27,7 @@ import {SampleTypesEnum} from 'dsm/pages/kitsInfo-pages/enums/sampleTypes-enum';
 import {getDate} from 'utils/date-utils';
 import {logInfo} from 'utils/log-utils';
 import TrackingScanPage from 'dsm/pages/scanner-pages/trackingScan-page';
+import ErrorPage from 'dsm/pages/samples/error-page';
 
 // don't run in parallel
 test.describe.serial('Saliva Kits upload flow', () => {
@@ -88,13 +89,18 @@ test.describe.serial('Saliva Kits upload flow', () => {
         kitUploadInfo.address.country = (await contactInformationTab.getCountry()) || kitUploadInfo.address.country;
       }
 
-      // deactivate all kits for the participant
+      // deactivate all kits for the participant (in both Kits w/o Label and Kit Error page)
       const kitsWithoutLabelPage = await navigation.selectFromSamples<KitsWithoutLabelPage>(SamplesNavEnum.KITS_WITHOUT_LABELS);
       await kitsWithoutLabelPage.waitForReady();
       await kitsWithoutLabelPage.selectKitType(kitType);
       await kitsWithoutLabelPage.assertCreateLabelsBtn();
       await kitsWithoutLabelPage.assertReloadKitListBtn();
       await kitsWithoutLabelPage.deactivateAllKitsFor(shortID);
+
+      const kitErrorPage = await navigation.selectFromSamples<ErrorPage>(SamplesNavEnum.ERROR);
+      await kitErrorPage.waitForReady();
+      await kitErrorPage.selectKitType(kitType);
+      await kitErrorPage.deactivateAllKitsFor(shortID);
 
       // Uploads kit
       const kitUploadPage = await navigation.selectFromSamples<KitUploadPage>(SamplesNavEnum.KIT_UPLOAD);

--- a/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
+++ b/playwright-e2e/tests/dsm/participant/participant-sending-sample-received-creates-germline-consent-addendum.spec.ts
@@ -28,6 +28,7 @@ import crypto from 'crypto';
 import { logInfo } from 'utils/log-utils';
 import { login } from 'authentication/auth-angio';
 import { waitForResponse } from 'utils/test-utils';
+import ErrorPage from 'dsm/pages/samples/error-page';
 
 test.describe.serial('Sending SAMPLE_RECEIVED event to DSS', () => {
   const studies = [StudyEnum.LMS]; //Only clinical (pecgs) studies get this event
@@ -604,6 +605,11 @@ async function prepareSentKit(shortID: string,
     await kitsWithoutLabelPage.assertReloadKitListBtn();
     await kitsWithoutLabelPage.deactivateAllKitsFor(shortID);
   }
+
+  const kitErrorPage = await navigation.selectFromSamples<ErrorPage>(SamplesNavEnum.ERROR);
+  await kitErrorPage.waitForReady();
+  await kitErrorPage.selectKitType(kitType);
+  await kitErrorPage.deactivateAllKitsFor(shortID);
 
   //Get first name and last name of the participant - Kit Upload checks that the names match the given short ids
   const participantListPage = await navigation.selectFromStudy<ParticipantListPage>(StudyNavEnum.PARTICIPANT_LIST);

--- a/playwright-e2e/tests/dsm/tissue-request/cmi-tissue-request.spec.ts
+++ b/playwright-e2e/tests/dsm/tissue-request/cmi-tissue-request.spec.ts
@@ -9,6 +9,7 @@ import { OncHistoryInputColumnsEnum, OncHistorySelectRequestEnum } from 'dsm/com
 import { expect } from '@playwright/test';
 import { getDate } from 'utils/date-utils';
 import { TissueDynamicFieldsEnum } from 'dsm/pages/tissue/enums/tissue-information-enum';
+import { logInfo } from 'utils/log-utils';
 
 test.describe('Tissue Request Flow', () => {
   const studies = [StudyEnum.PANCAN];
@@ -18,6 +19,7 @@ test.describe('Tissue Request Flow', () => {
       const participantListPage = await ParticipantListPage.goto(page, study, request);
       const customizeViewPanel = participantListPage.filters.customizeViewPanel;
       const searchPanel = participantListPage.filters.searchPanel;
+      let shortID = '';
 
       await test.step('Search for the right participant', async () => {
         await customizeViewPanel.open();
@@ -31,6 +33,13 @@ test.describe('Tissue Request Flow', () => {
         await searchPanel.dates('Onc History Created', { additionalFilters: [AdditionalFilter.EMPTY] });
         await searchPanel.text('Your Mailing Address *', { additionalFilters: [AdditionalFilter.NOT_EMPTY] });
 
+        await searchPanel.search();
+        shortID = await participantListPage.findParticipantWithTab(
+          { findPediatricParticipant: false, tab: TabEnum.ONC_HISTORY, uriString: 'ui/filterList'}
+        );
+        logInfo(`Short id: ${shortID}`);
+        await searchPanel.open();
+        await searchPanel.text('Short ID', { textValue: shortID });
         await searchPanel.search();
       })
 


### PR DESCRIPTION
This ticket: https://broadworkbench.atlassian.net/browse/PEPPER-1249 adds a tracking label requirement for saliva kits, so adding that to the tests - just need to add a few more (and run them locally to check to make sure)