### PR TITLE
PEPPER-1332 When an upload fails, recover cleanly

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/interceptors/Http-interceptor.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/interceptors/Http-interceptor.service.ts
@@ -11,12 +11,12 @@ import {Injectable} from '@angular/core';
 import {ErrorsService} from '../services/errors.service';
 import {Auth} from '../services/auth.service';
 
-// set this header on any request that you don't want processed
-// by this interceptor
-export const InterceptorSkipHeader = 'X-Skip-Interceptor';
-
 @Injectable()
 export class HttpInterceptorService implements HttpInterceptor {
+  // set this header on any request that you don't want processed
+  // by this interceptor
+  public static InterceptorSkipHeader = 'X-Skip-Interceptor';
+
   private readonly ignoreStatuses: number[] = [401];
 
   constructor(private readonly errorsService: ErrorsService,
@@ -25,7 +25,7 @@ export class HttpInterceptorService implements HttpInterceptor {
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     return next.handle(req).pipe(
       catchError((error: any) => {
-        if (!(req.headers.has(InterceptorSkipHeader))) {
+        if (!(req.headers.has(HttpInterceptorService.InterceptorSkipHeader))) {
           if (error instanceof HttpErrorResponse) {
             !this.ignoreStatuses.includes(error?.status) &&
             this.errorsService.openSnackbar(error);

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dsm.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dsm.service.ts
@@ -1215,7 +1215,6 @@ export class DSMService {
     );
   }
 
-  // todo arz make it break
   public logToCloud(payload: string, sev = 'INFO'): Observable<any> {
     const url =  `https://us-central1-${DDP_ENV.projectGcpId}.cloudfunctions.net/LoggingService`;
     const body = {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dsm.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dsm.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { JwtHelperService } from '@auth0/angular-jwt';
-import {throwError, Observable, of, tap} from 'rxjs';
+import { throwError, Observable, of, tap} from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { Filter } from '../filter-column/filter-column.model';
 import {Sort} from '../sort/sort.model';
@@ -23,12 +23,12 @@ import {SendToParticipantRequest} from '../sharedLearningUpload/interfaces/sendT
 import {AddUsersRequest, RemoveUsersRequest} from '../usersAndPermissions/interfaces/addRemoveUsers';
 import {EditUsers} from '../usersAndPermissions/interfaces/editUsers';
 import {EditUserRoles} from '../usersAndPermissions/interfaces/role';
-import { InterceptorSkipHeader} from '../interceptors/Http-interceptor.service';
 
 declare var DDP_ENV: any;
 
 @Injectable({providedIn: 'root'})
 export class DSMService {
+  private interceptorSkipHeader  = 'X-Skip-Interceptor';
   public static UI = 'ui/';
   public static REALM = 'realm';
   public static TARGET = 'target';
@@ -1228,7 +1228,8 @@ export class DSMService {
     return this.http.post(
       url,
       body,
-      { headers: new HttpHeaders({ 'Content-Type': 'application/json'}).set(InterceptorSkipHeader, 'true')
+      { headers: new HttpHeaders({ 'Content-Type': 'application/json'}).set(
+          this.interceptorSkipHeader, 'true')
            }).pipe(
       catchError((err: any) => {
         console.log('Error logging to cloud: ' + err);

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dsm.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dsm.service.ts
@@ -23,7 +23,7 @@ import {SendToParticipantRequest} from '../sharedLearningUpload/interfaces/sendT
 import {AddUsersRequest, RemoveUsersRequest} from '../usersAndPermissions/interfaces/addRemoveUsers';
 import {EditUsers} from '../usersAndPermissions/interfaces/editUsers';
 import {EditUserRoles} from '../usersAndPermissions/interfaces/role';
-import { InterceptorSkipHeader} from "../interceptors/Http-interceptor.service";
+import { InterceptorSkipHeader} from '../interceptors/Http-interceptor.service';
 
 declare var DDP_ENV: any;
 

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dsm.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/dsm.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { JwtHelperService } from '@auth0/angular-jwt';
-import { throwError, Observable} from 'rxjs';
+import {throwError, Observable, of} from 'rxjs';
 import { catchError } from 'rxjs/operators';
 import { Filter } from '../filter-column/filter-column.model';
 import {Sort} from '../sort/sort.model';
@@ -1215,7 +1215,8 @@ export class DSMService {
     );
   }
 
-  public logToCloud(payload: string, sev = 'INFO'): Observable<void> {
+  // todo arz make it break
+  public logToCloud(payload: string, sev = 'INFO'): Observable<any> {
     const url =  `https://us-central1-${DDP_ENV.projectGcpId}.cloudfunctions.net/LoggingService`;
     const body = {
       logName: 'study-manager-ui',
@@ -1229,7 +1230,10 @@ export class DSMService {
       url,
       body,
       { headers: new HttpHeaders({ 'Content-Type': 'application/json' }) }).pipe(
-      catchError(this.handleError.bind(this))
+      catchError((err: any) => {
+        console.log('Error logging to cloud: ' + err);
+        return of(null);
+      })
     );
   }
 

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/components/uploadFile/uploadFile.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/components/uploadFile/uploadFile.component.ts
@@ -16,7 +16,7 @@ import {HttpRequestStatusEnum} from '../../enums/httpRequestStatus-enum';
 import {HttpErrorResponse, HttpHeaders} from '@angular/common/http';
 import {SomaticResultsFile} from '../../interfaces/somaticResultsFile';
 import {RoleService} from '../../../services/role.service';
-import { InterceptorSkipHeader} from "../../../interceptors/Http-interceptor.service";
+import { InterceptorSkipHeader} from '../../../interceptors/Http-interceptor.service';
 
 @Component({
   selector: 'app-upload-files',
@@ -73,7 +73,7 @@ export class UploadFileComponent implements OnDestroy {
         .pipe(
           tap(signedUrlResponse => {
             somaticResultsFile = signedUrlResponse.somaticResultUpload;
-            const headers = new HttpHeaders().set(InterceptorSkipHeader,"true");
+            const headers = new HttpHeaders().set(InterceptorSkipHeader,'true');
             this.sharedLearningsHTTPService.upload(signedUrlResponse.signedUrl, selectedFile, headers).pipe(
               tap(uploadResponse => this.handleSuccess(somaticResultsFile)),
               catchError(err => {
@@ -83,14 +83,14 @@ export class UploadFileComponent implements OnDestroy {
                 this.sharedLearningsHTTPService.delete(somaticResultsFile.somaticDocumentId)
                   .pipe(
                     tap(deleteResponse => {
-                      console.log('Deleted ' + somaticResultsFile.somaticDocumentId)
+                      console.log('Deleted ' + somaticResultsFile.somaticDocumentId);
                       this.updateUploadButtonBy(HttpRequestStatusEnum.ERROR_RETRY);
                       return EMPTY;
                     }),
-                    catchError(err => {
-                      console.log('Error deleting ' + somaticResultsFile.somaticDocumentId + ': ' + JSON.stringify(err));
-                      this.handleError(err);
-                      return throwError(err);
+                    catchError(deleteErr => {
+                      console.log('Error deleting ' + somaticResultsFile.somaticDocumentId + ': ' + JSON.stringify(deleteErr));
+                      this.handleError(deleteErr);
+                      return throwError(deleteErr);
                     }),
                   ).subscribe();
                 return EMPTY;

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/components/uploadFile/uploadFile.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/components/uploadFile/uploadFile.component.ts
@@ -83,7 +83,8 @@ export class UploadFileComponent implements OnDestroy {
             // if there's an error storing the file, remove the file
             // and inform the user to retry
             this.sharedLearningsHTTPService.delete(somaticResultsFile.somaticDocumentId);
-            this.updateUploadButtonBy(HttpRequestStatusEnum.RETRY);
+            this.updateUploadButtonBy(HttpRequestStatusEnum.ERROR_RETRY);
+            console.log(error);
           }
         });
     }
@@ -119,7 +120,7 @@ export class UploadFileComponent implements OnDestroy {
   }
 
   public get shouldDisableButton(): boolean {
-    return !this.isFileSelected || this.uploadStatus === HttpRequestStatusEnum.SUCCESS || noConnectionToBucket;
+    return !this.isFileSelected || this.uploadStatus === HttpRequestStatusEnum.SUCCESS;
   }
 
   public get btnClass(): string {
@@ -202,6 +203,10 @@ export class UploadFileComponent implements OnDestroy {
       case  HttpRequestStatusEnum.RETRY:
         this.uploadStatus = HttpRequestStatusEnum.RETRY;
         this.uploadButtonText = UploadButtonText.UPLOAD_RETRY;
+        break;
+      case  HttpRequestStatusEnum.ERROR_RETRY:
+        this.uploadStatus = HttpRequestStatusEnum.ERROR_RETRY;
+        this.uploadButtonText = UploadButtonText.ERROR_RETRY;
         break;
       default:
         this.uploadStatus = HttpRequestStatusEnum.NONE;

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/components/uploadFile/uploadFile.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/components/uploadFile/uploadFile.component.ts
@@ -16,7 +16,6 @@ import {HttpRequestStatusEnum} from '../../enums/httpRequestStatus-enum';
 import {HttpErrorResponse, HttpHeaders} from '@angular/common/http';
 import {SomaticResultsFile} from '../../interfaces/somaticResultsFile';
 import {RoleService} from '../../../services/role.service';
-import { InterceptorSkipHeader} from '../../../interceptors/Http-interceptor.service';
 
 @Component({
   selector: 'app-upload-files',
@@ -25,6 +24,7 @@ import { InterceptorSkipHeader} from '../../../interceptors/Http-interceptor.ser
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class UploadFileComponent implements OnDestroy {
+  private interceptorSkipHeader  = 'X-Skip-Interceptor';
   private readonly NO_FILE = 'No File';
   private readonly MAX_FILE_SIZE = 30000000;
   private readonly MAX_FILE_NAME_LENGTH = 255;
@@ -73,7 +73,7 @@ export class UploadFileComponent implements OnDestroy {
         .pipe(
           tap(signedUrlResponse => {
             somaticResultsFile = signedUrlResponse.somaticResultUpload;
-            const headers = new HttpHeaders().set(InterceptorSkipHeader,'true');
+            const headers = new HttpHeaders().set(this.interceptorSkipHeader,'true');
             this.sharedLearningsHTTPService.upload(signedUrlResponse.signedUrl, selectedFile, headers).pipe(
               tap(uploadResponse => this.handleSuccess(somaticResultsFile)),
               catchError(err => {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/enums/httpRequestStatus-enum.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/enums/httpRequestStatus-enum.ts
@@ -3,5 +3,6 @@ export enum HttpRequestStatusEnum {
   SUCCESS = 'SUCCESS',
   FAIL = 'FAIL',
   IN_PROGRESS = 'IN_PROGRESS',
-  RETRY = 'RETRY'
+  RETRY = 'RETRY',
+  ERROR_RETRY = 'ERROR_RETRY'
 }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/enums/uploadButtonText-enum.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/enums/uploadButtonText-enum.ts
@@ -5,5 +5,6 @@ export enum UploadButtonText {
   UPLOAD_IN_PROGRESS = 'Uploading...',
   UPLOAD_RETRY = 'Retry',
   FILE_SIZE_TOO_LARGE = 'Too large size',
-  FILE_NAME_TOO_LARGE = 'Too long name'
+  FILE_NAME_TOO_LARGE = 'Too long name',
+  ERROR_RETRY = 'Error, please retry'
 }

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/services/sharedLearningsHTTP.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/services/sharedLearningsHTTP.service.ts
@@ -7,7 +7,7 @@ import {
   SomaticResultSignedUrlResponse
 } from '../interfaces/somaticResultSignedUrlRequest';
 import {SessionService} from '../../services/session.service';
-import {HttpHeaders} from "@angular/common/http";
+import {HttpHeaders} from '@angular/common/http';
 
 @Injectable()
 export class SharedLearningsHTTPService {

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/services/sharedLearningsHTTP.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/sharedLearningUpload/services/sharedLearningsHTTP.service.ts
@@ -7,6 +7,7 @@ import {
   SomaticResultSignedUrlResponse
 } from '../interfaces/somaticResultSignedUrlRequest';
 import {SessionService} from '../../services/session.service';
+import {HttpHeaders} from "@angular/common/http";
 
 @Injectable()
 export class SharedLearningsHTTPService {
@@ -33,16 +34,13 @@ export class SharedLearningsHTTPService {
     return this.dsmService.getSomaticResultsFileUploadSignedUrl(this.selectedRealm, participantId, fileInformation);
   }
 
-  public upload(signedUrl: string, file: File): Observable<any> {
+  public upload(signedUrl: string, file: File, headers?: HttpHeaders): Observable<any> {
     this.dsmService.logToCloud(`Uploading file ${file.name} to url ${signedUrl}.`).subscribe({
-      next: data => {
-        console.log('logged upload');
-      },
       error: err => {
-        console.log('error logging upload ' + err);
+        console.error('error logging upload ' + err);
       }
     });
-    return this.dsmService.uploadSomaticResultsFile(signedUrl, file);
+    return this.dsmService.uploadSomaticResultsFile(signedUrl, file, headers);
   }
 
   public sendToParticipant(participantId: string, somaticDocumentId: number): Observable<object> {


### PR DESCRIPTION
Investigation of a recent upload failure (PEPPER-1332) uncovered that when the browser can't reach GCP logging or storage as a result of client-side networking issues, the user experience gets pretty ugly and we get called in for support to clean up messy data.  This PR changes the behavior in this situation so that when the browser fails to write the bytes to the signed URL, the following happens:

* the big red box isn't displayed ([see here](https://github.com/broadinstitute/ddp-angular/pull/2376/files#r1595275141))
* the upload record is [soft deleted from the database](https://github.com/broadinstitute/ddp-angular/pull/2376/files#r1595278152) (thankfully, an existing service can be used to do this, although [there's a small backed PR here as well](https://github.com/broadinstitute/ddp-study-server/pull/2870))
*  the user is instructed to [retry the upload](https://github.com/broadinstitute/ddp-angular/pull/2376/files#r1595279345) via different text in the upload button.
* the endless spinning wheel is gone and the table of uploaded files does not show the failed attempt

The big red error box shows up with basically *any* abnormal http response as a result of a global http intercepter, but now callers can bypass this by setting a header that instructs the error box to ignore an error, giving calling code better ability to do error handling.

Simulating the networking failure that we saw when reviewing this ticket was done locally using the built-in "block request" feature in chrome dev tools.