### PR TITLE
PEPPER-1332 add more remote logging to somatic file upload

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/phi-manifest/phi-manifest.component.spec.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/phi-manifest/phi-manifest.component.spec.ts
@@ -17,6 +17,7 @@ describe('Component: PhiManifestComponent', () => {
     const mockRoleService = jasmine.createSpyObj('RoleService', ['method1', 'method2']);
     const mockRouter = jasmine.createSpyObj('Router', ['navigate']);
     const mockLocalStorageService = jasmine.createSpyObj('LocalStorageService', ['getItem', 'setItem']);
+    const mockLoggingServiceSpy = jasmine.createSpyObj('LoggingService', ['logToCloud']);
 
     // Create a mock DSMService using the mock dependencies
     mockDSMService = new DSMService(
@@ -24,7 +25,8 @@ describe('Component: PhiManifestComponent', () => {
       mockSessionService,
       mockRoleService,
       mockRouter,
-      mockLocalStorageService
+      mockLocalStorageService,
+      mockLoggingServiceSpy
     );
 
     const auth = jasmine.createSpyObj('Auth', ['authenticated', 'sessionLogout']);

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dsm.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dsm.service.ts
@@ -23,7 +23,7 @@ import {SendToParticipantRequest} from '../sharedLearningUpload/interfaces/sendT
 import {AddUsersRequest, RemoveUsersRequest} from '../usersAndPermissions/interfaces/addRemoveUsers';
 import {EditUsers} from '../usersAndPermissions/interfaces/editUsers';
 import {EditUserRoles} from '../usersAndPermissions/interfaces/role';
-import {LoggingService} from "ddp-sdk";
+import {LoggingService} from 'ddp-sdk';
 
 declare var DDP_ENV: any;
 

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dsm.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dsm.service.ts
@@ -23,6 +23,7 @@ import {SendToParticipantRequest} from '../sharedLearningUpload/interfaces/sendT
 import {AddUsersRequest, RemoveUsersRequest} from '../usersAndPermissions/interfaces/addRemoveUsers';
 import {EditUsers} from '../usersAndPermissions/interfaces/editUsers';
 import {EditUserRoles} from '../usersAndPermissions/interfaces/role';
+import {LoggingService} from "ddp-sdk";
 
 declare var DDP_ENV: any;
 
@@ -39,7 +40,8 @@ export class DSMService {
                private sessionService: SessionService,
                private role: RoleService,
                private router: Router,
-              private localStorageService: LocalStorageService) {
+              private localStorageService: LocalStorageService,
+              private log: LoggingService) {
   }
 
   getDashboardData({startDate, endDate}: IDateRange, chartOrCount: StatisticsEnum): Observable<any> {
@@ -1216,6 +1218,7 @@ export class DSMService {
   }
 
   private handleError(error: any): Observable<any> {
+    this.log.logToCloud(error);
     return throwError(() => error);
   }
 

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/components/uploadFile/uploadFile.component.spec.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/components/uploadFile/uploadFile.component.spec.ts
@@ -1,5 +1,5 @@
 import {ComponentFixture, TestBed, waitForAsync} from '@angular/core/testing';
-import {ConfigurationService} from 'ddp-sdk';
+import {ConfigurationService, LoggingService} from 'ddp-sdk';
 import {MatTooltipModule} from '@angular/material/tooltip';
 import {RoleService} from '../../../services/role.service';
 import {DebugElement} from '@angular/core';
@@ -39,7 +39,7 @@ describe('UploadFileComponent', () => {
 
     spyOnProperty(roleService, 'allowUploadRorFile', 'get').and.returnValue(true);
 
-    const httpService = new SharedLearningsHTTPService({} as DSMService, sessionService);
+    const httpService = new SharedLearningsHTTPService({} as DSMService, sessionService, {} as LoggingService);
     spyOn(httpService, 'getSignedUrl')
       .and
       .returnValue(

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/services/sharedLearningsHTTP.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/services/sharedLearningsHTTP.service.ts
@@ -7,13 +7,15 @@ import {
   SomaticResultSignedUrlResponse
 } from '../interfaces/somaticResultSignedUrlRequest';
 import {SessionService} from '../../services/session.service';
+import {LoggingService} from "ddp-sdk";
 
 @Injectable()
 export class SharedLearningsHTTPService {
 
   constructor(
     private readonly dsmService: DSMService,
-    private readonly sessionService: SessionService
+    private readonly sessionService: SessionService,
+    private readonly log: LoggingService
   ) {}
 
   public getFiles(participantId: string): Observable<SomaticResultsFile[]> {
@@ -34,6 +36,7 @@ export class SharedLearningsHTTPService {
   }
 
   public upload(signedUrl: string, file: File): Observable<any> {
+    this.log.logToCloud(`Uploading file ${file} to url ${signedUrl}.`);
     return this.dsmService.uploadSomaticResultsFile(signedUrl, file);
   }
 

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/services/sharedLearningsHTTP.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/services/sharedLearningsHTTP.service.ts
@@ -7,7 +7,7 @@ import {
   SomaticResultSignedUrlResponse
 } from '../interfaces/somaticResultSignedUrlRequest';
 import {SessionService} from '../../services/session.service';
-import {LoggingService} from "ddp-sdk";
+import {LoggingService} from 'ddp-sdk';
 
 @Injectable()
 export class SharedLearningsHTTPService {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/services/sharedLearningsState.service.spec.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/services/sharedLearningsState.service.spec.ts
@@ -8,7 +8,7 @@ import {first} from 'rxjs/operators';
 import {expect} from '@angular/flex-layout/_private-utils/testing';
 import {HttpRequestStatusEnum} from '../enums/httpRequestStatus-enum';
 import {SomaticResultsFileVirusStatusEnum} from '../enums/somaticResultsFileVirusStatus-enum';
-import {LoggingService} from "ddp-sdk";
+import {LoggingService} from 'ddp-sdk';
 
 const testDocuments: any = [
   {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/services/sharedLearningsState.service.spec.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/services/sharedLearningsState.service.spec.ts
@@ -8,6 +8,7 @@ import {first} from 'rxjs/operators';
 import {expect} from '@angular/flex-layout/_private-utils/testing';
 import {HttpRequestStatusEnum} from '../enums/httpRequestStatus-enum';
 import {SomaticResultsFileVirusStatusEnum} from '../enums/somaticResultsFileVirusStatus-enum';
+import {LoggingService} from "ddp-sdk";
 
 const testDocuments: any = [
   {
@@ -58,7 +59,7 @@ describe('Shared Learnings State Service', () => {
     const sessionService = new SessionService();
     spyOnProperty(sessionService, 'selectedRealm', 'get').and.returnValue('test study');
 
-    const httpService = new SharedLearningsHTTPService({} as DSMService, sessionService);
+    const httpService = new SharedLearningsHTTPService({} as DSMService, sessionService, {} as LoggingService);
     spyOn(httpService, 'getFiles').and.returnValue(of(testDocuments));
     spyOn(httpService, 'getFile').and.returnValue(of(testDocuments[0]));
     spyOn(httpService, 'sendToParticipant').and.returnValue(of({data: 123}));


### PR DESCRIPTION
PEPPER-1332

While troubleshooting a somatic file upload error, it became clear that we are not doing any remote logging for somatic file uploads.  This is making it hard to troubleshoot via GCP logs.  This PR adds some remote logging for somatic file uploads, and also for DSMService errors in general.