### PR TITLE
[PEPPER-1335] Fix osteo index reference

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
@@ -1801,7 +1801,7 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
             somaticConsentAddendumTumorAdult = consentAddendum?.questionsAnswers
               ?.find(({answer, stableId}) => stableId === 'SOMATIC_CONSENT_ADDENDUM_TUMOR' && answer);
 
-          } else if (this.participant.data.ddp?.toLowerCase() === 'cmi-osteo') {
+          } else if (this.participant.data.ddp?.toLowerCase().startsWith('cmi-osteo')) {
               somaticConsentAddendumTumorAdult = consentAddendum?.questionsAnswers
                 ?.find(({answer, stableId}) => stableId === 'SOMATIC_CONSENT_TUMOR' && answer);
           }


### PR DESCRIPTION
PEPPER-1335

There is a direct reference to the base name of the osteo index in this code. This is hacky but at this point making this more robust is out of scope for this release. This will fix the issue for now.

We could also have the code check for `cmi-osteo2` directly, but this seemed a bit more forgiving.