### PR TITLE
[Playwright] Fix cmi-tissue-request.spec test

### DIFF
--- a/playwright-e2e/tests/dsm/tumor-collaborator-sample-id/participant-search.spec.ts
+++ b/playwright-e2e/tests/dsm/tumor-collaborator-sample-id/participant-search.spec.ts
@@ -50,12 +50,14 @@ test.describe.serial('Tumor Collaborator Sample ID', () => {
         await customizeViewPanel.deselectColumns(CustomViewColumns.PARTICIPANT, ['DDP', 'Last Name', 'First Name']);
         await customizeViewPanel.selectColumns(CustomViewColumns.DSM_COLUMNS, ['Onc History Created']);
         await customizeViewPanel.selectColumns(CustomViewColumns.MEDICAL_RECORD, ['MR Problem']);
+        await customizeViewPanel.selectColumns(CustomViewColumns.RESEARCH_CONSENT_FORM, ['CONSENT_BLOOD', 'CONSENT_TISSUE']);
 
         const searchPanel = participantListPage.filters.searchPanel;
         await searchPanel.open();
         await searchPanel.checkboxes('Status', { checkboxValues: ['Enrolled'] });
         await searchPanel.checkboxes('MR Problem', { checkboxValues: ['No'] });
-        // await searchPanel.dates('Onc History Created', { additionalFilters: [AdditionalFilter.EMPTY] });
+        await searchPanel.checkboxes('CONSENT_BLOOD', { checkboxValues: ['Yes'] });
+        await searchPanel.checkboxes('CONSENT_TISSUE', { checkboxValues: ['Yes'] });
         await searchPanel.search();
 
         const numParticipants = await participantListTable.numOfParticipants();
@@ -65,7 +67,11 @@ test.describe.serial('Tumor Collaborator Sample ID', () => {
 
       // Open Participant page
       await participantListTable.sort('Registration Date', SortOrder.ASC);
-      const row = 0;
+      const [row] = await participantListTable.randomizeRows();
+      const shortID = await participantListTable.getParticipantDataAt(row, 'Short ID');
+      expect(shortID?.length).toStrictEqual(6);
+      logInfo(`Participant Short ID: ${shortID}`);
+
       const participantPage: ParticipantPage = await participantListTable.openParticipantPageAt(row);
       const oncHistoryTab = await participantPage.clickTab<OncHistoryTab>(TabEnum.ONC_HISTORY);
       const oncHistoryTable = oncHistoryTab.table;


### PR DESCRIPTION
First test `cmi-tissue-request.spec.ts`: 

Test is not waiting long enough for the `Onc History Created` date field to be automatically populated.

```
Error: Onc History Date has not been updated

expect(received).toBeTruthy()

Received: ""

  58 |
  59 |         const oncHistoryCreatedDate = await participantPage.oncHistoryCreatedDate();
> 60 |         expect(oncHistoryCreatedDate, 'Onc History Date has not been updated').toBeTruthy();
     |                                                                                ^
  61 |       })
  62 |
  63 |       await participantPage.clickTab<OncHistoryTab>(TabEnum.ONC_HISTORY);

    at /home/circleci/repo/playwright-e2e/tests/dsm/tissue-request/cmi-tissue-request.spec.ts:60:80
    at /home/circleci/repo/playwright-e2e/tests/dsm/tissue-request/cmi-tissue-request.spec.ts:55:7
```

</hr>

Second test `tests/dsm/tumor-collaborator-sample-id/participant-search.spec.ts`:
PT has not consented to tissue or blood.

```
Error: Onc History Table - the column Facility doesn't exist

Timed out 30000ms waiting for expect(locator).toBeVisible()

Locator: locator('//table/thead/tr[1]/th[descendant-or-self::*[text()[normalize-space()=\'Facility\']]]')
Expected: visible
Received: hidden
Call log:
  - Onc History Table - the column Facility doesn't exist with timeout 30000ms
  - waiting for locator('//table/thead/tr[1]/th[descendant-or-self::*[text()[normalize-space()=\'Facility\']]]')


   at dsm/component/tables/onc-history-table.ts:285

  283 |     }
  284 |     await expect(column, `Onc History Table - the column ${columnName} doesn't exist`)
> 285 |       .toBeVisible();
      |        ^
  286 |
  287 |     const cell: Locator = this.td(columnName).nth(rowIndex);
  288 |     await expect(cell, `Kits Table - more than one or no column was found with the name ${columnName}`)

    at OncHistoryTable.checkColumnAndCellValidity (/home/circleci/repo/playwright-e2e/dsm/component/tables/onc-history-table.ts:285:8)
    at OncHistoryTable.fillField (/home/circleci/repo/playwright-e2e/dsm/component/tables/onc-history-table.ts:101:18)
    at /home/circleci/repo/playwright-e2e/tests/dsm/tumor-collaborator-sample-id/participant-search.spec.ts:76:9
    at /home/circleci/repo/playwright-e2e/tests/dsm/tumor-collaborator-sample-id/participant-search.spec.ts:75:7
 ```