### PR TITLE
[Playwright] Flakey test due to async race condtion

### DIFF
--- a/playwright-e2e/dsm/component/tables/onc-history-table.ts
+++ b/playwright-e2e/dsm/component/tables/onc-history-table.ts
@@ -179,11 +179,11 @@ export default class OncHistoryTable extends Table {
     }
 
     if (currentValue !== actualValue) {
+      await textarea.fill(actualValue, false);
       const [resp] = await Promise.all([
         waitForResponse(this.page, { uri: 'patch' }),
-        textarea.fill(actualValue, false),
+        textarea.blur(),
       ]);
-      await textarea.blur();
       hasLookup && await this.lookup(lookupSelectIndex);
       return resp;
     }

--- a/playwright-e2e/dsm/component/tables/onc-history-table.ts
+++ b/playwright-e2e/dsm/component/tables/onc-history-table.ts
@@ -181,9 +181,9 @@ export default class OncHistoryTable extends Table {
     if (currentValue !== actualValue) {
       const [resp] = await Promise.all([
         waitForResponse(this.page, { uri: 'patch' }),
-        await textarea.fill(actualValue, false),
-        await textarea.blur()
+        textarea.fill(actualValue, false),
       ]);
+      await textarea.blur();
       hasLookup && await this.lookup(lookupSelectIndex);
       return resp;
     }

--- a/playwright-e2e/dsm/component/tables/onc-history-table.ts
+++ b/playwright-e2e/dsm/component/tables/onc-history-table.ts
@@ -179,11 +179,10 @@ export default class OncHistoryTable extends Table {
     }
 
     if (currentValue !== actualValue) {
+      const respPromise = waitForResponse(this.page, { uri: 'patch' });
       await textarea.fill(actualValue, false);
-      const [resp] = await Promise.all([
-        waitForResponse(this.page, { uri: 'patch' }),
-        textarea.blur(),
-      ]);
+      await textarea.blur();
+      const resp = await respPromise;
       hasLookup && await this.lookup(lookupSelectIndex);
       return resp;
     }

--- a/playwright-e2e/dsm/pages/kits-page-base.ts
+++ b/playwright-e2e/dsm/pages/kits-page-base.ts
@@ -176,10 +176,10 @@ export default abstract class KitsPageBase extends DsmPageBase {
     await expect(this.deactivateReasonBtn).toBeVisible();
 
     const reason = `testDeactivate-${new Date().getTime()}`;
+    await this.deactivateReasonInput.fill(reason);
     await Promise.all([
       waitForResponse(this.page, {uri: '/deactivateKit'}),
       waitForResponse(this.page, {uri: '/kitRequests'}),
-      this.deactivateReasonInput.fill(reason),
       this.deactivateReasonBtn.click(),
     ]);
 

--- a/playwright-e2e/dsm/pages/medical-records/medical-records-request-page.ts
+++ b/playwright-e2e/dsm/pages/medical-records/medical-records-request-page.ts
@@ -73,11 +73,11 @@ export default class MedicalRecordsRequestPage {
 
     const existingValue = await input.currentValue();
     if (existingValue !== value) {
+      await input.fill(value, { overwrite: true });
       await Promise.all([
         waitForResponse(this.page, { uri: 'patch' }),
-        input.fill(value, { overwrite: true }),
+        input.blur(),
       ]);
-      await input.blur();
     }
   }
 

--- a/playwright-e2e/dsm/pages/medical-records/medical-records-request-page.ts
+++ b/playwright-e2e/dsm/pages/medical-records/medical-records-request-page.ts
@@ -76,8 +76,8 @@ export default class MedicalRecordsRequestPage {
       await Promise.all([
         waitForResponse(this.page, { uri: 'patch' }),
         input.fill(value, { overwrite: true }),
-        input.blur()
       ]);
+      await input.blur();
     }
   }
 

--- a/playwright-e2e/dsm/pages/medical-records/medical-records-request-page.ts
+++ b/playwright-e2e/dsm/pages/medical-records/medical-records-request-page.ts
@@ -73,11 +73,10 @@ export default class MedicalRecordsRequestPage {
 
     const existingValue = await input.currentValue();
     if (existingValue !== value) {
+      const respPromise = waitForResponse(this.page, { uri: 'patch' });
       await input.fill(value, { overwrite: true });
-      await Promise.all([
-        waitForResponse(this.page, { uri: 'patch' }),
-        input.blur(),
-      ]);
+      await input.blur();
+      await respPromise;
     }
   }
 

--- a/playwright-e2e/dsm/pages/participant-page/rgp/family-member-tab.ts
+++ b/playwright-e2e/dsm/pages/participant-page/rgp/family-member-tab.ts
@@ -159,9 +159,8 @@ export default class FamilyMemberTab {
      */
     public async inputImportantNotes(notes: string): Promise<void> {
       const textarea = this.getImportantNotes();
-      await textarea.clear();
-      await textarea.fill(notes, false);
       const respPromise = waitForResponse(this.page, {uri: 'ui/patch'});
+      await textarea.fill(notes, false);
       await textarea.blur();
       await respPromise;
     }
@@ -180,9 +179,8 @@ export default class FamilyMemberTab {
      */
     public async inputProcessNotes(notes: string): Promise<void> {
       const textarea = this.getProcessNotes();
-      await textarea.clear();
-      await textarea.fill(notes, false);
       const respPromise = waitForResponse(this.page, {uri: 'ui/patch'});
+      await textarea.fill(notes, false);
       await textarea.blur();
       await respPromise;
     }
@@ -272,9 +270,8 @@ export default class FamilyMemberTab {
      */
     public async inputMixedRaceNotes(notes: string): Promise<void> {
       const textarea = this.getMixedRaceNotes();
-      await textarea.clear();
-      await textarea.fill(notes, false);
       const respPromise = waitForResponse(this.page, {uri: 'ui/patch'});
+      await textarea.fill(notes, false);
       await textarea.blur();
       await respPromise;
     }

--- a/playwright-e2e/dsm/pages/participant-page/rgp/family-member-tab.ts
+++ b/playwright-e2e/dsm/pages/participant-page/rgp/family-member-tab.ts
@@ -163,8 +163,8 @@ export default class FamilyMemberTab {
       await Promise.all([
         waitForResponse(this.page, {uri: 'ui/patch'}),
         textarea.fill(notes, false),
-        textarea.blur(),
       ]);
+      await textarea.blur();
     }
 
     /**
@@ -185,8 +185,8 @@ export default class FamilyMemberTab {
       await Promise.all([
         waitForResponse(this.page, {uri: 'ui/patch'}),
         textarea.fill(notes, false),
-        textarea.blur(),
       ]);
+      await textarea.blur();
     }
 
     /**
@@ -278,8 +278,8 @@ export default class FamilyMemberTab {
       await Promise.all([
         waitForResponse(this.page, {uri: 'ui/patch'}),
         textarea.fill(notes, false),
-        textarea.blur(),
       ]);
+      await textarea.blur();
     }
 
     /**

--- a/playwright-e2e/dsm/pages/participant-page/rgp/family-member-tab.ts
+++ b/playwright-e2e/dsm/pages/participant-page/rgp/family-member-tab.ts
@@ -161,10 +161,9 @@ export default class FamilyMemberTab {
       const textarea = this.getImportantNotes();
       await textarea.clear();
       await textarea.fill(notes, false);
-      await Promise.all([
-        waitForResponse(this.page, {uri: 'ui/patch'}),
-        textarea.blur(),
-      ]);
+      const respPromise = waitForResponse(this.page, {uri: 'ui/patch'});
+      await textarea.blur();
+      await respPromise;
     }
 
     /**
@@ -183,10 +182,9 @@ export default class FamilyMemberTab {
       const textarea = this.getProcessNotes();
       await textarea.clear();
       await textarea.fill(notes, false);
-      await Promise.all([
-        waitForResponse(this.page, {uri: 'ui/patch'}),
-        textarea.blur(),
-      ]);
+      const respPromise = waitForResponse(this.page, {uri: 'ui/patch'});
+      await textarea.blur();
+      await respPromise;
     }
 
     /**
@@ -276,10 +274,9 @@ export default class FamilyMemberTab {
       const textarea = this.getMixedRaceNotes();
       await textarea.clear();
       await textarea.fill(notes, false);
-      await Promise.all([
-        waitForResponse(this.page, {uri: 'ui/patch'}),
-        textarea.blur(),
-      ]);
+      const respPromise = waitForResponse(this.page, {uri: 'ui/patch'});
+      await textarea.blur();
+      await respPromise;
     }
 
     /**

--- a/playwright-e2e/dsm/pages/participant-page/rgp/family-member-tab.ts
+++ b/playwright-e2e/dsm/pages/participant-page/rgp/family-member-tab.ts
@@ -160,11 +160,11 @@ export default class FamilyMemberTab {
     public async inputImportantNotes(notes: string): Promise<void> {
       const textarea = this.getImportantNotes();
       await textarea.clear();
+      await textarea.fill(notes, false);
       await Promise.all([
         waitForResponse(this.page, {uri: 'ui/patch'}),
-        textarea.fill(notes, false),
+        textarea.blur(),
       ]);
-      await textarea.blur();
     }
 
     /**
@@ -182,11 +182,11 @@ export default class FamilyMemberTab {
     public async inputProcessNotes(notes: string): Promise<void> {
       const textarea = this.getProcessNotes();
       await textarea.clear();
+      await textarea.fill(notes, false);
       await Promise.all([
         waitForResponse(this.page, {uri: 'ui/patch'}),
-        textarea.fill(notes, false),
+        textarea.blur(),
       ]);
-      await textarea.blur();
     }
 
     /**
@@ -275,11 +275,11 @@ export default class FamilyMemberTab {
     public async inputMixedRaceNotes(notes: string): Promise<void> {
       const textarea = this.getMixedRaceNotes();
       await textarea.clear();
+      await textarea.fill(notes, false);
       await Promise.all([
         waitForResponse(this.page, {uri: 'ui/patch'}),
-        textarea.fill(notes, false),
+        textarea.blur(),
       ]);
-      await textarea.blur();
     }
 
     /**

--- a/playwright-e2e/dsm/pages/samples/search-page.ts
+++ b/playwright-e2e/dsm/pages/samples/search-page.ts
@@ -39,9 +39,9 @@ export default class SearchPage extends KitsPageBase {
     const select = new Select(this.page, { label: 'Search by Field', root: 'app-shipping-search' });
     await select.selectOption(searchField);
     const locator = this.page.locator('//div[button[normalize-space()="Search Kit"]]');
+    await locator.locator('//input').fill(value);
     await Promise.all([
       waitForResponse(this.page, {uri: '/ui/searchKit'}),
-      locator.locator('//input').fill(value),
       locator.locator('//button').click()
     ]);
     await waitForNoSpinner(this.page);

--- a/playwright-e2e/tests/rgp/dsm-family-enrollment.spec.ts
+++ b/playwright-e2e/tests/rgp/dsm-family-enrollment.spec.ts
@@ -15,6 +15,7 @@ import { v4 as uuid } from 'uuid';
 import ParticipantPage from 'dsm/pages/participant-page/participant-page';
 import { WelcomePage } from 'dsm/pages/welcome-page';
 import { StudyEnum } from 'dsm/component/navigation/enums/selectStudyNav-enum';
+import * as crypto from 'crypto';
 
 
 test.describe.serial('DSM Family Enrollment Handling', () => {

--- a/playwright-e2e/utils/test-utils.ts
+++ b/playwright-e2e/utils/test-utils.ts
@@ -1,5 +1,4 @@
 import { BrowserContext, Download, errors, expect, Locator, Page, Response } from '@playwright/test';
-import TimeoutError from '@playwright/test'
 import { StudyEnum } from 'dsm/component/navigation/enums/selectStudyNav-enum';
 import Input from 'dss/component/input';
 import Checkbox from 'dss/component/checkbox';


### PR DESCRIPTION
Fixing a race condition that caused the error below. It was a change included in my last PR. I did not see this problem because all tests have passed without any issue when I ran (many times) on localhost.

```
Error: TimeoutError: waiting for URI: ui/patch: Timeout exceeded

   at utils/test-utils.ts:54

  52 |   } catch (err) {
  53 |     if (err instanceof errors.TimeoutError) {
> 54 |       throw new Error(`TimeoutError: waiting for URI: ${uri}: Timeout exceeded`);
     |             ^
  55 |     }
  56 |     throw err;
  57 |   }

    at waitForResponse (/home/circleci/repo/playwright-e2e/utils/test-utils.ts:54:13)
    at FamilyMemberTab.inputImportantNotes (/home/circleci/repo/playwright-e2e/dsm/pages/participant-page/rgp/family-member-tab.ts:163:7)
    at /home/circleci/repo/playwright-e2e/tests/rgp/dsm-family-enrollment.spec.ts:169:5
```