### PR TITLE
skipping angio new ptp creation test due to incoming changes

### DIFF
--- a/playwright-e2e/tests/angio/adult-self-enrollment.spec.ts
+++ b/playwright-e2e/tests/angio/adult-self-enrollment.spec.ts
@@ -13,7 +13,7 @@ import ResearchConsentPage from 'dss/pages/angio/enrollment/research-consent-pag
 
 const { ANGIO_USER_EMAIL, ANGIO_USER_PASSWORD } = process.env;
 
-test.describe('Adult Enrollment', () => {
+test.describe.skip('Adult Enrollment', () => {
   // Randomize last name
   const lastName = generateUserName(user.patient.lastName);
 

--- a/playwright-e2e/tests/dsm/kitUploadFlow/kit-queue-ui.spec.ts
+++ b/playwright-e2e/tests/dsm/kitUploadFlow/kit-queue-ui.spec.ts
@@ -8,7 +8,7 @@ import { Label } from 'dsm/enums';
 
 test.describe('Sample Kit Queue UI', () => {
   const studies = [
-    StudyName.ANGIO, StudyName.BRAIN, StudyName.OSTEO, StudyName.OSTEO2, StudyName.PANCAN,
+    StudyName.BRAIN, StudyName.OSTEO, StudyName.OSTEO2, StudyName.PANCAN,
     StudyName.RGP, StudyName.LMS, StudyName.ESC, StudyName.PROSTATE
   ];
 

--- a/playwright-e2e/tests/dsm/miscellaneous/show-follow-up-survey.spec.ts
+++ b/playwright-e2e/tests/dsm/miscellaneous/show-follow-up-survey.spec.ts
@@ -8,7 +8,7 @@ import { StudyName } from 'dsm/navigation';
 test.describe('Follow-Up Surveys', () => {
   let followupSurveyPage: FollowUpSurveyPage;
 
-  const studies = [StudyName.ANGIO, StudyName.OSTEO, StudyName.LMS, StudyName.OSTEO2, StudyName.PROSTATE, StudyName.ESC];
+  const studies = [StudyName.OSTEO, StudyName.LMS, StudyName.OSTEO2, StudyName.PROSTATE, StudyName.ESC];
 
   for (const study of studies) {
     test(`Shows list of follow-up surveys configured in @${study} @dsm @functional`, async ({ page, request }) => {


### PR DESCRIPTION
disabled the following:

- [DSS] New Angio adult enrollment due to incoming changes for PEPPER-1376
- [DSM] Took out Angio as being a study in the `show-follow-up-survey.spec.ts` test due to incoming changes for PEPPER-1495
- [DSM] Took out Angio as being a study in the `kit-queue-ui.spec.ts` due to incoming changes for PEPPER-1495