### PR TITLE
[Playwright] Remove false errors from test logs

### DIFF
--- a/playwright-e2e/authentication/auth-base.ts
+++ b/playwright-e2e/authentication/auth-base.ts
@@ -19,12 +19,7 @@ export async function fillInEmailPassword(
   const passwordInput = page.locator('input[type="password"]').locator('visible=true');
   const notYourAcctLink = page.locator('.auth0-lock-alternative-link:has-text("Not your account")');
 
-  const timeout = 10000;
-  await Promise.race([
-    notYourAcctLink.waitFor({ state: 'visible' }),
-    emailInput.waitFor({ state: 'visible' }),
-    new Promise((_, reject) => setTimeout(() => reject(Error('Timeout Error: Fail to confirm Log in successful.')), timeout)),
-  ]);
+  await expect(emailInput.or(notYourAcctLink)).toBeVisible({timeout: 10000});
 
   try {
     const existLink = await notYourAcctLink.isVisible();

--- a/playwright-e2e/utils/test-utils.ts
+++ b/playwright-e2e/utils/test-utils.ts
@@ -18,22 +18,20 @@ const { SITE_PASSWORD } = process.env;
 
 export async function waitForNoSpinner(page: Page, opts: { timeout?: number } = {}): Promise<void> {
   const { timeout = 50 * 1000 } = opts;
+
   const spinner = page.locator('[data-icon="spinner"].fa-spin, mat-spinner[role="progressbar"]').first();
   const appError = page.locator('app-error-snackbar .snackbar-content').first();
+
   await page.waitForLoadState().catch((err) => logError(err));
-  const pageStatus = await Promise.race([
-    spinner.waitFor({ state: 'hidden' }).then(() => 'Ready'),
-    appError.waitFor({ state: 'visible' }).then(() => 'Error'),
-    new Promise((_, reject) => setTimeout(() => reject(Error('Time out waiting for loading spinner to stop or a app error.')), timeout)),
-  ]);
-  if (pageStatus === 'Ready') {
-    // Check again for app error after spinner stopped
-    const visible = await appError.isVisible();
-    if (visible) {
-      throw new Error(await appError.innerText());
-    }
+
+  const existsSpinner = await spinner.isVisible();
+  if (existsSpinner) {
+    await expect(spinner, 'Timeout exception: Encountered app loading spinner.').toBeHidden({timeout});
   }
-  if (pageStatus === 'Error') {
+
+  // App error popup normally displays after loading spinner has finished
+  const existError = await appError.isVisible();
+  if (existError) {
     throw new Error(await appError.innerText());
   }
 }


### PR DESCRIPTION
When using `Promise.race`, a rejected promise is logged as failed step in test log. It is very annoying and it can be misleading to someone who is new to Playwright test log.