### PR TITLE
PEPPER-1453 add sadiqa to cmi site

### DIFF
--- a/ddp-workspace/projects/ddp-pancan/src/assets/i18n/en.json
+++ b/ddp-workspace/projects/ddp-pancan/src/assets/i18n/en.json
@@ -224,6 +224,7 @@
                         {
                             "Title": "Leadership",
                             "List": [
+                                "<b>Sadiqa Mahmood</b><br/>President",
                                 "<b>Diane Diehl</b><br/>Director, Scientific Operations",
                                 "<b>Taisha Hendrickson</b><br/>Director of Outreach, Engagement & Communications",
                                 "<b>Elana Anastasio</b><br/>Associate Director, Project Strategy and Development"

--- a/ddp-workspace/projects/ddp-pancan/src/assets/i18n/es.json
+++ b/ddp-workspace/projects/ddp-pancan/src/assets/i18n/es.json
@@ -223,6 +223,7 @@
                         {
                             "Title": "Liderazgo",
                             "List": [
+                                "<b>Sadiqa Mahmood</b><br/>Presidenta",
                                 "<b>Diane Diehl</b><br/>Directora, Operaciones Científicas",
                                 "<b>Taisha Hendrickson</b><br/>Directora de Comunicacion, Acercamiento e Involucramiento",
                                 "<b>Elana Anastasio</b><br/>Directora Asociada, Estrategia y Desarrollo del Proyecto"


### PR DESCRIPTION
Per PEPPER-1453, this adds Sadiqa to the CMI about us page.

The PR for a hotfix is [here](https://github.com/broadinstitute/ddp-angular/pull/2373).