### PR TITLE
 [DSM] PEPPER-1468,fix for selecting tissue additional fields breaking participant list

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/utils/dynamic-value-util.model.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/utils/dynamic-value-util.model.ts
@@ -41,7 +41,7 @@ export class DynamicValueUtilModel{
   }
 
   public static isObjectEmpty(obj: Object): boolean {
-    return Object.keys(obj).length === 0;
+    return obj && Object.keys(obj).length === 0;
   }
 
 }


### PR DESCRIPTION
This PR fixed the save current view and participant list broken. The reason for the bug was an NPE in `isObjectEmpty` that only shows up when participant has onc histories but no tissues. 