### PR TITLE
Playwright_removing Germline Consent Status and Somatic Consent Status

### DIFF
--- a/playwright-e2e/dsm/enums.ts
+++ b/playwright-e2e/dsm/enums.ts
@@ -554,7 +554,7 @@ export enum Label {
   RESULTS = 'Results',
   RETURN_DATE = 'Return Date',
   SAMPLE_DEACTIVATION = 'Sample Deactivation',
-  SAMPLE_FFPE = 'Is the sample FFPE',
+  SAMPLE_FFPE = 'Is the sample FFPE?',
   SAMPLE_KIT_BARCODE = 'Sample kit barcode for genome study',
   SAMPLE_NOTES = 'Sample Notes',
   SAMPLE_RECEIVED = 'Sample Received',

--- a/playwright-e2e/tests/dsm/osteo/os2-display-verification.spec.ts
+++ b/playwright-e2e/tests/dsm/osteo/os2-display-verification.spec.ts
@@ -119,6 +119,7 @@ test.describe.serial(`${StudyName.OSTEO2}: Verify expected display of participan
       const quickFilters = participantListPage.quickFilters;
       await quickFilters.assertQuickFilterDisplayed(QuickFilter.MEDICAL_RECORDS_NOT_REQUESTED_YET);
       await quickFilters.assertQuickFilterDisplayed(QuickFilter.MEDICAL_RECORDS_NOT_RECEIVED_YET);
+      await quickFilters.assertQuickFilterDisplayed(QuickFilter.PAPER_CR_NEEDED);
       await quickFilters.assertQuickFilterDisplayed(QuickFilter.TISSUE_NEEDS_REVIEW);
       await quickFilters.assertQuickFilterDisplayed(QuickFilter.TISSUE_NOT_REQUESTED_YET);
       await quickFilters.assertQuickFilterDisplayed(QuickFilter.TISSUE_REQUESTED_NOT_RECEIVED_YET);

--- a/playwright-e2e/tests/dsm/osteo/os2-display-verification.spec.ts
+++ b/playwright-e2e/tests/dsm/osteo/os2-display-verification.spec.ts
@@ -164,7 +164,6 @@ test.describe.serial(`${StudyName.OSTEO2}: Verify expected display of participan
       await customizeViewPanel.openColumnGroup({ columnSection: CV.PARTICIPANT_DSM, stableID: ID.PARTICIPANT_DSM });
 
       await customizeViewPanel.assertColumnOptionDisplayed(CV.PARTICIPANT_DSM, ID.PARTICIPANT_DSM, Label.DATE_WITHDRAWN);
-      await customizeViewPanel.assertColumnOptionDisplayed(CV.PARTICIPANT_DSM, ID.PARTICIPANT_DSM, Label.GERMLINE_CONSENT_STATUS);
       await customizeViewPanel.assertColumnOptionDisplayed(CV.PARTICIPANT_DSM, ID.PARTICIPANT_DSM, Label.INCOMPLETE_OR_MINIMAL_MEDICAL_RECORDS);
       await customizeViewPanel.assertColumnOptionDisplayed(CV.PARTICIPANT_DSM, ID.PARTICIPANT_DSM, Label.MR_ASSIGNEE);
       await customizeViewPanel.assertColumnOptionDisplayed(CV.PARTICIPANT_DSM, ID.PARTICIPANT_DSM, Label.ONC_HISTORY_CREATED);
@@ -173,7 +172,6 @@ test.describe.serial(`${StudyName.OSTEO2}: Verify expected display of participan
       await customizeViewPanel.assertColumnOptionDisplayed(CV.PARTICIPANT_DSM, ID.PARTICIPANT_DSM, Label.PAPER_CR_SENT);
       await customizeViewPanel.assertColumnOptionDisplayed(CV.PARTICIPANT_DSM, ID.PARTICIPANT_DSM, Label.PARTICIPANT_NOTES);
       await customizeViewPanel.assertColumnOptionDisplayed(CV.PARTICIPANT_DSM, ID.PARTICIPANT_DSM, Label.READY_FOR_ABSTRACTION);
-      await customizeViewPanel.assertColumnOptionDisplayed(CV.PARTICIPANT_DSM, ID.PARTICIPANT_DSM, Label.SOMATIC_CONSENT_STATUS);
       await customizeViewPanel.assertColumnOptionDisplayed(CV.PARTICIPANT_DSM, ID.PARTICIPANT_DSM, Label.TISSUE_ASSIGNEE);
 
       await customizeViewPanel.closeColumnGroup({ columnSection: CV.PARTICIPANT_DSM, stableID: ID.PARTICIPANT_DSM });


### PR DESCRIPTION
those are not actually supposed to be there until PEPPER-1265 is done it seems. They are present in Test and Staging (with slightly different text) but not in Dev or Prod.

Will also add a check for the Paper C/R Needed quick filter