### PR TITLE
[DSS] PEPPER-1366 Upgrade python runtime version to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,10 @@ references:
 
   # Note: important that values of guids and keys have matching order!"
   study_keys: &study_keys
-    "basil dsm-ui osteo brain angio mbc testboston mpc prion atcp rgp esc cgc circadia pancan brugada lms"
+    "basil dsm-ui osteo brain angio mbc testboston mpc prion atcp rgp esc cgc pancan brugada lms"
 
   study_guids: &study_guids
-    "basil NA CMI-OSTEO cmi-brain ANGIO cmi-mbc testboston cmi-mpc PRION atcp RGP cmi-esc cgc circadia cmi-pancan brugada cmi-lms"
+    "basil NA CMI-OSTEO cmi-brain ANGIO cmi-mbc testboston cmi-mpc PRION atcp RGP cmi-esc cgc cmi-pancan brugada cmi-lms"
 
   # Job runs for develop branch only
   filter-develop-branch: &filter-develop-branch
@@ -519,8 +519,6 @@ jobs:
       - conditionally-launch-build-and-store:
           study_key: cgc
       - conditionally-launch-build-and-store:
-          study_key: circadia
-      - conditionally-launch-build-and-store:
           study_key: pancan
       - conditionally-launch-build-and-store:
           study_key: brugada
@@ -799,7 +797,7 @@ workflows:
           matrix:
             alias: app-build
             parameters: &studies
-              study_key: [ dsm-ui, basil, osteo, brain, angio, mbc, testboston, mpc, prion, atcp, rgp, esc, cgc, circadia, pancan, brugada, lms ]
+              study_key: [ dsm-ui, basil, osteo, brain, angio, mbc, testboston, mpc, prion, atcp, rgp, esc, cgc, pancan, brugada, lms ]
           check_changed: true
           requires:
             - << matrix.study_key >>-ui-unit-test-pr
@@ -1013,9 +1011,6 @@ workflows:
       - deploy-stored-build-job:
           <<: *deploy_branch_filters
           study_key: cgc
-      - deploy-stored-build-job:
-          <<: *deploy_branch_filters
-          study_key: circadia
       - deploy-stored-build-job:
           <<: *deploy_branch_filters
           study_key: pancan

--- a/config/app.yaml.ctmpl
+++ b/config/app.yaml.ctmpl
@@ -4,7 +4,7 @@
 {{$study_guid := env "STUDY_GUID"}}
 
 service: {{$study}}
-runtime: python37
+runtime: python312
 
 # This setting will not matter except to prevent default automatic-scaling which prevents disabling
 # earlier versions of this service

--- a/ddp-workspace/projects/ddp-angio/app.yaml
+++ b/ddp-workspace/projects/ddp-angio/app.yaml
@@ -1,5 +1,5 @@
 service: angio
-runtime: python37
+runtime: python312
 
 # This setting will not matter except to prevent default automatic-scaling which prevents disabling
 # earlier versions of this service

--- a/ddp-workspace/projects/ddp-basil/app.yaml
+++ b/ddp-workspace/projects/ddp-basil/app.yaml
@@ -1,5 +1,5 @@
 service: basil
-runtime: python37
+runtime: python312
 
 # This setting will not matter except to prevent default automatic-scaling which prevents disabling
 # earlier versions of this service

--- a/ddp-workspace/projects/ddp-brain/app.yaml
+++ b/ddp-workspace/projects/ddp-brain/app.yaml
@@ -1,5 +1,5 @@
 service: brain
-runtime: python37
+runtime: python312
 
 # This setting will not matter except to prevent default automatic-scaling which prevents disabling
 # earlier versions of this service

--- a/ddp-workspace/projects/ddp-brugada/app.yaml
+++ b/ddp-workspace/projects/ddp-brugada/app.yaml
@@ -1,5 +1,5 @@
 service: brugada
-runtime: python37
+runtime: python312
 
 # This setting will not matter except to prevent default automatic-scaling which prevents disabling
 # earlier versions of this service

--- a/ddp-workspace/projects/ddp-cgc/app.yaml
+++ b/ddp-workspace/projects/ddp-cgc/app.yaml
@@ -1,5 +1,5 @@
 service: cgc
-runtime: python37
+runtime: python312
 
 # This setting will not matter except to prevent default automatic-scaling which prevents disabling
 # earlier versions of this service

--- a/ddp-workspace/projects/ddp-circadia/app.yaml
+++ b/ddp-workspace/projects/ddp-circadia/app.yaml
@@ -1,5 +1,5 @@
 service: circadia
-runtime: python37
+runtime: python312
 
 # This setting will not matter except to prevent default automatic-scaling which prevents disabling
 # earlier versions of this service

--- a/ddp-workspace/projects/ddp-dsm-ui/app.yaml
+++ b/ddp-workspace/projects/ddp-dsm-ui/app.yaml
@@ -1,5 +1,5 @@
 service: study-manager-ui
-runtime: python37
+runtime: python312
 
 # This setting will not matter except to prevent default automatic-scaling which prevents disabling
 # earlier versions of this service

--- a/ddp-workspace/projects/ddp-esc/app.yaml
+++ b/ddp-workspace/projects/ddp-esc/app.yaml
@@ -1,5 +1,5 @@
 service: esc
-runtime: python37
+runtime: python312
 
 # This setting will not matter except to prevent default automatic-scaling which prevents disabling
 # earlier versions of this service

--- a/ddp-workspace/projects/ddp-fon/app.yaml
+++ b/ddp-workspace/projects/ddp-fon/app.yaml
@@ -1,5 +1,5 @@
 service: fon
-runtime: python37
+runtime: python312
 
 # This setting will not matter except to prevent default automatic-scaling which prevents disabling
 # earlier versions of this service

--- a/ddp-workspace/projects/ddp-lms/app.yaml
+++ b/ddp-workspace/projects/ddp-lms/app.yaml
@@ -1,5 +1,5 @@
 service: lms
-runtime: python37
+runtime: python312
 
 # This setting will not matter except to prevent default automatic-scaling which prevents disabling
 # earlier versions of this service

--- a/ddp-workspace/projects/ddp-mbc/app.yaml
+++ b/ddp-workspace/projects/ddp-mbc/app.yaml
@@ -1,5 +1,5 @@
 service: mbc
-runtime: python37
+runtime: python312
 
 # This setting will not matter except to prevent default automatic-scaling which prevents disabling
 # earlier versions of this service

--- a/ddp-workspace/projects/ddp-mpc/app.yaml
+++ b/ddp-workspace/projects/ddp-mpc/app.yaml
@@ -1,5 +1,5 @@
 service: mpc
-runtime: python37
+runtime: python312
 
 # This setting will not matter except to prevent default automatic-scaling which prevents disabling
 # earlier versions of this service

--- a/ddp-workspace/projects/ddp-osteo/app.yaml
+++ b/ddp-workspace/projects/ddp-osteo/app.yaml
@@ -1,5 +1,5 @@
 service: osteo
-runtime: python37
+runtime: python312
 
 # This setting will not matter except to prevent default automatic-scaling which prevents disabling
 # earlier versions of this service

--- a/ddp-workspace/projects/ddp-pancan/app.yaml
+++ b/ddp-workspace/projects/ddp-pancan/app.yaml
@@ -1,5 +1,5 @@
 service: pancan
-runtime: python37
+runtime: python312
 
 # This setting will not matter except to prevent default automatic-scaling which prevents disabling
 # earlier versions of this service

--- a/ddp-workspace/projects/ddp-prion/app.yaml
+++ b/ddp-workspace/projects/ddp-prion/app.yaml
@@ -1,5 +1,5 @@
 service: prion
-runtime: python37
+runtime: python312
 
 # This setting will not matter except to prevent default automatic-scaling which prevents disabling
 # earlier versions of this service

--- a/ddp-workspace/projects/ddp-rarex/app.yaml
+++ b/ddp-workspace/projects/ddp-rarex/app.yaml
@@ -1,5 +1,5 @@
 service: rarex
-runtime: python37
+runtime: python312
 
 # This setting will not matter except to prevent default automatic-scaling which prevents disabling
 # earlier versions of this service

--- a/ddp-workspace/projects/ddp-rgp/app.yaml
+++ b/ddp-workspace/projects/ddp-rgp/app.yaml
@@ -1,5 +1,5 @@
 service: rgp
-runtime: python37
+runtime: python312
 
 # This setting will not matter except to prevent default automatic-scaling which prevents disabling
 # earlier versions of this service

--- a/ddp-workspace/projects/ddp-singular/app.yaml
+++ b/ddp-workspace/projects/ddp-singular/app.yaml
@@ -1,5 +1,5 @@
 service: singular
-runtime: python37
+runtime: python312
 
 # This setting will not matter except to prevent default automatic-scaling which prevents disabling
 # earlier versions of this service

--- a/ddp-workspace/projects/ddp-testboston/app.yaml
+++ b/ddp-workspace/projects/ddp-testboston/app.yaml
@@ -1,5 +1,5 @@
 service: testboston
-runtime: python37
+runtime: python312
 
 # This setting will not matter except to prevent default automatic-scaling which prevents disabling
 # earlier versions of this service

--- a/ddp-workspace/projects/sandbox-app/app.yaml
+++ b/ddp-workspace/projects/sandbox-app/app.yaml
@@ -1,5 +1,5 @@
 service: sandbox
-runtime: python37
+runtime: python312
 
 # This setting will not matter except to prevent default automatic-scaling which prevents disabling
 # earlier versions of this service


### PR DESCRIPTION
[PEPPER-1366](https://broadworkbench.atlassian.net/browse/PEPPER-1366)

gcloud app deploy encountered this error:  Runtime python37 is end of support and no longer allowed.

[PEPPER-1366]: https://broadworkbench.atlassian.net/browse/PEPPER-1366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ