### PR TITLE
PEPPER-1418 Fix for double login.

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/services/auth.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/services/auth.service.ts
@@ -171,8 +171,7 @@ export class Auth implements OnDestroy {
   public buildHeaders(): any {
     const headers = new HttpHeaders({
       'Content-Type': 'application/json',
-      Accept: 'application/json',
-      Authorization: this.sessionService.getAuthBearerHeaderValue()
+      Accept: 'application/json'
     });
     return {headers, withCredentials: true};
   }


### PR DESCRIPTION
Although PEPPER-1418 started off as just an investigation, I just couldn't stop myself from making a fix.  There are a number of other things that could be improved along the way, but I am being as surgical as possible.

The double login happens when tokens expire because the frontend does not fully wipe out the token when it detects that it has expired.  During the first auth attempt, after the frontend recognizes that a token has expired, after the user has authenticated, the frontend **includes the known stale dsm_token as a `Bearer` header** to the `/ui/auth0` route.  Under normal operation, this auth route checks the auth0 token in the payload (which is separate from the `dsm_token` in the header) and returns the augmented token that becomes `dsm_token`.  Notably, the `/ui/auth0` route does not require a Bearer token, and in fact DSMServer explicitly bypasses the auth filter--which is good, since `ui/auth0` should only be checking the auth0 token in the payload.

Unfortunately, the LoggingFilter in the backend actually **validates** the token before logging it, and that's where the problems start.  In the process of validating the token during logging, the `/ui/auth0` route bails with a 401, since the token in the header is the expired `dsm_token` from the frontend.  The frontend then catches the error, finally wiping out the known-expired `dsm_token`, and prompts the user to login again.  This time, when the auth token is posted to the `/ui/auth0` route the second time, it does so with a blank Authorization header, and the LoggingFilter does not attempt to validate the token in the header because it's empty.

The frontend caches some values and doesn't evaluate whether a token has expired in a consistent manner.  One approach I decided against was an extensive rewrite of the auth code in the frontend to check for token validity on-the-fly, by re-reading the token from storage, and adding a timer job to periodically check the validity of the token instead of waiting for server-side operations to trigger a check.  I decided against this because it's a big lift.

Another approach would have been to just change the logging filter so that it parses and logs token information, but without validating it.  I ruled this approach out because the logging filter has been around for a long time, and changing this behavior may accidentally make the backend less secure if this incidental validation is actually catching an auth issue that might otherwise be missed.

I confirmed that this works by replacing `dsm_token` and `auth_token` values in browser local storage with expired tokens, and watching what happens during login.  First, I copy pasted the tokens from a valid session on dev, and then I waited for them to expire.  You can speed things along by changing the auth0 tenant to shrink the expiration time, but I wanted to really see this in the wild, so I waited.  With the fix in place, you only login once after replacing the fresh tokens in local storage with the expired tokens.  Without the fix, you get the double login.