### PR TITLE
Playwright_Take out reload method from Search page class

### DIFF
--- a/playwright-e2e/dsm/pages/samples/search-page.ts
+++ b/playwright-e2e/dsm/pages/samples/search-page.ts
@@ -78,12 +78,4 @@ export default class SearchPage extends KitsPageBase {
     await expect(saveDateButton).toBeVisible();
     await saveDateButton.click();
   }
-
-  /**
-   * Click Reload button
-   * @returns {Promise<void>}
-   */
-  async reload(): Promise<void> {
-    await this.page.locator('button', { hasText: 'Reload' }).click();
-  }
 }


### PR DESCRIPTION
turns out the reload line in the gp-collection-date-permissions-check.spec.ts was meant to use the method in the dsm page base class which just reloads the page (not clicks a reload button) - after running it - it passes 

(also made sure to check that that page indeed doesn't have that button - found a pic from a year ago in this ticket which seems to show that that page never had that button: https://broadworkbench.atlassian.net/browse/PEPPER-779)

other pw test failures seem to be due to easypost or fedex being wonky with label creation for kits - 1 was due to 2 tests trying to use the same kit (since rgp dev previously didn't have any other kits in kits w/o label - kits have been added now)