### PR TITLE
PEPPER-1458 added a custom data-ddp-test attribute (consistent with o…

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/onc-history-detail/onc-history-detail.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/onc-history-detail/onc-history-detail.component.html
@@ -70,7 +70,7 @@
           <app-field-datepicker [dateString]="oncHis.datePx" [showTodayButton]="false" [allowUnknownDay]="true"
                                 [disabled]="!editable || participantExited"
                                 (dateChanged)="valueChanged($event, 'datePx', i)"
-                                [colorDuringPatch]="isPatchedCurrently('datePx', i)"></app-field-datepicker>
+                                [colorDuringPatch]="isPatchedCurrently('datePx', i)" [attr.data-ddp-test]="'pxDate-' + oncHis.oncHistoryDetailId" ></app-field-datepicker>
         </td>
         <td>
           <app-lookup [lookupValue]="oncHis.typePx" [lookupType]="'tType'" [multiLineInput]="true"


### PR DESCRIPTION
For PEPPER-1458, added a custom `data-ddp-test` attribute (consistent with our dss frontend attribute) for easier PW selectors.  In some places, creating a selector based on existing attributes and structure is hard/fragile, so we can add these custom attributes to help keep our PW tests clean.  Many server-side generated widgets in surveys in DSS autogenerate `data-ddp-test` attributes with various stable ids, and that has been a useful pattern.

This is a PR-off-the-PR that I wanted to share with folks after a pair programming session with Kiara.