### PR TITLE
Playwright_increased the timeout for the expect.toPass

### DIFF
--- a/playwright-e2e/tests/dsm/miscellaneous/participant-withdrawal.spec.ts
+++ b/playwright-e2e/tests/dsm/miscellaneous/participant-withdrawal.spec.ts
@@ -94,7 +94,7 @@ test.describe('Participants Withdrawal', () => {
           /// Status of participant should update to “Exited after enrollment” or “Exited before enrollment”
           const participantStatus = await participantsTable.findCell(Label.SHORT_ID, shortIdColumnId, Label.STATUS);
           await expect(participantStatus!).toContainText(/Exited (before|after) Enrollment/);
-        }).toPass({ timeout: 600000 }); //timeout currently changed to ~ 10 mins; previously 5 mins
+        }).toPass({ timeout: 10 * 60 * 1000 }); //timeout currently changed to ~ 10 mins; previously 5 mins
 
         // At Participant Page, verify few detail
         const participantPage: ParticipantPage = await participantsTable.openParticipantPageAt(0);

--- a/playwright-e2e/tests/dsm/miscellaneous/participant-withdrawal.spec.ts
+++ b/playwright-e2e/tests/dsm/miscellaneous/participant-withdrawal.spec.ts
@@ -94,7 +94,7 @@ test.describe('Participants Withdrawal', () => {
           /// Status of participant should update to “Exited after enrollment” or “Exited before enrollment”
           const participantStatus = await participantsTable.findCell(Label.SHORT_ID, shortIdColumnId, Label.STATUS);
           await expect(participantStatus!).toContainText(/Exited (before|after) Enrollment/);
-        }).toPass({ timeout: 600000 }); //timeout currently changed to ~ 10 mins
+        }).toPass({ timeout: 600000 }); //timeout currently changed to ~ 10 mins; previously 5 mins
 
         // At Participant Page, verify few detail
         const participantPage: ParticipantPage = await participantsTable.openParticipantPageAt(0);

--- a/playwright-e2e/tests/dsm/miscellaneous/participant-withdrawal.spec.ts
+++ b/playwright-e2e/tests/dsm/miscellaneous/participant-withdrawal.spec.ts
@@ -94,7 +94,7 @@ test.describe('Participants Withdrawal', () => {
           /// Status of participant should update to “Exited after enrollment” or “Exited before enrollment”
           const participantStatus = await participantsTable.findCell(Label.SHORT_ID, shortIdColumnId, Label.STATUS);
           await expect(participantStatus!).toContainText(/Exited (before|after) Enrollment/);
-        }).toPass({ timeout: 10 * 60 * 1000 }); //timeout currently changed to ~ 10 mins; previously 5 mins
+        }).toPass({ timeout: 20 * 60 * 1000 }); //timeout currently changed to ~ 20 mins; previously 5 mins
 
         // At Participant Page, verify few detail
         const participantPage: ParticipantPage = await participantsTable.openParticipantPageAt(0);

--- a/playwright-e2e/tests/dsm/miscellaneous/participant-withdrawal.spec.ts
+++ b/playwright-e2e/tests/dsm/miscellaneous/participant-withdrawal.spec.ts
@@ -94,7 +94,7 @@ test.describe('Participants Withdrawal', () => {
           /// Status of participant should update to “Exited after enrollment” or “Exited before enrollment”
           const participantStatus = await participantsTable.findCell(Label.SHORT_ID, shortIdColumnId, Label.STATUS);
           await expect(participantStatus!).toContainText(/Exited (before|after) Enrollment/);
-        }).toPass({ timeout: 5 * 60 * 1000 });
+        }).toPass({ timeout: 600000 }); //timeout currently changed to ~ 10 mins
 
         // At Participant Page, verify few detail
         const participantPage: ParticipantPage = await participantsTable.openParticipantPageAt(0);

--- a/playwright-e2e/tests/dsm/participant/participant-update-data.spec.ts
+++ b/playwright-e2e/tests/dsm/participant/participant-update-data.spec.ts
@@ -73,7 +73,7 @@ test.describe.serial('Editing Participant Information', () => {
           participantPage = await participantListTable.openParticipantPageAt(0);
           expect(await participantPage.getFirstName()).toEqual(newFirstName);
           expect(await participantPage.getLastName()).toEqual(newLastName);
-        }).toPass({ timeout: 5 * 60 * 1000 }); //currently changed to be ~ 5 mins; previously 3.5 mins
+        }).toPass({ timeout: 20 * 60 * 1000 }); //currently changed to be ~ 20 mins; previously 3.5 mins
       });
     });
   }

--- a/playwright-e2e/tests/dsm/participant/participant-update-data.spec.ts
+++ b/playwright-e2e/tests/dsm/participant/participant-update-data.spec.ts
@@ -73,7 +73,7 @@ test.describe.serial('Editing Participant Information', () => {
           participantPage = await participantListTable.openParticipantPageAt(0);
           expect(await participantPage.getFirstName()).toEqual(newFirstName);
           expect(await participantPage.getLastName()).toEqual(newLastName);
-        }).toPass({ timeout: 300000 }); //currently changed to be ~ 5 mins
+        }).toPass({ timeout: 300000 }); //currently changed to be ~ 5 mins; previously 3.5 mins
       });
     });
   }

--- a/playwright-e2e/tests/dsm/participant/participant-update-data.spec.ts
+++ b/playwright-e2e/tests/dsm/participant/participant-update-data.spec.ts
@@ -73,7 +73,7 @@ test.describe.serial('Editing Participant Information', () => {
           participantPage = await participantListTable.openParticipantPageAt(0);
           expect(await participantPage.getFirstName()).toEqual(newFirstName);
           expect(await participantPage.getLastName()).toEqual(newLastName);
-        }).toPass({ timeout: 300000 }); //currently changed to be ~ 5 mins; previously 3.5 mins
+        }).toPass({ timeout: 5 * 60 * 1000 }); //currently changed to be ~ 5 mins; previously 3.5 mins
       });
     });
   }

--- a/playwright-e2e/tests/dsm/participant/participant-update-data.spec.ts
+++ b/playwright-e2e/tests/dsm/participant/participant-update-data.spec.ts
@@ -73,7 +73,7 @@ test.describe.serial('Editing Participant Information', () => {
           participantPage = await participantListTable.openParticipantPageAt(0);
           expect(await participantPage.getFirstName()).toEqual(newFirstName);
           expect(await participantPage.getLastName()).toEqual(newLastName);
-        }).toPass({ timeout: 3.5 * 60 * 1000 });
+        }).toPass({ timeout: 300000 }); //currently changed to be ~ 5 mins
       });
     });
   }


### PR DESCRIPTION
increases the timeout for 2 tests:

- participant-withdrawal.spec.ts (5 mins -> 10 mins)
- participant-update-data.spec.ts (3.5 mins -> 5 mins)