### PR TITLE
skipping brain in tumor test due to dev env only weirdness

### DIFF
--- a/playwright-e2e/tests/brain/brain-regression-test.spec.ts
+++ b/playwright-e2e/tests/brain/brain-regression-test.spec.ts
@@ -136,6 +136,9 @@ test('Brain statics @dss @brain', async ({ page }) => {
   await page.getByRole('img', { name: 'The Angiosarcoma Project data release diagram' }).click();
 });
 
+//Skipping due to the Brain (Dev ENV only!) bug that makes registration impossible since register modal does not appear, only login modal
+//Above is noted by PEPPER-177
+//Brain Dev also seems to have the previous frontend version - there's mention of Brain Cancer Project instead of Brain Tumor Project
 test.fixme('Brain enroll kid on their behalf @dss @brain', async ({ page }) => {
   test.slow();
   await page.goto(BRAIN_BASE_URL!);

--- a/playwright-e2e/tests/dsm/tumor-collaborator-sample-id/participant-search.spec.ts
+++ b/playwright-e2e/tests/dsm/tumor-collaborator-sample-id/participant-search.spec.ts
@@ -33,7 +33,7 @@ import { StudyName } from 'dsm/navigation';
  */
 test.describe.serial('Tumor Collaborator Sample ID', () => {
   // Some studies are excluded due to lack of the suitable paricipants
-  const studies: StudyName[] = [StudyName.OSTEO2, StudyName.PANCAN, StudyName.MBC, StudyName.BRAIN];
+  const studies: StudyName[] = [StudyName.OSTEO2, StudyName.PANCAN, StudyName.MBC];
 
   for (const study of studies) {
     test(`Search by tumor sample id for non-legacy participant @dsm @${study}`, async ({ page, request }) => {


### PR DESCRIPTION
Skipping Brain in participant-search.spec.ts due to not being able to create new Brain ptps in DSS since the registration modal is replaced by the login modal among other things (behaviors are DEV Env only and have been for some time - the login modal behavior is noted by the following ticket: https://broadworkbench.atlassian.net/browse/PEPPER-177)

It seems that the test is currently failing when ran using Brain due to too much test info - example is Brain Dev ptp PNDVC4 (this is the guess since it's happened before and the fix was either deleting the ptp or cleaning up some of their test data) - but it's not the only ptp like that - going into their Participant Page can cause the browser tab to crash
(or at least it did this morning but now seems to be fine - looking into it)