### PR TITLE
Playwright CircleCI config improvement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -701,7 +701,7 @@ jobs:
               npx playwright test --list --project="dss" | grep -o 'tests/.*.spec.ts' | sort | uniq > e2e_tests.txt
             elif [ "<< parameters.test_suite >>" == "dsm" ]
             then
-              npx playwright test --list --project="dsm" | grep -o 'tests/.*.spec.ts' | sort | uniq > e2e_tests.txt
+              TEST_SLOW_MO=1000 npx playwright test --list --project="dsm" | grep -o 'tests/.*.spec.ts' | sort | uniq > e2e_tests.txt
             else
               npx playwright test --list | grep -o 'tests/.*.spec.ts' | sort | uniq > e2e_tests.txt
             fi
@@ -776,6 +776,9 @@ parameters:
   playwright_parallelism:
     type: integer
     default: 1
+  playwright_test_suite:
+    type: string
+    default: "UNKNOWN"
 
 workflows:
   version: 2
@@ -1035,6 +1038,6 @@ workflows:
           <<: *filter-develop-branch
           env: << pipeline.parameters.deploy_env >>
           parallelism_num: << pipeline.parameters.playwright_parallelism >>
-          test_suite: UNKNOWN
+          test_suite: << pipeline.parameters.playwright_test_suite >>
           requires:
             - playwright-build

--- a/playwright-e2e/playwright.config.ts
+++ b/playwright-e2e/playwright.config.ts
@@ -8,7 +8,7 @@ import path from 'path';
 import * as dotenv from 'dotenv';
 dotenv.config({ path: path.resolve(__dirname, '.env') });
 
-const { CI } = process.env;
+const { CI, TEST_SLOW_MO } = process.env;
 
 /**
  * Base Playwright TestConfig.
@@ -69,7 +69,7 @@ const testConfig: PlaywrightTestConfig = {
     browserName: 'chromium',
     headless: true,
     launchOptions: {
-      slowMo: 100,
+      slowMo: TEST_SLOW_MO ? parseInt(TEST_SLOW_MO) : 500,
       // Account for minor difference in text rendering and resolution between headless and headed mode
       ignoreDefaultArgs: ['--hide-scrollbars']
     },


### PR DESCRIPTION
Avoid flaky test failures due to slow DSM backend.
- For nightly schedule Playwright test run in CircleCI, run DSS and DSM tests separately at different time.
- Slowmo when run DSM tests in CircleCI