### PR TITLE
PEPPER-1407 include http response body in error modal

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/Shared/components/errorsHistory-snackbar/errorsHistory-snackbar.component.html
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/Shared/components/errorsHistory-snackbar/errorsHistory-snackbar.component.html
@@ -23,7 +23,7 @@
   <div class="option-selected"
        *ngIf="httpErrorSelectionList.selectedOptions.hasValue() && httpErrorSelectionList.selectedOptions.selected[0].value as errorResponse">
     <div class="option-selected-data">
-      <p>Message: <span>{{errorResponse.message }}</span></p>
+      <p>Message: <span>{{errorResponse.error}}</span></p>
       <p>Status Code: <span>{{errorResponse.status}}</span></p>
       <p>Status Text: <span>{{errorResponse.statusText}}</span></p>
     </div>


### PR DESCRIPTION
PEPPER-1407. Changed error modal to use the error field instead of the…message field, since the values in the message are already shown in other places in the modal, and the error message, which is the body of the http response from the server, is what we want to show to users.

What it was:

![Screenshot 2024-05-31 at 8 49 07 AM](https://github.com/broadinstitute/ddp-angular/assets/1653048/70ccdbc6-e054-4845-8784-32e187700de5)

Note that the URL, status code, URL, and status text are already shown in multiple places.

In the new version, you can still find URL, status code, and status text, but BONUS!  You can also see the error message, which corresponds to the body of the http response.

![Screenshot 2024-05-31 at 8 50 57 AM](https://github.com/broadinstitute/ddp-angular/assets/1653048/a966f480-ee17-4498-a0ab-0ebd5d760de7)
