### PR TITLE
PEPPER-926 Handle age up scenarios in somatic-results tab

### DIFF
--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
@@ -1828,7 +1828,8 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
           }
 
           //Once aged up and NOT followedup consent will be suspended, so check if CONSENT_SUSPENDED
-          //To handle agedup scenarios, check consent(assent)AddendumPediatric (which are from pre age up activity) only if adult consentAddendum doesn't exist
+          //To handle agedup scenarios, check consent(assent)AddendumPediatric (which are from pre age up activity)
+          // only if adult consentAddendum doesn't exist
           return mercuryAllow && studyAllow && hasConsentedToTissueSample && !consentSuspended &&
             (somaticConsentAddendumTumorAdult?.answer ||
               (somaticConsentTumorPediatric?.answer && somaticAssentAddendum?.answer && consentAddendum === undefined) ||

--- a/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
+++ b/ddp-workspace/projects/ddp-dsm-ui/src/app/participant-page/participant-page.component.ts
@@ -1801,6 +1801,7 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
           const studyAllow = allowedStudies.includes(this.sessionService.selectedRealm);
 
           const hasConsentedToTissueSample = this.participant.data.dsm?.['hasConsentedToTissueSample'];
+          const consentSuspended = this.participant.data.status === 'CONSENT_SUSPENDED';
 
           const consentAddendumPediatric = this.participant.data.activities
             ?.find(({activityCode}) => activityCode === 'CONSENT_ADDENDUM_PEDIATRIC');
@@ -1826,11 +1827,13 @@ export class ParticipantPageComponent implements OnInit, OnDestroy, AfterViewChe
                 ?.find(({answer, stableId}) => stableId === 'SOMATIC_CONSENT_TUMOR' && answer);
           }
 
-          return mercuryAllow && studyAllow && hasConsentedToTissueSample &&
+          //Once aged up and NOT followedup consent will be suspended, so check if CONSENT_SUSPENDED
+          //To handle agedup scenarios, check consent(assent)AddendumPediatric (which are from pre age up activity) only if adult consentAddendum doesn't exist
+          return mercuryAllow && studyAllow && hasConsentedToTissueSample && !consentSuspended &&
             (somaticConsentAddendumTumorAdult?.answer ||
-              (somaticConsentTumorPediatric?.answer && somaticAssentAddendum?.answer) ||
+              (somaticConsentTumorPediatric?.answer && somaticAssentAddendum?.answer && consentAddendum === undefined) ||
               (somaticConsentTumorPediatric?.answer && consentAddendumPediatricStatus === 'COMPLETE'
-                && somaticAssentAddendum === undefined)
+                && somaticAssentAddendum === undefined && consentAddendum === undefined)
             );
         })
       );


### PR DESCRIPTION
PEPPER-926

update checks to handle ageup scenarios in somatic-results tab visibility 
1. If CONSENT_SUSPENDED/ Lost to Followup, dont show the upload results tab
2. Make sure right forms are checked if aged-up. ex: Make sure self consent / self consent addendum is checked rather than pediatric forms once aged-up . 

Once merged and depending on the QA in Dev, will make any additional tweaks if needed.