### PR TITLE
forgot to skip the pancan test that redirects to Brain

### DIFF
--- a/playwright-e2e/tests/pancan/enrollment/redirect-glioblastoma-study.spec.ts
+++ b/playwright-e2e/tests/pancan/enrollment/redirect-glioblastoma-study.spec.ts
@@ -8,7 +8,7 @@ import HomePage from 'dss/pages/pancan/home-page';
 import { assertHeader } from 'utils/assertion-helper';
 import { fillSitePassword } from 'utils/test-utils';
 
-test.describe('Redirect to Brain cancer project', () => {
+test.skip('Redirect to Brain cancer project', () => {
   test('When selecting Glioblastoma as diagnosed cancer @dss @pancan', async ({ page }) => {
     const pancanHomePage = new HomePage(page);
     await pancanHomePage.join({ waitForNav: true });


### PR DESCRIPTION
this tests failed in a recent run in circleci - I forgot to mark it as skipped earlier (since Brain study enrollment is coming to an end)