### PR TITLE
[DSS] Minor update RGP kit upload Playwright test

### DIFF
--- a/playwright-e2e/tests/dsm/kitUploadFlow/rgp-blood-rna-kit-upload.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/rgp-blood-rna-kit-upload.spec.ts
@@ -175,8 +175,21 @@ test.describe('Blood & RNA Kit Upload', () => {
     //RGP final scan page - RNA labels must have the prefix 'RNA' (all caps)
     const finalScanPage = await navigation.selectFromSamples<RgpFinalScanPage>(SamplesNavEnum.RGP_FINAL_SCAN);
     const rnaNumber = crypto.randomUUID().toString().substring(0, 10);
-    const rnaLabel = `RNA${rnaNumber}`;
+
     await finalScanPage.assertPageTitle();
+
+    // No error should be visible
+    const pageError = page.locator('mat-error');
+    await expect(pageError).not.toBeVisible();
+
+    // An error is shown that the RNA label should start with "RNA"
+    const rnaInvalidLabel = `MA${rnaNumber}`;
+    await finalScanPage.fillScanTrio(kitLabel, rnaInvalidLabel, shippingID, 1);
+    // Check error text
+    await expect(pageError).toBeVisible();
+    expect(await pageError.innerText()).toStrictEqual('This barcode does not contain the “RNA” prefix');
+
+    const rnaLabel = `RNA${rnaNumber}`;
     await finalScanPage.fillScanTrio(kitLabel, rnaLabel, shippingID, 1);
     await finalScanPage.save();
 


### PR DESCRIPTION
[PEPPER-1278](https://broadworkbench.atlassian.net/browse/PEPPER-1278)

In RGP Final Scan page, enter the kit label, the shipping id from queue page and a label for rna, an error is shown that the RNA label should start with "RNA"

Also, renamed `blood-and-rna-kit-upload-flow.spec.ts` to `rgp-blood-rna-kit-upload.spec.ts`.

<img width="1042" alt="Screenshot 2024-02-15 at 4 31 28 PM" src="https://github.com/broadinstitute/ddp-angular/assets/35533885/295d5a53-408b-4e91-a210-5030bfc62937">



[PEPPER-1278]: https://broadworkbench.atlassian.net/browse/PEPPER-1278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ