### PR TITLE
Playwright_take out pancan from followup survey tests due to workflow changes

### DIFF
--- a/playwright-e2e/tests/dsm/miscellaneous/create-follow-up-survey.spec.ts
+++ b/playwright-e2e/tests/dsm/miscellaneous/create-follow-up-survey.spec.ts
@@ -10,7 +10,7 @@ import { StudyName } from 'dsm/navigation';
 
 
 test.describe('Create Follow-Up Survey', () => {
-  const studies = [StudyName.PANCAN, StudyName.PROSTATE, StudyName.ESC];
+  const studies = [StudyName.PROSTATE, StudyName.ESC];
   let followupSurveyPage: FollowUpSurveyPage;
 
   test(`FAMILY_HISTORY (NONREPEATING) in @pancan @dsm @functional`, async ({ page, request }) => {

--- a/playwright-e2e/tests/dsm/miscellaneous/show-follow-up-survey.spec.ts
+++ b/playwright-e2e/tests/dsm/miscellaneous/show-follow-up-survey.spec.ts
@@ -68,9 +68,6 @@ test.describe('Follow-Up Surveys', () => {
   async function selectSurveyForStudy(followupSurveyPage: FollowUpSurveyPage, study: string): Promise<void> {
     let survey: string;
     switch (study) {
-      case StudyName.PANCAN:
-        survey = 'FAMILY_HISTORY  (NONREPEATING)';
-        break;
       case StudyName.ANGIO:
         survey = 'followupconsent  (REPEATING)';
         break;
@@ -94,9 +91,6 @@ test.describe('Follow-Up Surveys', () => {
   function surveysForStudy(followupSurveyPage: FollowUpSurveyPage, study: string): string[] {
     let configuredSurveys: string[];
     switch (study) {
-      case StudyName.PANCAN:
-        configuredSurveys = ['BLOOD_CONSENT (REPEATING)', 'FAMILY_HISTORY (NONREPEATING)', 'DIET_LIFESTYLE (NONREPEATING)'];
-        break;
       case StudyName.ANGIO:
         configuredSurveys = ['followupconsent (REPEATING)'];
         break;

--- a/playwright-e2e/tests/dsm/miscellaneous/show-follow-up-survey.spec.ts
+++ b/playwright-e2e/tests/dsm/miscellaneous/show-follow-up-survey.spec.ts
@@ -8,7 +8,7 @@ import { StudyName } from 'dsm/navigation';
 test.describe('Follow-Up Surveys', () => {
   let followupSurveyPage: FollowUpSurveyPage;
 
-  const studies = [StudyName.PANCAN, StudyName.ANGIO, StudyName.OSTEO, StudyName.LMS, StudyName.OSTEO2, StudyName.PROSTATE, StudyName.ESC];
+  const studies = [StudyName.ANGIO, StudyName.OSTEO, StudyName.LMS, StudyName.OSTEO2, StudyName.PROSTATE, StudyName.ESC];
 
   for (const study of studies) {
     test(`Shows list of follow-up surveys configured in @${study} @dsm @functional`, async ({ page, request }) => {

--- a/playwright-e2e/tests/pancan/enrollment/adult-self-and-child-enrollment.spec.ts
+++ b/playwright-e2e/tests/pancan/enrollment/adult-self-and-child-enrollment.spec.ts
@@ -17,7 +17,8 @@ import HomePage from 'dss/pages/pancan/home-page';
 
 const { PANCAN_USER_EMAIL, PANCAN_USER_PASSWORD } = process.env;
 
-test.describe('Adult self-enroll & child (consent) enrollment', () => {
+//Skipping until new family history addition to workflow is automated - will be taken cared of by ticket PEPPER-1475
+test.describe.skip('Adult self-enroll & child (consent) enrollment', () => {
   test.slow();
 
   // Randomize patient last name

--- a/playwright-e2e/tests/pancan/enrollment/adult-self-enrollment.spec.ts
+++ b/playwright-e2e/tests/pancan/enrollment/adult-self-enrollment.spec.ts
@@ -17,7 +17,8 @@ import HomePage from 'dss/pages/pancan/home-page';
 
 const { PANCAN_USER_EMAIL, PANCAN_USER_PASSWORD } = process.env;
 
-test.describe('Enroll myself as adult', () => {
+//Skipping until new family history addition to workflow is automated - will be taken cared of by ticket PEPPER-1475
+test.describe.skip('Enroll myself as adult', () => {
   test('can complete self-enrollment @dss @pancan @functional', async ({ page }) => {
     const pancanHomePage = new HomePage(page);
     await pancanHomePage.join({ waitForNav: true });

--- a/playwright-e2e/tests/pancan/enrollment/child-self-enrollment.spec.ts
+++ b/playwright-e2e/tests/pancan/enrollment/child-self-enrollment.spec.ts
@@ -17,7 +17,8 @@ import ConsentFormPage from 'dss/pages/pancan/enrollment/consent-form-page';
 
 const { PANCAN_USER_EMAIL, PANCAN_USER_PASSWORD } = process.env;
 
-test.describe('Enroll child ', () => {
+//Skipping until new family history addition to workflow is automated - will be taken cared of by ticket PEPPER-1475
+test.describe.skip('Enroll child ', () => {
   const lastName = generateUserName(user.patient.lastName);
 
   test('can complete child-enrollment @dss @pancan @functional', async ({ page }) => {


### PR DESCRIPTION
changes were made to pancan family history - it is now apart of workflow so taking it out of the list of studies the following tests run on:

- create-follow-up-survey.spec.ts
- show-follow-up-survey.spec.ts

skipping the following until family history is automated as a part of pancan's workflow:

- adult-self-and-child-enrollment.spec.ts
- adult-self-enrollment.spec.ts
- child-self-enrollment.spec.ts