### PR TITLE
PEPPER-1487 Fix receiving scan page

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/scanner/services/scanner.service.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/scanner/services/scanner.service.ts
@@ -100,7 +100,7 @@ export class ScannerService {
       saveFn: (data: object) => this.saveReceivingScan(data),
       inputFields: [
         {
-          controllerName: 'kit',
+          controllerName: 'kitLabel',
           placeholder: 'SM-ID',
           maxLength: undefined,
           validators: [Validators.required]


### PR DESCRIPTION
The receiving scan page was sending the kit label as `kit` in the json, resulting in the backend always seeing the value as null.  The fix is to use `kitLabel` instead in the payload.

![Screenshot 2024-06-13 at 10 27 47 AM](https://github.com/broadinstitute/ddp-angular/assets/1653048/a2f9af4c-5dbe-4cb5-94fd-9038ab71950e)
